### PR TITLE
Site properties: align site property names across datasets

### DIFF
--- a/data/ANBG_2019/metadata.yml
+++ b/data/ANBG_2019/metadata.yml
@@ -57,4021 +57,4021 @@ sites:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Adelaide Botanic Gardens.
-    collector: Carmen, P.
+    recorded by: Carmen, P.
   Blue Mountains National Park, Govetts Leap, 100 m S towards Evans Lookout, Blackheath.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Blue Mountains National Park, Govetts Leap, 100 m S towards Evans Lookout,
       Blackheath.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   Brisbane Botanic Gardens Conservation Seed Bank (BBGCS).:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Brisbane Botanic Gardens Conservation Seed Bank (BBGCS).
-    collector: Golson, T.
+    recorded by: Golson, T.
   Burraga Swamp, Barrington Tops.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Burraga Swamp, Barrington Tops.
-    collector: Wallace, B.J.
+    recorded by: Wallace, B.J.
   c. 11 km north of Mt Isa on Barkly Highway.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: c. 11 km north of Mt Isa on Barkly Highway.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   Central Australian district; Ayers Rock National Park.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Central Australian district; Ayers Rock National Park.
-    collector: Tyrrel, C.
+    recorded by: Tyrrel, C.
   CULTIVATED Albury Botanic Gardens.Original location 10 km SW of Bicheno, Tas..:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Albury Botanic Gardens.Original location 10 km SW of Bicheno,
       Tas..
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   CULTIVATED Albury Botanic Gardens.Original location Stawell, Vic.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Albury Botanic Gardens.Original location Stawell, Vic.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   CULTIVATED Australian National Botanic Gardens, Canberra.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Canberra.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   CULTIVATED Australian National Botanic Gardens, Canberra; nursery permanent pot collec:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Canberra; nursery permanent
       pot collection.
-    collector: ANBG Nursery
+    recorded by: ANBG Nursery
   CULTIVATED Australian National Botanic Gardens, Canberra; nursery.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Canberra; nursery.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   CULTIVATED Australian National Botanic Gardens, Canberra; section 189.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Canberra; section 189.
-    collector: North, T.G.
+    recorded by: North, T.G.
   CULTIVATED Australian National Botanic Gardens, Nursery, no. 8703152.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Nursery, no. 8703152.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   CULTIVATED Australian National Botanic Gardens, permanent pots, ex 90062155.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, permanent pots, ex 90062155.
-    collector: ANBG
+    recorded by: ANBG
   CULTIVATED Australian National Botanic Gardens, permanent pots.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, permanent pots.
-    collector: ANBG
+    recorded by: ANBG
   CULTIVATED Australian National Botanic Gardens, Sect. 191f.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Sect. 191f.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   CULTIVATED Australian National Botanic Gardens, sect. 4, no. 8602220.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, sect. 4, no. 8602220.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   CULTIVATED Australian National Botanic Gardens, Sect. 66, No. 8501813.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Sect. 66, No. 8501813.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   CULTIVATED Australian National Botanic Gardens, Section 183a, as per CBG 8503344.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, Section 183a, as per
       CBG 8503344.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   CULTIVATED Australian National Botanic Gardens, section 300.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Australian National Botanic Gardens, section 300.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   CULTIVATED Brisbane, CSIRO Cunningham Laboratory, glasshouse.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Brisbane, CSIRO Cunningham Laboratory, glasshouse.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   CULTIVATED Brunswick East.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Brunswick East.
-    collector: Scarlett, N.H.
+    recorded by: Scarlett, N.H.
   CULTIVATED Canberra Botanic Gardens 67737 Crowea saligna. Position 119B 029.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Canberra Botanic Gardens 67737 Crowea saligna. Position 119B
       029.
-    collector: Cummings, D.J.
+    recorded by: Cummings, D.J.
   CULTIVATED CSIRO, Division of Entomology - Canberra. Original plant collected by John:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED CSIRO, Division of Entomology - Canberra. Original plant
       collected by John Swarbrick QMO, Mt Gowrie, Warrego Hwy, 10 km WNW of Toowoomba.
       These plants are progeny of the original collection.
-    collector: Woodburn - CSIRO, T.
+    recorded by: Woodburn - CSIRO, T.
   CULTIVATED Kings Park and Botanic Garden, rare and endangered garden.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Kings Park and Botanic Gardens, rare and endangered garden.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   CULTIVATED Kings Park and Botanic Garden.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Kings Park and Botanic Gardens.
-    collector: ANBG
+    recorded by: ANBG
   CULTIVATED Kings Park, Perth.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Kings Park, Perth.
-    collector: ANBG
+    recorded by: ANBG
   CULTIVATED National Botanic Garden, Canberra.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED National Botanic Gardens, Canberra.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   CULTIVATED National Botanic Gardens, Canberra, Section 4.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED National Botanic Gardens, Canberra, Section 4.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   CULTIVATED National Botanic Gardens, Canberra.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED National Botanic Gardens, Canberra.
-    collector: Verdon, D.
+    recorded by: Verdon, D.
   CULTIVATED Purchased from Nindethana Seed Service Pty Ltd, WA.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: CULTIVATED Purchased from Nindethana Seed Service Pty Ltd, WA.
-    collector: ANBG Nursery
+    recorded by: ANBG Nursery
   Donated by Debbie Downes of Wollongong Botanic Garden, to the Australian National Bota:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Donated by Debbie Downes of Wollongong Botanic Gardens, to the Australian
       National Botanic Gardens, Canberra.
-    collector: Golson, T.
+    recorded by: Golson, T.
   Gympie district, 10 km SE of Kilkivan, Oakview State Forest, track along creek near fo:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Gympie district, 10 km SE of Kilkivan, Oakview State Forest, track along
       creek near forestry camp.
-    collector: Bird, L.
+    recorded by: Bird, L.
   Hout Bay road, opposite Spes Bona, S. of Capetown, Cape Peninsula.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Hout Bay road, opposite Spes Bona, S. of Capetown, Cape Peninsula.
-    collector: Shaughnessy, G.
+    recorded by: Shaughnessy, G.
   No locality given.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: No locality given.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   Peak Charles.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Peak Charles.
-    collector: ANBG
+    recorded by: ANBG
   Probably collected from Scottsdale Bush Heritage Reserve, NSW (as LS46) or Mulligans F:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Probably collected from Scottsdale Bush Heritage Reserve, NSW (as LS46)
       or Mulligans Flat, ACT (as LS48). Details to be entered when field book submitted;
       ANHSIR entry created in advance for ANBG seedbank.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   Received from Whitsunday Catchment Landcare (Queensland propagator licence number WIPQ:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Received from Whitsunday Catchment Landcare (Queensland propagator licence
       number WIPQ 2869605).
-    collector: Golson, T.
+    recorded by: Golson, T.
   Royal Botanic Gardens, Sydney.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Royal Botanic Gardens, Sydney.
-    collector: Golson, T.
+    recorded by: Golson, T.
   Side of track south of Sunset Country Reference Area 12A. 35 km south of Bambill. Mino:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Side of track south of Sunset Country Reference Area 12A. 35 km south
       of Bambill. Minor Grid A40.
-    collector: Browne, J.H.
+    recorded by: Browne, J.H.
   site_at_-10.4803_degS_and_105.6419_degE:
     latitude (deg): -10.4803
     longitude (deg): 105.6419
     locality: Christmas Island; 800 m W from Jedah Cave towards Murray Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-12.1667_degS_and_131.0167_degE:
     latitude (deg): -12.1667
     longitude (deg): 131.0167
     locality: Gunn Point.
-    collector: Parker, M.O.
+    recorded by: Parker, M.O.
   site_at_-12.3833_degS_and_132.95_degE:
     latitude (deg): -12.3833
     longitude (deg): 132.95
     locality: Kakadu National Park, Obiri Rock.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.4_degS_and_132.95_degE:
     latitude (deg): -12.4
     longitude (deg): 132.95
     locality: Kakadu National Park, Obiri Rock track, 4 km NW of East Alligator River
       crossing of Oenpelli Road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.4167_degS_and_130.6667_degE:
     latitude (deg): -12.4167
     longitude (deg): 130.6667
     locality: East Point, 6 km NNW of Darwin.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.4167_degS_and_132.95_degE:
     latitude (deg): -12.4167
     longitude (deg): 132.95
     locality: Kakadu National Park, 2 km along Obiri Rock track from Oenpelli road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.4833_degS_and_132.8833_degE:
     latitude (deg): -12.4833
     longitude (deg): 132.8833
     locality: 14 km from East Alligator River crossing on Oenpelli road towards Arnhem
       Highway.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.5_degS_and_132.9_degE:
     latitude (deg): -12.5
     longitude (deg): 132.9
     locality: 19 km from Arnhem Highway along Oenpelli road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.58_degS_and_132.9736_degE:
     latitude (deg): -12.58
     longitude (deg): 132.9736
     locality: Kakadu National Park; 12.74 km NE of Jabiru Airport; Northern Outliers.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.5806_degS_and_132.9736_degE:
     latitude (deg): -12.5806
     longitude (deg): 132.9736
     locality: Kakadu National Park; 12.74 km NE of Jabiru Airport; Northern Outliers.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.5839_degS_and_132.9919_degE:
     latitude (deg): -12.5839
     longitude (deg): 132.9919
     locality: Kakadu National Park; Northern Outliers; 6 km N of Jabiru, fire plot
       144. Coordinates given plot 13.5 km NE of Jabiru airport and c. 20 km ~ENE from
       Jabiru.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.5844_degS_and_132.9922_degE:
     latitude (deg): -12.5844
     longitude (deg): 132.9922
     locality: Kakadu National Park; fire plot 144, (c. 19 km ~ENE of Jabiru).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.6667_degS_and_132.4833_degE:
     latitude (deg): -12.6667
     longitude (deg): 132.4833
     locality: 2.4 km from South Alligator River crossing on Arnhem Highway towards
       Darwin.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.6833_degS_and_132.9167_degE:
     latitude (deg): -12.6833
     longitude (deg): 132.9167
     locality: 4 km ESE of Jabiru, E of Ranger Plant.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.7622_degS_and_132.6606_degE:
     latitude (deg): -12.7622
     longitude (deg): 132.6606
     locality: Kakadu National Park; Nourlangie Camp, Unlaar (Anlarrh).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.7686_degS_and_132.6628_degE:
     latitude (deg): -12.7686
     longitude (deg): 132.6628
     locality: Kakadu National Park; Nourlangie camp, Unlaar.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.8092_degS_and_132.9047_degE:
     latitude (deg): -12.8092
     longitude (deg): 132.9047
     locality: Kakadu National Park; at 53,272584,8583035 (c. 17 km ~SSE of Jabiru).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.8106_degS_and_132.9044_degE:
     latitude (deg): -12.8106
     longitude (deg): 132.9044
     locality: Kakadu National Park. On sandstone plateau near Mount Brockman, c. 16.83
       km south from Jabiru air strip or 12.31 km north east from Nourlangie Rock.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-12.8333_degS_and_132.8667_degE:
     latitude (deg): -12.8333
     longitude (deg): 132.8667
     locality: Kakadu National Park, 2.5 km NW of Koongarra Saddle.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.8356_degS_and_132.8511_degE:
     latitude (deg): -12.8356
     longitude (deg): 132.8511
     locality: Kakadu National Park. 800 m west of Gubara carpark.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-12.8367_degS_and_132.8511_degE:
     latitude (deg): -12.8367
     longitude (deg): 132.8511
     locality: Kakadu National Park; Gubara Rocks area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.8492_degS_and_132.8594_degE:
     latitude (deg): -12.8492
     longitude (deg): 132.8594
     locality: Kakadu National Park; Koongarra, 3 km from locked gate, 100 m W of vehicle
       track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.8494_degS_and_132.8619_degE:
     latitude (deg): -12.8494
     longitude (deg): 132.8619
     locality: Kakadu National Park; Koongarra, 3 km from locked gate, 100 m NE of
       vehicle track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.85_degS_and_132.8667_degE:
     latitude (deg): -12.85
     longitude (deg): 132.8667
     locality: Koongarra Saddle, Kakadu.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-12.8533_degS_and_132.865_degE:
     latitude (deg): -12.8533
     longitude (deg): 132.865
     locality: Kakadu National Park; Koongarra, 3 km from locked gate, c. 500 m E of
       vehicle track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-12.8833_degS_and_131.8833_degE:
     latitude (deg): -12.8833
     longitude (deg): 131.8833
     locality: 32 km from Mary River crossing on Arnhem Highway towards Jabiru.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-12.9167_degS_and_132.9667_degE:
     latitude (deg): -12.9167
     longitude (deg): 132.9667
     locality: Kakadu National Park, East Alligator River at Oenpelli road crossing.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-13.1106_degS_and_132.9761_degE:
     latitude (deg): -13.1106
     longitude (deg): 132.9761
     locality: Kakadu National Park; 4 km S of Deaf Adder Gorge.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.28_degS_and_132.5447_degE:
     latitude (deg): -13.28
     longitude (deg): 132.5447
     locality: Kakadu National Park; 40 km SE Jabiru; 3 km S of Graveside Gorge carpark;
       Graveside Gorge.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.2839_degS_and_132.5422_degE:
     latitude (deg): -13.2839
     longitude (deg): 132.5422
     locality: Kakadu National Park; 40 km SE Jabiru; 3 km S of Graveside Gorge carpark;
       Graveside Gorge.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.3153_degS_and_132.8703_degE:
     latitude (deg): -13.3153
     longitude (deg): 132.8703
     locality: Kakadu National Park; c. 5 km SE of Jim Jim Falls.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.4325_degS_and_132.4161_degE:
     latitude (deg): -13.4325
     longitude (deg): 132.4161
     locality: Kakadu National Park; Gunlom plunge pool.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.4847_degS_and_132.2553_degE:
     latitude (deg): -13.4847
     longitude (deg): 132.2553
     locality: Kakadu National Park. Ca 14 km NNW (straightline) of Mary River Road
       House on Kakadu Highway, about 100 m east in from highway.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-13.4933_degS_and_132.4786_degE:
     latitude (deg): -13.4933
     longitude (deg): 132.4786
     locality: Kakadu National Park; Gunlom and Koolpin T-junction. Ca 23 km directly
       ~ENE of Kakadu southern entry and ranger station.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.4981_degS_and_132.58_degE:
     latitude (deg): -13.4981
     longitude (deg): 132.58
     locality: Kakadu National Park; Koolpin Gorge, Pink Pool.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.5169_degS_and_132.5761_degE:
     latitude (deg): -13.5169
     longitude (deg): 132.5761
     locality: Kakadu National Park; Koolpin. Between Koolpin Gorge track entrance
       and Koolpin Gorge (Jarrangbarnmi).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.5633_degS_and_132.2931_degE:
     latitude (deg): -13.5633
     longitude (deg): 132.2931
     locality: Kakadu National Park. In creek at Ferny Gully camp ground.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-13.5692_degS_and_132.4939_degE:
     latitude (deg): -13.5692
     longitude (deg): 132.4939
     locality: Kakadu National Park; Northern Outliers.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-13.5833_degS_and_143.4167_degE:
     latitude (deg): -13.5833
     longitude (deg): 143.4167
     locality: McIlwraith Range Leo Creek Falls and Leo Creek, 0.5 km upstream from
       falls.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-13.7167_degS_and_143.4833_degE:
     latitude (deg): -13.7167
     longitude (deg): 143.4833
     locality: Chester River E of McIlwraith range escarpment.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-14.7833_degS_and_126.8_degE:
     latitude (deg): -14.7833
     longitude (deg): 126.8
     locality: Carson River, 32 km E of new Theda homestead.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-15.3_degS_and_145.0167_degE:
     latitude (deg): -15.3
     longitude (deg): 145.0167
     locality: Henderson Range, c. 33 km NW of Cooktown, 0.5 km from Isabella Falls
       along Battle Camp Road towards Laura.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-15.7667_degS_and_130.5167_degE:
     latitude (deg): -15.7667
     longitude (deg): 130.5167
     locality: 5 km S of Timber Creek racecourse along old road to Victoria River Downs.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-15.7833_degS_and_128.6833_degE:
     latitude (deg): -15.7833
     longitude (deg): 128.6833
     locality: Dunham River, at Duncan Highway bridge.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-16.0333_degS_and_130.8_degE:
     latitude (deg): -16.0333
     longitude (deg): 130.8
     locality: 1.6 km E of Jasper Ck bridge along Timber Creek -Victoria River Downs
       road.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-16.4667_degS_and_145.3333_degE:
     latitude (deg): -16.4667
     longitude (deg): 145.3333
     locality: Mossman Gorge, N Qld.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-16.5_degS_and_145.4167_degE:
     latitude (deg): -16.5
     longitude (deg): 145.4167
     locality: Cassowary Creek, S of Mossman towards Cairns, left-hand side cutting.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-16.5167_degS_and_145.3833_degE:
     latitude (deg): -16.5167
     longitude (deg): 145.3833
     locality: 3 km along road to Mount Molloy from Cook Highway.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-16.5833_degS_and_145.2667_degE:
     latitude (deg): -16.5833
     longitude (deg): 145.2667
     locality: Mt. Lewis, summit ridge.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-16.5833_degS_and_150.3167_degE:
     latitude (deg): -16.5833
     longitude (deg): 150.3167
     locality: Magdelaine Cay.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-16.9333_degS_and_149.1833_degE:
     latitude (deg): -16.9333
     longitude (deg): 149.1833
     locality: NE Herald Cay.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-16.9833_degS_and_149.8833_degE:
     latitude (deg): -16.9833
     longitude (deg): 149.8833
     locality: Coringa Islet.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-17.1639_degS_and_145.65_degE:
     latitude (deg): -17.1639
     longitude (deg): 145.65
     locality: Atherton Tableland, Lake Euramoo.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-17.2833_degS_and_145.45_degE:
     latitude (deg): -17.2833
     longitude (deg): 145.45
     locality: Atherton Tableland, Mt Baldy, lower slope behind van park.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-17.3_degS_and_145.4167_degE:
     latitude (deg): -17.3
     longitude (deg): 145.4167
     locality: Herberton Range, 2 km along Baldy Mountain State Forest road from Atherton-Herberton
       road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-17.3333_degS_and_145.4167_degE:
     latitude (deg): -17.3333
     longitude (deg): 145.4167
     locality: Herberton Range, 2 km along Baldy Mountain State Forest road from Atherton-Herberton
       road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-17.3333_degS_and_145.4333_degE:
     latitude (deg): -17.3333
     longitude (deg): 145.4333
     locality: Herberton Range, 12 km from Atherton towards Herberton.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-17.3667_degS_and_145.4167_degE:
     latitude (deg): -17.3667
     longitude (deg): 145.4167
     locality: Wild River gorge, 5 miles from Herberton.
-    collector: Wrigley, J.
+    recorded by: Wrigley, J.
   site_at_-17.3833_degS_and_145.4667_degE:
     latitude (deg): -17.3833
     longitude (deg): 145.4667
     locality: Bellenden Ker Range, Mt Bartle Frere track near Bobin Bobin Falls.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-17.3953_degS_and_145.8208_degE:
     latitude (deg): -17.3953
     longitude (deg): 145.8208
     locality: 400 m NE of summit of Mt Bartle Frere.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-17.4167_degS_and_151.8833_degE:
     latitude (deg): -17.4167
     longitude (deg): 151.8833
     locality: Anne Cay.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-17.6539_degS_and_145.4775_degE:
     latitude (deg): -17.6539
     longitude (deg): 145.4775
     locality: Millstream Falls, SW of Ravenshoe.
-    collector: Wrigley, J.
+    recorded by: Wrigley, J.
   site_at_-17.7167_degS_and_139.7833_degE:
     latitude (deg): -17.7167
     longitude (deg): 139.7833
     locality: 8 km NE of Burketown towards Triginni Truganini Landing.
-    collector: Ollerenshaw, N.
+    recorded by: Ollerenshaw, N.
   site_at_-18.0833_degS_and_144.8667_degE:
     latitude (deg): -18.0833
     longitude (deg): 144.8667
     locality: 67.7 km by road SW of Mt Garnet on Kennedy Highway, 40 Mile Scrub, roadside.
-    collector: Makinson, R.O.
+    recorded by: Makinson, R.O.
   site_at_-18.3167_degS_and_144.7333_degE:
     latitude (deg): -18.3167
     longitude (deg): 144.7333
     locality: Undara lava tubes, tourist camp site, near Undara crater.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-18.6_degS_and_143.8333_degE:
     latitude (deg): -18.6
     longitude (deg): 143.8333
     locality: Newcastle Range, 37 km from Einasleigh along road to Forsyth.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-19.65_degS_and_138.4667_degE:
     latitude (deg): -19.65
     longitude (deg): 138.4667
     locality: 43 miles (53 km) NE of Camooweal on road to Thorntonia.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-19.7833_degS_and_129_degE:
     latitude (deg): -19.7833
     longitude (deg): 129.0
     locality: 1 km W of WA-NT border on Tanami-Billiluna road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-19.9667_degS_and_129.6667_degE:
     latitude (deg): -19.9667
     longitude (deg): 129.6667
     locality: Tanami Gorge.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-19.9667_degS_and_129.7167_degE:
     latitude (deg): -19.9667
     longitude (deg): 129.7167
     locality: Tanami.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-19.9833_degS_and_129.65_degE:
     latitude (deg): -19.9833
     longitude (deg): 129.65
     locality: Tanami Range.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-19_degS_and_146.0836_degE:
     latitude (deg): -19.0
     longitude (deg): 146.0836
     locality: 6 km from Paluma along road to Hidden Valley.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-20.1681_degS_and_133.0517_degE:
     latitude (deg): -20.1681
     longitude (deg): 133.0517
     locality: Henbury Station; 6 km WNW of Mount Keartland summit.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-20.3333_degS_and_130.1_degE:
     latitude (deg): -20.3333
     longitude (deg): 130.1
     locality: 37 km NW of The Granites on Tanami-Alice Springs road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-20.6333_degS_and_134.2167_degE:
     latitude (deg): -20.6333
     longitude (deg): 134.2167
     locality: c. 2 km SW of Devils Marbles.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-20.6333_degS_and_141.3833_degE:
     latitude (deg): -20.6333
     longitude (deg): 141.3833
     locality: 116 miles (187 km) W of Richmond.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-20.65_degS_and_139.5333_degE:
     latitude (deg): -20.65
     longitude (deg): 139.5333
     locality: c. 11 km NE of Mt. Isa along road to Lake Moondarra.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-20.6833_degS_and_139.4833_degE:
     latitude (deg): -20.6833
     longitude (deg): 139.4833
     locality: Ca 1 km along road to Lake Moondarra after turn-off from Mt Isa road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-20.6833_degS_and_139.5_degE:
     latitude (deg): -20.6833
     longitude (deg): 139.5
     locality: Ca 3 miles (5 km) N of Mt Isa, on road to Lake Moondarra off Barkly
       Highway - turn-off east to dam.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-20.8_degS_and_144.9167_degE:
     latitude (deg): -20.8
     longitude (deg): 144.9167
     locality: c. 12 km WSW of Torrens Creek on Burdekin Hwy.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-20.8697_degS_and_144.4158_degE:
     latitude (deg): -20.8697
     longitude (deg): 144.4158
     locality: c. 16 miles (26 km) East of Hughenden on Flinders Highway.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-21.0333_degS_and_148.65_degE:
     latitude (deg): -21.0333
     longitude (deg): 148.65
     locality: Eungella National Park, Clarke Range, Finch Hatton Gorge, picnic area
       at creek.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-21.0667_degS_and_148.6333_degE:
     latitude (deg): -21.0667
     longitude (deg): 148.6333
     locality: Clarke Range, Eungella Range, Finch Hatton Gorge, Wheel of Fire Falls.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-21.1167_degS_and_148.5167_degE:
     latitude (deg): -21.1167
     longitude (deg): 148.5167
     locality: Clarke Range, Eungella National Park, Peases Lookout.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-21.2333_degS_and_159.7167_degE:
     latitude (deg): -21.2333
     longitude (deg): 159.7167
     locality: Rarotonga, mouth of Avana Stream.
-    collector: Elix, J.A.
+    recorded by: Elix, J.A.
   site_at_-21.3_degS_and_144.6333_degE:
     latitude (deg): -21.3
     longitude (deg): 144.6333
     locality: 50 km from Praire along road to Muttaburra.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-21.55_degS_and_148.2167_degE:
     latitude (deg): -21.55
     longitude (deg): 148.2167
     locality: Carborough Range, 1 km NW of Lake Elphinstone outlet.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-21.9167_degS_and_131.25_degE:
     latitude (deg): -21.9167
     longitude (deg): 131.25
     locality: 16 km N of Old Doreen High School homestead - coordinates calculated
       by compiler are for 16 km N of Doreen homestead ruins, along Tanami Road.
-    collector: Brown, R.B.
+    recorded by: Brown, R.B.
   site_at_-22.3522_degS_and_127.7697_degE:
     latitude (deg): -22.3522
     longitude (deg): 127.7697
     locality: Kiwirrkurra Indigenous Protected Area; c. 51.6 km due N of Kiwirrkurra.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-22.3833_degS_and_149.1167_degE:
     latitude (deg): -22.3833
     longitude (deg): 149.1167
     locality: 4 km from Lotus Creek crossing on inland highway towards Marlborough.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-22.7489_degS_and_128.3431_degE:
     latitude (deg): -22.7489
     longitude (deg): 128.3431
     locality: Kiwirrkurra Indigenous Protected Area; 69.6 km by track ENE of Kiwirrkurra
       community store, along track to Balgo.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-22.7567_degS_and_126.6261_degE:
     latitude (deg): -22.7567
     longitude (deg): 126.6261
     locality: Kiwirrkurra Indigenous Protected Area; c. 115.3 km due W of Kiwirrkurra
       and c. 14 km due NNE of Jupiter Well.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-22.7656_degS_and_126.8906_degE:
     latitude (deg): -22.7656
     longitude (deg): 126.8906
     locality: Kiwirrkurra Indigenous Protected Area; 13.8 km due ENE of Nyinmy oustation
       (c. 32.6 km due NE of Jupiter Well).
-    collector: Wright, B.
+    recorded by: Wright, B.
   site_at_-22.8111_degS_and_127.7422_degE:
     latitude (deg): -22.8111
     longitude (deg): 127.7422
     locality: Kiwirrkurra Indigenous Protected Area; Kiwirrkurra airstrip.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-22.8114_degS_and_127.93_degE:
     latitude (deg): -22.8114
     longitude (deg): 127.93
     locality: Kiwirrkurra Indigenous Protected Area; 18.3 km by track E of Kiwirrkurra
       store, along track to Balgo.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-22.85_degS_and_138.2_degE:
     latitude (deg): -22.85
     longitude (deg): 138.2
     locality: Upper slope of Breakaway, north side of Toko Range, about 1 km N. of
       Poodyea Point.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-22.95_degS_and_139.9167_degE:
     latitude (deg): -22.95
     longitude (deg): 139.9167
     locality: 5km S of Boulia near Goodwood.
-    collector: Ganter, W.
+    recorded by: Ganter, W.
   site_at_-22.9956_degS_and_149.9117_degE:
     latitude (deg): -22.9956
     longitude (deg): 149.9117
     locality: Redcliffe Ranges, c. 18 km S of Marlborough, 30 km by road from Marlborough
       via Coorumburra Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-23.0333_degS_and_143.9833_degE:
     latitude (deg): -23.0333
     longitude (deg): 143.9833
     locality: Manfred Station, 45 km from Longreach along Landsborough Highway towards
       Winton.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-23.1833_degS_and_144.05_degE:
     latitude (deg): -23.1833
     longitude (deg): 144.05
     locality: 30 km from Longreach along Landsborough Highway towards Winton.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-23.1833_degS_and_150.8_degE:
     latitude (deg): -23.1833
     longitude (deg): 150.8
     locality: Bluff Point, 8 km SE of Yeppoon.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-23.2_degS_and_150.7833_degE:
     latitude (deg): -23.2
     longitude (deg): 150.7833
     locality: Mulambin Beach, Bluff Point, 9 km SE of Yeppoon.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-23.2508_degS_and_149.9003_degE:
     latitude (deg): -23.2508
     longitude (deg): 149.9003
     locality: Redcliffe Ranges, c. 18 km S of Marlborough, 30 km by road from Marlborough
       via Coorumburra Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-23.2667_degS_and_144.1167_degE:
     latitude (deg): -23.2667
     longitude (deg): 144.1167
     locality: 23.2 km from Longreach on the Winton road, Landsborough Highway.
-    collector: Zich, F.A.; Wang, B.
+    recorded by: Zich, F.A.; Wang, B.
   site_at_-23.3631_degS_and_138.1867_degE:
     latitude (deg): -23.3631
     longitude (deg): 138.1867
     locality: Cravens Peak Reserve (Bush Heritage), north-eastern Simpson Desert area.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-23.4333_degS_and_145.2667_degE:
     latitude (deg): -23.4333
     longitude (deg): 145.2667
     locality: 6.7 km from Barcaldine toward Isisford.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-23.5281_degS_and_137.9644_degE:
     latitude (deg): -23.5281
     longitude (deg): 137.9644
     locality: Tobermorey Station, north-eastern Simpson Desert.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-23.5333_degS_and_132.4333_degE:
     latitude (deg): -23.5333
     longitude (deg): 132.4333
     locality: Mt Razorback.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   site_at_-23.5833_degS_and_145.25_degE:
     latitude (deg): -23.5833
     longitude (deg): 145.25
     locality: CULTIVATED Barcaldine Showground.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-23.6_degS_and_134.4833_degE:
     latitude (deg): -23.6
     longitude (deg): 134.4833
     locality: 1.6 km S of Ross River homestead.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-23.6167_degS_and_146.3_degE:
     latitude (deg): -23.6167
     longitude (deg): 146.3
     locality: Mitchell/Kennedy South districts  97km E of Barcaldine on Landsborough
       Highway.
-    collector: Carne, L.C.
+    recorded by: Carne, L.C.
   site_at_-23.6694_degS_and_137.9342_degE:
     latitude (deg): -23.6694
     longitude (deg): 137.9342
     locality: Field River, S of Mt Gardner area, north-eastern Simpson Desert.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-23.7_degS_and_145.2833_degE:
     latitude (deg): -23.7
     longitude (deg): 145.2833
     locality: 17.8 km S of Barcaldine on Blackall road, Landsborough Highway.
-    collector: Zich, F.A.
+    recorded by: Zich, F.A.
   site_at_-23.7242_degS_and_133.4719_degE:
     latitude (deg): -23.7242
     longitude (deg): 133.4719
     locality: Standley Chasm carpark; right hand side of sut out; nearest place Wupataka
       Land Trust.
-    collector: Ogden, W.
+    recorded by: Ogden, W.
   site_at_-23.7833_degS_and_149.2_degE:
     latitude (deg): -23.7833
     longitude (deg): 149.2
     locality: Blackdown Tableland, 2 km northwards from Mimosa Creek road crossing.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-23.8_degS_and_120.9667_degE:
     latitude (deg): -23.8
     longitude (deg): 120.9667
     locality: Savory Creek.
-    collector: Morse, G.J.
+    recorded by: Morse, G.J.
   site_at_-23.85_degS_and_133.8833_degE:
     latitude (deg): -23.85
     longitude (deg): 133.8833
     locality: 7.1 km along the Chambers Pillar road from the Santa Teresa road, S
       of Alice Springs.
-    collector: Craven, L.A.; Brubaker, C.L.; Grace, J.P.
+    recorded by: Craven, L.A.; Brubaker, C.L.; Grace, J.P.
   site_at_-23.85_degS_and_149.0833_degE:
     latitude (deg): -23.85
     longitude (deg): 149.0833
     locality: Expedition Range, Blackdown Tableland, 1 km W of Rainbow Falls.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-23.9_degS_and_132.65_degE:
     latitude (deg): -23.9
     longitude (deg): 132.65
     locality: Along road to Undandita; 13 km W of Hermannsburgh.
-    collector: Verdon, D.
+    recorded by: Verdon, D.
   site_at_-24.05_degS_and_144.4833_degE:
     latitude (deg): -24.05
     longitude (deg): 144.4833
     locality: 25.1 km from Isisford toward Ilfracombe.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-24.1167_degS_and_148.0833_degE:
     latitude (deg): -24.1167
     longitude (deg): 148.0833
     locality: Springsure.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-24.1608_degS_and_133.0622_degE:
     latitude (deg): -24.1608
     longitude (deg): 133.0622
     locality: Henbury Station; 6 km NW of Mount Keartland summit; headwaters of Boggy
       Hole Creek.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1667_degS_and_151.3_degE:
     latitude (deg): -24.1667
     longitude (deg): 151.3
     locality: Many Peaks Range, 0.5 km W of Mt Castletower.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-24.1692_degS_and_132.6122_degE:
     latitude (deg): -24.1692
     longitude (deg): 132.6122
     locality: Henbury Station; 25 km due W of Mount Merrick; along minor watercourse
       on sandstone ridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1697_degS_and_133.06_degE:
     latitude (deg): -24.1697
     longitude (deg): 133.06
     locality: Henbury Station; 4.5 km WNW of Mount Keartland summit (straight line
       GPS); top of unnamed ridge c. 10 km S of Wallace Rockhole.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1706_degS_and_133.0631_degE:
     latitude (deg): -24.1706
     longitude (deg): 133.0631
     locality: Henbury Station; 4.5 km WNW of Mount Keartland summit (straight line
       GPS); top of ridge below Mount Keartland.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1708_degS_and_133.0594_degE:
     latitude (deg): -24.1708
     longitude (deg): 133.0594
     locality: Henbury Station; c. 6 km WNW of Mount Keartland summit (straight line
       GPS); near summit of range.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1708_degS_and_133.0667_degE:
     latitude (deg): -24.1708
     longitude (deg): 133.0667
     locality: Henbury Station; c. 4.5 km WNW of Mount Keartland summit (straight line
       GPS); ridge below Mount Keartland.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1711_degS_and_132.61_degE:
     latitude (deg): -24.1711
     longitude (deg): 132.61
     locality: Henbury Station; 18 km SW of Palm Valley camp ground above Pukai rock
       hole; sandstone ridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1711_degS_and_132.6122_degE:
     latitude (deg): -24.1711
     longitude (deg): 132.6122
     locality: Henbury Station; 25 km due W of Mount Merrick; on top of sandstone ridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.1833_degS_and_151.2333_degE:
     latitude (deg): -24.1833
     longitude (deg): 151.2333
     locality: Many Peaks Range, c. 5 km SW of Mount Castletower.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-24.1833_degS_and_151.25_degE:
     latitude (deg): -24.1833
     longitude (deg): 151.25
     locality: Many Peaks Range, 4 km W of Mt Castletower.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-24.3333_degS_and_143.2833_degE:
     latitude (deg): -24.3333
     longitude (deg): 143.2833
     locality: Floodplain of Thompson River, about 2 km NE of Stonehenge.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-24.4114_degS_and_147.325_degE:
     latitude (deg): -24.4114
     longitude (deg): 147.325
     locality: Ca 1 km N of Dawson Developmental Road, E of crossing of Nogoa River,
       in old gravel-scrape area.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-24.4386_degS_and_133.1286_degE:
     latitude (deg): -24.4386
     longitude (deg): 133.1286
     locality: Henbury Station; 18 km NW of Henbury homestead; near Cave Hole.
-    collector: Latz, P.K.
+    recorded by: Latz, P.K.
   site_at_-24.5_degS_and_149.3667_degE:
     latitude (deg): -24.5
     longitude (deg): 149.3667
     locality: 10.6 km from Bauhinia along Duaringa road, then 3.3 km along Oombabeer
       road.
-    collector: Zich, F.A.; Wang, B.
+    recorded by: Zich, F.A.; Wang, B.
   site_at_-24.5111_degS_and_133.1789_degE:
     latitude (deg): -24.5111
     longitude (deg): 133.1789
     locality: Henbury Station; 9 km directly WNW of Henbury homestead (direct)
-    collector: Latz, P.K.
+    recorded by: Latz, P.K.
   site_at_-24.5114_degS_and_133.4556_degE:
     latitude (deg): -24.5114
     longitude (deg): 133.4556
     locality: Henbury Station; 21 km ~NE of Henbury homestead (straight line GPS);
       base of sandstone ridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5117_degS_and_133.4572_degE:
     latitude (deg): -24.5117
     longitude (deg): 133.4572
     locality: Henbury Station; 21 km ~NE of Henbury homestead (straight line GPS);
       base of sandstone ridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5119_degS_and_132.6819_degE:
     latitude (deg): -24.5119
     longitude (deg): 132.6819
     locality: Henbury Station; c. 58 km directly ~W from Henbury homestead; edge of
       seasonal swamp on track towards Boggy Hole.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5197_degS_and_133.2531_degE:
     latitude (deg): -24.5197
     longitude (deg): 133.2531
     locality: Henbury Station; Stuart Highway, c. 3 km NNE of Henbury Station homestead
       turnoff towards Alice Springs; 400 m S of road.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5472_degS_and_133.5314_degE:
     latitude (deg): -24.5472
     longitude (deg): 133.5314
     locality: Henbury Station; c. 9 km N of Mount Gloaming; sandy earth plain.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5492_degS_and_133.5319_degE:
     latitude (deg): -24.5492
     longitude (deg): 133.5319
     locality: Henbury Station; 28 km E of Henbury homestead; mulga community between
       red sand dunes.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5503_degS_and_133.2525_degE:
     latitude (deg): -24.5503
     longitude (deg): 133.2525
     locality: Henbury Station; old cattle holding paddock, Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5503_degS_and_133.5333_degE:
     latitude (deg): -24.5503
     longitude (deg): 133.5333
     locality: Henbury Station; 28.4 km E of Henbury homestead (straight line GPS);
       sandy rise.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5519_degS_and_133.5367_degE:
     latitude (deg): -24.5519
     longitude (deg): 133.5367
     locality: Henbury Station; red earth plain c. 2 km due S of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5639_degS_and_133.2517_degE:
     latitude (deg): -24.5639
     longitude (deg): 133.2517
     locality: Henbury Station; track c. 2 km due S of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5717_degS_and_133.2414_degE:
     latitude (deg): -24.5717
     longitude (deg): 133.2414
     locality: Henbury Station; 3 km S of Henbury homestead turn-off, just E of Stuart
       Highway.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5731_degS_and_133.2517_degE:
     latitude (deg): -24.5731
     longitude (deg): 133.2517
     locality: Henbury Station; clay pan c. 3 km due S of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5742_degS_and_133.2536_degE:
     latitude (deg): -24.5742
     longitude (deg): 133.2536
     locality: Henbury Station; clay pan c. 3 km due S of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.5833_degS_and_135.7167_degE:
     latitude (deg): -24.5833
     longitude (deg): 135.7167
     locality: Floodout of Hale River, near Numery soak.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-24.6031_degS_and_133.2222_degE:
     latitude (deg): -24.6031
     longitude (deg): 133.2222
     locality: Henbury Station; c. 6 km ~SSW of Henbury homestead; 100 m E of Stuart
       Highway at base of gravelly slope.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6086_degS_and_133.2306_degE:
     latitude (deg): -24.6086
     longitude (deg): 133.2306
     locality: Henbury Station; c. 6 km directly ~SSW of Henbury homestead; gravelly
       topped clay slope near dam.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6089_degS_and_133.23_degE:
     latitude (deg): -24.6089
     longitude (deg): 133.23
     locality: Henbury Station; c. 6 km directly ~SSW of Henbury homestead; edge of
       dam.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6375_degS_and_132.7119_degE:
     latitude (deg): -24.6375
     longitude (deg): 132.7119
     locality: Henbury Station; c. 58 km directly ~WSW from Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6397_degS_and_132.7283_degE:
     latitude (deg): -24.6397
     longitude (deg): 132.7283
     locality: Henbury Station; c. 54 km directly ~WSW from Henbury homestead; in gravelly
       watercourse.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6425_degS_and_133.4311_degE:
     latitude (deg): -24.6425
     longitude (deg): 133.4311
     locality: Henbury Station; c. 22 km directly ~SE of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6425_degS_and_133.4317_degE:
     latitude (deg): -24.6425
     longitude (deg): 133.4317
     locality: Henbury Station; c. 22 km directly ~SE of Henbury homestead; edge of
       seasonal swamp.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6428_degS_and_132.6733_degE:
     latitude (deg): -24.6428
     longitude (deg): 132.6733
     locality: Henbury Station; c. 56 km directly ~WSW from Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6436_degS_and_133.4314_degE:
     latitude (deg): -24.6436
     longitude (deg): 133.4314
     locality: Henbury Station; c. 22 km directly ~SE of Henbury homestead.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6442_degS_and_133.4369_degE:
     latitude (deg): -24.6442
     longitude (deg): 133.4369
     locality: Henbury Station; c. 22 km directly ~SE of Henbury homestead, 8 km SWS
       of Mt Gloaming.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.6444_degS_and_133.4319_degE:
     latitude (deg): -24.6444
     longitude (deg): 133.4319
     locality: Henbury Station; c. 22 km directly ~SE of Henbury homestead, 8 km SWS
       of Mt Gloaming.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-24.7_degS_and_146.3333_degE:
     latitude (deg): -24.7
     longitude (deg): 146.3333
     locality: 19.9 km from Tambo toward Alpha.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-24.75_degS_and_152.1833_degE:
     latitude (deg): -24.75
     longitude (deg): 152.1833
     locality: 20 km NW of Bundaberg, Moorland.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-24.8667_degS_and_150.9833_degE:
     latitude (deg): -24.8667
     longitude (deg): 150.9833
     locality: Coomingalah Range, Coomingalah State Forest, 1.5 km along Mannigans
       Road from Hurdle Gully-Scrubby Road intersection.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-24.9_degS_and_150.9667_degE:
     latitude (deg): -24.9
     longitude (deg): 150.9667
     locality: 15 km (direct) W of Monto, Coominglah State Forest, E boundary road
       at 10 km S along Hannigans Road from Hurdle Gully Road.
-    collector: Makinson, R.O.
+    recorded by: Makinson, R.O.
   site_at_-24.9167_degS_and_113.7167_degE:
     latitude (deg): -24.9167
     longitude (deg): 113.7167
     locality: 13 km S of Carnarvon.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-25.0569_degS_and_148.2258_degE:
     latitude (deg): -25.0569
     longitude (deg): 148.2258
     locality: Carnarvon Gorge National Park. Mount Howe 8547-235280. Carnarvon Gorge,
       700 m along main track from Information Centre NW up Carnarvon Gorge from SE
       end.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-25.1244_degS_and_143.1586_degE:
     latitude (deg): -25.1244
     longitude (deg): 143.1586
     locality: Welford National Park; Desert Drive, second (north) dune.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-25.1308_degS_and_143.1472_degE:
     latitude (deg): -25.1308
     longitude (deg): 143.1472
     locality: Welford National Park; Desert Drive, S side of first dune.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-25.1467_degS_and_143.1147_degE:
     latitude (deg): -25.1467
     longitude (deg): 143.1147
     locality: Welford National Park; Desert Drive, 2.3 km W from Desert Waterhole.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-25.2167_degS_and_145.2_degE:
     latitude (deg): -25.2167
     longitude (deg): 145.2
     locality: 99.3 km from Blackall toward Adavale, near Listowel Downs Station.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-25.2806_degS_and_130.7433_degE:
     latitude (deg): -25.2806
     longitude (deg): 130.7433
     locality: Uluru - Kata Tjuta National Park; along entrance to Valley of the Winds,
       N/W of Kata Tjuta.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-25.2864_degS_and_130.7372_degE:
     latitude (deg): -25.2864
     longitude (deg): 130.7372
     locality: Uluru - Kata Tjuta National Park Olgas walking track (Kata Tjuta).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.2878_degS_and_130.74_degE:
     latitude (deg): -25.2878
     longitude (deg): 130.74
     locality: Uluru - Kata Tjuta National Park; Valley of the Winds area.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-25.2886_degS_and_130.7322_degE:
     latitude (deg): -25.2886
     longitude (deg): 130.7322
     locality: Uluru - Kata Tjuta National Park beside the Valley of the Winds walking
       track in the Olgas (Kata Tjuta).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.2969_degS_and_130.7061_degE:
     latitude (deg): -25.2969
     longitude (deg): 130.7061
     locality: Uluru - Kata Tjuta National Park Kata Tjuta.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-25.3_degS_and_130.9833_degE:
     latitude (deg): -25.3
     longitude (deg): 130.9833
     locality: Uluru - Kata Tjuta National Park; NNW of Park Headquarters 8 km on road
       to Yulara Resort.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-25.3119_degS_and_130.6942_degE:
     latitude (deg): -25.3119
     longitude (deg): 130.6942
     locality: Uluru - Kata Tjuta National Park; c. 6 km ~W of Kata Tjuta.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-25.3167_degS_and_130.7_degE:
     latitude (deg): -25.3167
     longitude (deg): 130.7
     locality: Ayers Rock National Park, Mount Olga, Mount Olga Gorge.
-    collector: Verdon, D.
+    recorded by: Verdon, D.
   site_at_-25.3167_degS_and_131.75_degE:
     latitude (deg): -25.3167
     longitude (deg): 131.75
     locality: Ayers Rock Road, Curtin Springs Station, 73 km E of Ayers Rock.
-    collector: Verdon, D.
+    recorded by: Verdon, D.
   site_at_-25.3333_degS_and_131_degE:
     latitude (deg): -25.3333
     longitude (deg): 131.0
     locality: Uluru - Kata Tjuta National Park.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-25.3342_degS_and_131.0167_degE:
     latitude (deg): -25.3342
     longitude (deg): 131.0167
     locality: Uluru - Kata Tjuta National Park 1.1 km NW of Uluru (Ayers Rock).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.3425_degS_and_131.0475_degE:
     latitude (deg): -25.3425
     longitude (deg): 131.0475
     locality: Uluru - Kata Tjuta National Park E edge of Uluru (Ayers Rock).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.3464_degS_and_131.0636_degE:
     latitude (deg): -25.3464
     longitude (deg): 131.0636
     locality: Uluru - Kata Tjuta National Park Talinguru, 1.2 km ENE of Uluru (Ayers
       Rock).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.35_degS_and_131.0167_degE:
     latitude (deg): -25.35
     longitude (deg): 131.0167
     locality: Uluru - Kata Tjuta National Park; Park Headquarters.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-25.3533_degS_and_130.7861_degE:
     latitude (deg): -25.3533
     longitude (deg): 130.7861
     locality: Uluru - Kata Tjuta National Park northern side of Lasseter Highway,
       23.8 km due W of Uluru (Ayers Rock) and c. 5 km S of Kata Tjuta (the Olgas).
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-25.4167_degS_and_144.9333_degE:
     latitude (deg): -25.4167
     longitude (deg): 144.9333
     locality: Adavale-Blackall road, about 19 km approx. SW of Listowel Valley homestead.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-25.45_degS_and_150.1667_degE:
     latitude (deg): -25.45
     longitude (deg): 150.1667
     locality: Nathan Gorge, 23 km SW of Cracow, Cabbagetree Creek.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-25.7833_degS_and_139.325_degE:
     latitude (deg): -25.7833
     longitude (deg): 139.325
     locality: 14 km N of Birdsville towards Bedourie, along the Eyre Development Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-25.8833_degS_and_146.1667_degE:
     latitude (deg): -25.8833
     longitude (deg): 146.1667
     locality: 22.5 km from road junction near (c. 3.7 km c. SE of) Oakwood Station
       toward Charleville, on road along Ward River.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-25.9167_degS_and_144.6333_degE:
     latitude (deg): -25.9167
     longitude (deg): 144.6333
     locality: 3.9 km from Adavale toward Charleville.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-25.97_degS_and_137.9283_degE:
     latitude (deg): -25.97
     longitude (deg): 137.9283
     locality: Simpson Desert Conservation Park. Australian Desert Expeditions Great
       White Lakes traverse, day 16.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-25.9764_degS_and_113.5681_degE:
     latitude (deg): -25.9764
     longitude (deg): 113.5681
     locality: 8 km S of Denham, Shark Bay, on Denham Hamelin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-25.9833_degS_and_151.3333_degE:
     latitude (deg): -25.9833
     longitude (deg): 151.3333
     locality: 5.5 km W of Toondahra.
-    collector: Forster, P.
+    recorded by: Forster, P.
   site_at_-25_degS_and_142.75_degE:
     latitude (deg): -25.0
     longitude (deg): 142.75
     locality: 43 km S of Jundah on Windorah road.
-    collector: Zich, F.A.
+    recorded by: Zich, F.A.
   site_at_-26.0806_degS_and_137.9931_degE:
     latitude (deg): -26.0806
     longitude (deg): 137.9931
     locality: Simpson Desert Conservation Park. Australian Desert Expeditions Great
       White Lakes traverse, day 15. Eastern edge of Lake Thomas (large salina).
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.1189_degS_and_113.6431_degE:
     latitude (deg): -26.1189
     longitude (deg): 113.6431
     locality: 1 km N of Whale Bone Road, Shark Bay, on Denham Hamelin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.2167_degS_and_152.9333_degE:
     latitude (deg): -26.2167
     longitude (deg): 152.9333
     locality: 1.9 km along Bates Road from the Kin Kin Road, c. 26 km ESE of Gympie.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-26.2503_degS_and_138.085_degE:
     latitude (deg): -26.2503
     longitude (deg): 138.085
     locality: Simpson Desert Conservation Park. Australian Desert Expeditions Great
       White Lakes traverse, day 13.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.2547_degS_and_150.7208_degE:
     latitude (deg): -26.2547
     longitude (deg): 150.7208
     locality: Barakula State Forest; shortly before gate c. 2 km NE on track running
       ~E NE off Auburn Road at c. 59 km N from Warrego Highway.
-    collector: Schmidt-Lebuhn, A.N.
+    recorded by: Schmidt-Lebuhn, A.N.
   site_at_-26.2667_degS_and_152.8833_degE:
     latitude (deg): -26.2667
     longitude (deg): 152.8833
     locality: West Penda Creek, Kin Kin, Gympie District.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-26.2772_degS_and_113.8706_degE:
     latitude (deg): -26.2772
     longitude (deg): 113.8706
     locality: 13 km S of electric fence, Shark Bay, on Denham Hamelin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.3214_degS_and_113.9147_degE:
     latitude (deg): -26.3214
     longitude (deg): 113.9147
     locality: 19 km S of electric fence, Shark Bay, on Denham Hamelin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.3667_degS_and_150.6833_degE:
     latitude (deg): -26.3667
     longitude (deg): 150.6833
     locality: Barakula State Forest, Auburn Road, just N of Little Hellhole Creek
       crossing.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-26.3989_degS_and_138.1736_degE:
     latitude (deg): -26.3989
     longitude (deg): 138.1736
     locality: Simpson Desert Conservation Park. Australian Desert Expeditions Great
       White Lakes traverse, day 11, on K1 Line track.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.4_degS_and_149.9167_degE:
     latitude (deg): -26.4
     longitude (deg): 149.9167
     locality: 14.3 km from Gurulmundi Railway Siding on the Gurulmundi to Woleebee
       road.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-26.4_degS_and_153.0333_degE:
     latitude (deg): -26.4
     longitude (deg): 153.0333
     locality: N of Tewantin, road verge of Lake Cooroibah Drive.
-    collector: Jones, D.L.
+    recorded by: Jones, D.L.
   site_at_-26.4106_degS_and_114.3778_degE:
     latitude (deg): -26.4106
     longitude (deg): 114.3778
     locality: 21.5 km S of World Heritage grid, Shark Bay, on Denham Hamelin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.4575_degS_and_114.4792_degE:
     latitude (deg): -26.4575
     longitude (deg): 114.4792
     locality: 6.2 km S of the Overlander Ampol petrol station on North West Coastal
       Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.4822_degS_and_138.2125_degE:
     latitude (deg): -26.4822
     longitude (deg): 138.2125
     locality: Simpson Desert Conservation Park. Australian Desert Expeditions Great
       White Lakes traverse, day 10.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.5_degS_and_146.2167_degE:
     latitude (deg): -26.5
     longitude (deg): 146.2167
     locality: 12.7 km from Charleville toward Cunnamulla, by railway line.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-26.5_degS_and_153.0833_degE:
     latitude (deg): -26.5
     longitude (deg): 153.0833
     locality: 4.5 km N of Coolum Mountain.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-26.5078_degS_and_138.2281_degE:
     latitude (deg): -26.5078
     longitude (deg): 138.2281
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 10.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.5158_degS_and_114.5006_degE:
     latitude (deg): -26.5158
     longitude (deg): 114.5006
     locality: 12 km S of the Overlander Ampol petrol station on North West Coastal
       Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.5167_degS_and_153.0833_degE:
     latitude (deg): -26.5167
     longitude (deg): 153.0833
     locality: Mt Emu, Havana Road, c. 2.5 km N of Coolum Beach.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-26.5333_degS_and_151.7833_degE:
     latitude (deg): -26.5333
     longitude (deg): 151.7833
     locality: Mt Wooroolin, 4 km WNW of Kingaroy.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-26.5667_degS_and_150.5833_degE:
     latitude (deg): -26.5667
     longitude (deg): 150.5833
     locality: 12.5 km NNW along Auburn Road from junction with Warrego Highway.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-26.5667_degS_and_153.0833_degE:
     latitude (deg): -26.5667
     longitude (deg): 153.0833
     locality: Coolum Mountain, NE side of small gully on SE side of mountain, c. 100
       m from summit.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-26.5833_degS_and_113.9167_degE:
     latitude (deg): -26.5833
     longitude (deg): 113.9167
     locality: 25 km N of Tamala Station.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-26.6_degS_and_144.3333_degE:
     latitude (deg): -26.6
     longitude (deg): 144.3333
     locality: 8.4 km from Quilpie toward Charleville.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-26.6167_degS_and_152.9667_degE:
     latitude (deg): -26.6167
     longitude (deg): 152.9667
     locality: Northern tributary of Petrie Creek, nothern outskirts of Nambour, picnic
       area, just N of Major intersection of Bli Bli - Mapleton road.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-26.6333_degS_and_145.9_degE:
     latitude (deg): -26.6333
     longitude (deg): 145.9
     locality: 44.7 km from Charleville toward Quilpie, near Blacks Tank Road turnoff.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-26.6456_degS_and_150.5789_degE:
     latitude (deg): -26.6456
     longitude (deg): 150.5789
     locality: S of Barakula State Forest,  c. 11.3 km N of Warrego Highway on Auburn
       Road.
-    collector: Schmidt-Lebuhn, A.N.
+    recorded by: Schmidt-Lebuhn, A.N.
   site_at_-26.6739_degS_and_138.2492_degE:
     latitude (deg): -26.6739
     longitude (deg): 138.2492
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 9.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.6989_degS_and_138.2583_degE:
     latitude (deg): -26.6989
     longitude (deg): 138.2583
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 9, just north of Rig Road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.7286_degS_and_114.5806_degE:
     latitude (deg): -26.7286
     longitude (deg): 114.5806
     locality: 38 km S of the Overlander Ampol petrol station on North West Coastal
       Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-26.7372_degS_and_138.2614_degE:
     latitude (deg): -26.7372
     longitude (deg): 138.2614
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 8.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.7594_degS_and_138.2706_degE:
     latitude (deg): -26.7594
     longitude (deg): 138.2706
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 8.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.7833_degS_and_152.8_degE:
     latitude (deg): -26.7833
     longitude (deg): 152.8
     locality: Blackall Range, Mary Cairncross Park, c. 4 km ESE of Maleny.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-26.8_degS_and_149.5333_degE:
     latitude (deg): -26.8
     longitude (deg): 149.5333
     locality: Clayhole Creek, 26 km SE of Yuleba, 12.5 km from Condamine to Surat
       Road.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-26.8333_degS_and_151.5833_degE:
     latitude (deg): -26.8333
     longitude (deg): 151.5833
     locality: Bunya Mountains.
-    collector: Hodge, M.
+    recorded by: Hodge, M.
   site_at_-26.8442_degS_and_138.29_degE:
     latitude (deg): -26.8442
     longitude (deg): 138.29
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 8.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.85_degS_and_144.95_degE:
     latitude (deg): -26.85
     longitude (deg): 144.95
     locality: 35.1 km from Cheepie toward Quilpie, via Cowley Station.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-26.8667_degS_and_151.5667_degE:
     latitude (deg): -26.8667
     longitude (deg): 151.5667
     locality: Bunya Mts, Koondaii Lookout track.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-26.8833_degS_and_151.6_degE:
     latitude (deg): -26.8833
     longitude (deg): 151.6
     locality: Bunya Mts., Mt. Mowbullan.
-    collector: Dunlop, C.R.
+    recorded by: Dunlop, C.R.
   site_at_-26.8867_degS_and_138.2689_degE:
     latitude (deg): -26.8867
     longitude (deg): 138.2689
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 7.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-26.9_degS_and_151.6333_degE:
     latitude (deg): -26.9
     longitude (deg): 151.6333
     locality: 3/4 mile 1.2 km from Bunya Mts crest along road to Dalby.
-    collector: Carroll, E.J.
+    recorded by: Carroll, E.J.
   site_at_-26.9922_degS_and_138.2583_degE:
     latitude (deg): -26.9922
     longitude (deg): 138.2583
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 6.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.0167_degS_and_120.35_degE:
     latitude (deg): -27.0167
     longitude (deg): 120.35
     locality: 51 km S of Wiluna.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-27.0183_degS_and_138.2686_degE:
     latitude (deg): -27.0183
     longitude (deg): 138.2686
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 6.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.0647_degS_and_138.275_degE:
     latitude (deg): -27.0647
     longitude (deg): 138.275
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 6.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.2028_degS_and_138.2956_degE:
     latitude (deg): -27.2028
     longitude (deg): 138.2956
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 4; Pooliadinna Waterhole (dry) area.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.2544_degS_and_138.3111_degE:
     latitude (deg): -27.2544
     longitude (deg): 138.3111
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 4.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.2753_degS_and_138.3178_degE:
     latitude (deg): -27.2753
     longitude (deg): 138.3178
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 3.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.2783_degS_and_138.3253_degE:
     latitude (deg): -27.2783
     longitude (deg): 138.3253
     locality: Simpson Desert Regional Reserve. Australian Desert Expeditions Great
       White Lakes traverse, day 3.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.35_degS_and_152.6667_degE:
     latitude (deg): -27.35
     longitude (deg): 152.6667
     locality: 3 km NE of Splityard Creek power house, Wivenhoe Dam, 15 km NE of Fernvale.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.3786_degS_and_138.3656_degE:
     latitude (deg): -27.3786
     longitude (deg): 138.3656
     locality: Simpson Desert Regional Reserve, c. 5 km N of Kallakoopah Creek. Australian
       Desert Expeditions Great White Lakes traverse, day 2.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.3789_degS_and_138.3622_degE:
     latitude (deg): -27.3789
     longitude (deg): 138.3622
     locality: Simpson Desert Regional Reserve, c. 5 km N of Kallakoopah Creek. Australian
       Desert Expeditions Great White Lakes traverse, day 2.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.4386_degS_and_138.2769_degE:
     latitude (deg): -27.4386
     longitude (deg): 138.2769
     locality: Simpson Desert, Pathraootara Creek area N of junction with Kallakoopah
       Creek. Australian Desert Expeditions Great White Lakes traverse, day 1.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.4408_degS_and_138.2806_degE:
     latitude (deg): -27.4408
     longitude (deg): 138.2806
     locality: Simpson Desert, Pathraootara Creek area N of junction with Kallakoopah
       Creek. Australian Desert Expeditions Great White Lakes traverse, day 1.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.4417_degS_and_153.0028_degE:
     latitude (deg): -27.4417
     longitude (deg): 153.0028
     locality: Ithaca creek, Bancroft Park, Newmarket, Brisbane.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.4464_degS_and_114.6769_degE:
     latitude (deg): -27.4464
     longitude (deg): 114.6769
     locality: 100 km N of Northampton on North West Coastal Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-27.5_degS_and_152.7_degE:
     latitude (deg): -27.5
     longitude (deg): 152.7
     locality: Worlds End Pocket 19.5 km NW Ipswich.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.5111_degS_and_151.8333_degE:
     latitude (deg): -27.5111
     longitude (deg): 151.8333
     locality: Gowrie Mountian, Property of Alan Grunke
-    collector: Donaldson, S.R.
+    recorded by: Donaldson, S.R.
   site_at_-27.5167_degS_and_152.8167_degE:
     latitude (deg): -27.5167
     longitude (deg): 152.8167
     locality: Kholo Creek, near rock outcrop on old Ugly gully to Mt Crosby road,
       between Kholo Creek and Wirrabina.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-27.5167_degS_and_153.0833_degE:
     latitude (deg): -27.5167
     longitude (deg): 153.0833
     locality: Pine Mountain Reserve, Carina, Brisbane.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.5333_degS_and_152.7333_degE:
     latitude (deg): -27.5333
     longitude (deg): 152.7333
     locality: Pine Mountain, 12 km NW of Ipswich.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.5417_degS_and_144.475_degE:
     latitude (deg): -27.5417
     longitude (deg): 144.475
     locality: 15 km from Prairie turnoff the Quilpie-Thargomindah road, toward Eulo.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-27.55_degS_and_152.7667_degE:
     latitude (deg): -27.55
     longitude (deg): 152.7667
     locality: Bellbawrie, 18 km SW of GPO Brisbane.
-    collector: Bastock, P.
+    recorded by: Bastock, P.
   site_at_-27.575_degS_and_145.7_degE:
     latitude (deg): -27.575
     longitude (deg): 145.7
     locality: 19.8 km from Cunnamulla toward Charleville.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-27.5833_degS_and_152.8333_degE:
     latitude (deg): -27.5833
     longitude (deg): 152.8333
     locality: Ipswich; Woogararoo Creek, Goodna.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.6_degS_and_117.7667_degE:
     latitude (deg): -27.6
     longitude (deg): 117.7667
     locality: Lake Austin.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-27.6_degS_and_152.75_degE:
     latitude (deg): -27.6
     longitude (deg): 152.75
     locality: Beryens Hill area, near Ipswich.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-27.6167_degS_and_152.2833_degE:
     latitude (deg): -27.6167
     longitude (deg): 152.2833
     locality: 6 km S of Gatton on the Ropely road.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-27.6167_degS_and_152.7833_degE:
     latitude (deg): -27.6167
     longitude (deg): 152.7833
     locality: Ipswich, Bundamba, end of Barclay Street.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.6667_degS_and_114.2333_degE:
     latitude (deg): -27.6667
     longitude (deg): 114.2333
     locality: 8 km E of Kalbarri.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-27.7167_degS_and_136.7833_degE:
     latitude (deg): -27.7167
     longitude (deg): 136.7833
     locality: North western Lake Eyre Region, about 4.5 km NW of Tuppana Waterhole,
       Nardiebuckina Creek.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.75_degS_and_140.7167_degE:
     latitude (deg): -27.75
     longitude (deg): 140.7167
     locality: Policemans Waterhole, Cooper Creek, near Innamincka.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.8486_degS_and_153.2222_degE:
     latitude (deg): -27.8486
     longitude (deg): 153.2222
     locality: 30 km SW of Beenleigh on Pimpana River at Upper Ormeau.
-    collector: Hauser, J.
+    recorded by: Hauser, J.
   site_at_-27.8667_degS_and_114.1333_degE:
     latitude (deg): -27.8667
     longitude (deg): 114.1333
     locality: Kalbarri National Park, 3 km E of Bluff Point.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-27.8667_degS_and_114.5167_degE:
     latitude (deg): -27.8667
     longitude (deg): 114.5167
     locality: Kalbarri National Park, 20 km from North West Coastal Highway along
       road to Kalbarri.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-27.95_degS_and_114.7167_degE:
     latitude (deg): -27.95
     longitude (deg): 114.7167
     locality: 5.2 km E of Great Northern Highway, opposite junction with road to Ajana
       and Kalbarri.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-27.9833_degS_and_119.3_degE:
     latitude (deg): -27.9833
     longitude (deg): 119.3
     locality: 54 km E of Sandstone.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-27.9833_degS_and_152.6833_degE:
     latitude (deg): -27.9833
     longitude (deg): 152.6833
     locality: Boonah district, Mount Maroon, N slope.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-27.9925_degS_and_114.195_degE:
     latitude (deg): -27.9925
     longitude (deg): 114.195
     locality: 14.7 km S of Kalbarri National Park boundary on Grey Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.0072_degS_and_114.6744_degE:
     latitude (deg): -28.0072
     longitude (deg): 114.6744
     locality: 3.3 km N of Binnu on North West Coastal Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.0075_degS_and_114.2114_degE:
     latitude (deg): -28.0075
     longitude (deg): 114.2114
     locality: 20 km S of Kalbarri National Park boundary on Grey Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.0125_degS_and_114.6706_degE:
     latitude (deg): -28.0125
     longitude (deg): 114.6706
     locality: 400m along old road going S from junction of North West Coastal Highway,
       3 km N of Binnu.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.0183_degS_and_114.2953_degE:
     latitude (deg): -28.0183
     longitude (deg): 114.2953
     locality: 9 km E along South Binnu Road from Grey Road intersection towards Binnu.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.0186_degS_and_114.2308_degE:
     latitude (deg): -28.0186
     longitude (deg): 114.2308
     locality: 1 km E along South Binnu Road from Grey Road intersection to Binnu.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.0189_degS_and_114.3036_degE:
     latitude (deg): -28.0189
     longitude (deg): 114.3036
     locality: 10 km E along South Binnu Road from Grey Road intersection to Binnu.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.0333_degS_and_147.5_degE:
     latitude (deg): -28.0333
     longitude (deg): 147.5
     locality: c. 1 km from Bollon toward St. George.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-28.0333_degS_and_152.6_degE:
     latitude (deg): -28.0333
     longitude (deg): 152.6
     locality: Frenchs Creek, Mt French, 12 km SW of Boonah.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.0333_degS_and_152.6667_degE:
     latitude (deg): -28.0333
     longitude (deg): 152.6667
     locality: Mt French, 6 km SW of Boonah.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.05_degS_and_153.1167_degE:
     latitude (deg): -28.05
     longitude (deg): 153.1167
     locality: Canungra Creek valley, 5 km from Canungra along Cainbable road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.0583_degS_and_145.35_degE:
     latitude (deg): -28.0583
     longitude (deg): 145.35
     locality: 31.6 km from Cunnamulla toward Eulo, just W of Moonjaree Creek.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-28.0667_degS_and_152.4_degE:
     latitude (deg): -28.0667
     longitude (deg): 152.4
     locality: Mt Mitchell, 80 km SW Ipswich.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.0833_degS_and_152.5167_degE:
     latitude (deg): -28.0833
     longitude (deg): 152.5167
     locality: Mount Greville, Southeast Ridge.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.0833_degS_and_153.05_degE:
     latitude (deg): -28.0833
     longitude (deg): 153.05
     locality: Lamington National Park, access road from carpark to camping ground,
       Green Mountain (OReillys Guest House).
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-28.0833_degS_and_153.4333_degE:
     latitude (deg): -28.0833
     longitude (deg): 153.4333
     locality: Currumbin Creek valley, road to Tomewin Gap.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.0833_degS_and_153.45_degE:
     latitude (deg): -28.0833
     longitude (deg): 153.45
     locality: Burleigh Head.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.1458_degS_and_144.6958_degE:
     latitude (deg): -28.1458
     longitude (deg): 144.6958
     locality: Thargomindah - Eulo road, 18.3 km W of junction with road to Hungerford.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-28.1631_degS_and_114.6486_degE:
     latitude (deg): -28.1631
     longitude (deg): 114.6486
     locality: 1 km S of Hutt River crossing on North West Coastal Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.1756_degS_and_114.6467_degE:
     latitude (deg): -28.1756
     longitude (deg): 114.6467
     locality: 5 km S of Binnu on North West Coastal Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.1833_degS_and_151.6167_degE:
     latitude (deg): -28.1833
     longitude (deg): 151.6167
     locality: 0.2 km N. of the Cunningham Hwy., 9 km S.W. of Thanes Crossing. (In
       durikai S.F.).
-    collector: Pryor, L.D.
+    recorded by: Pryor, L.D.
   site_at_-28.1961_degS_and_114.6358_degE:
     latitude (deg): -28.1961
     longitude (deg): 114.6358
     locality: 18 km N of Northampton on North West Coastal Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.2_degS_and_152.5_degE:
     latitude (deg): -28.2
     longitude (deg): 152.5
     locality: 35 km SW of Boonah, Mt Bangalora.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.2_degS_and_152.7167_degE:
     latitude (deg): -28.2
     longitude (deg): 152.7167
     locality: Mt Maroon, summit plateau.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.2_degS_and_153.3333_degE:
     latitude (deg): -28.2
     longitude (deg): 153.3333
     locality: Lamington National Park, Binna Burra, Border Ranges Trail, 0.5-0.6 km
       from carpark.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-28.2167_degS_and_152.55_degE:
     latitude (deg): -28.2167
     longitude (deg): 152.55
     locality: 30 km SSW of Boonah, 6 km NE of White Swamp border gate, McPherson Range
       on escarpment overlooking Burnett Creek.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.2167_degS_and_152.7_degE:
     latitude (deg): -28.2167
     longitude (deg): 152.7
     locality: Mount Maroon, 36 km SW of Beaudesert.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.2167_degS_and_152.7333_degE:
     latitude (deg): -28.2167
     longitude (deg): 152.7333
     locality: Boonah district, Mount Maroon.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.25_degS_and_152.1833_degE:
     latitude (deg): -28.25
     longitude (deg): 152.1833
     locality: McPherson Range, Mt Merino.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.25_degS_and_152.7167_degE:
     latitude (deg): -28.25
     longitude (deg): 152.7167
     locality: McPherson Range, Mt Barney, East Peak.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.25_degS_and_153.2_degE:
     latitude (deg): -28.25
     longitude (deg): 153.2
     locality: QMO/NNC Mt. Merino, McPherson Range.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.2667_degS_and_114.4944_degE:
     latitude (deg): -28.2667
     longitude (deg): 114.4944
     locality: 3.5 km along Swamps Rd form Port Gregory Rd, from 16.5 km from Northampton
       toward Port Gregory.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.2667_degS_and_114.4967_degE:
     latitude (deg): -28.2667
     longitude (deg): 114.4967
     locality: 3.5 km along Swamps Road from Port Gregory Road, turnoff 16.5 km from
       Northampton towards Port Gregory Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-28.2667_degS_and_143.85_degE:
     latitude (deg): -28.2667
     longitude (deg): 143.85
     locality: 38 km S of Thargomindah.
-    collector: Zich, F.A.
+    recorded by: Zich, F.A.
   site_at_-28.2667_degS_and_153.25_degE:
     latitude (deg): -28.2667
     longitude (deg): 153.25
     locality: McPherson Range, Couchy Creek.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.2667_degS_and_153.4833_degE:
     latitude (deg): -28.2667
     longitude (deg): 153.4833
     locality: c. 3 km along the Pacific Highway from Tumbulgum towards Tweed Heads.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-28.2672_degS_and_145.7775_degE:
     latitude (deg): -28.2672
     longitude (deg): 145.7775
     locality: 133 km N of Enngonia on Mitchell Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-28.3_degS_and_153.1667_degE:
     latitude (deg): -28.3
     longitude (deg): 153.1667
     locality: 6 km NW of Tyalgum, 300 m NW beyond end of Butlers Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-28.3167_degS_and_153.3833_degE:
     latitude (deg): -28.3167
     longitude (deg): 153.3833
     locality: Murwillumbah
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-28.3333_degS_and_117.8333_degE:
     latitude (deg): -28.3333
     longitude (deg): 117.8333
     locality: 33 km S of Mt Magnet.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-28.3333_degS_and_153.5667_degE:
     latitude (deg): -28.3333
     longitude (deg): 153.5667
     locality: Beside road at entrance to Wollumbin Cudgen Nature Reserve between Hastings
       Point and Kingscliff.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.3531_degS_and_116.7228_degE:
     latitude (deg): -28.3531
     longitude (deg): 116.7228
     locality: 46 km E of Yalgoo on Geraldton Mt Magnet Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.3644_degS_and_116.5097_degE:
     latitude (deg): -28.3644
     longitude (deg): 116.5097
     locality: 21.3 km W of Yalgoo on Geraldton Mt Magnet Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.3667_degS_and_153.05_degE:
     latitude (deg): -28.3667
     longitude (deg): 153.05
     locality: Border Ranges National Park, Bar Mountain, Antarctic Beech grove (picnic
       area surrounds).
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-28.3667_degS_and_153.5667_degE:
     latitude (deg): -28.3667
     longitude (deg): 153.5667
     locality: Rainforest park in centre of Hastings Point, northern NSW.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.3672_degS_and_116.4614_degE:
     latitude (deg): -28.3672
     longitude (deg): 116.4614
     locality: 26.4 km W of Yalgoo on Geraldton - Mount Magnet Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-28.3833_degS_and_152.3667_degE:
     latitude (deg): -28.3833
     longitude (deg): 152.3667
     locality: Beside road leading from Koreelah Creek to Acacia Plateau, ca 19 km
       SW from White Swamp Border Gate.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.3833_degS_and_152.4583_degE:
     latitude (deg): -28.3833
     longitude (deg): 152.4583
     locality: Burringbar Gap, 3 km NW of Burringbar.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.3833_degS_and_153.1_degE:
     latitude (deg): -28.3833
     longitude (deg): 153.1
     locality: 24 km N of Kyogle, Wiangaree State Forest.
-    collector: Bird, L.
+    recorded by: Bird, L.
   site_at_-28.3833_degS_and_153.35_degE:
     latitude (deg): -28.3833
     longitude (deg): 153.35
     locality: Road from Murwillumbah to Tyalgum, 8 km NE of Mt Warning, N bank of
       Oxley River.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-28.4_degS_and_151.7_degE:
     latitude (deg): -28.4
     longitude (deg): 151.7
     locality: c. 39 km direct SW of Warwick, Herries Range, State Forest 444.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.4_degS_and_153.1167_degE:
     latitude (deg): -28.4
     longitude (deg): 153.1167
     locality: Tweed Range, 0.5 km S of Nothofagus Lookout.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.4_degS_and_153.2833_degE:
     latitude (deg): -28.4
     longitude (deg): 153.2833
     locality: Carpark at Mt Warning, c. 13.5 km SW of Murwillumbah.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-28.4333_degS_and_152.5333_degE:
     latitude (deg): -28.4333
     longitude (deg): 152.5333
     locality: c. 6 km along Back Creek Road from McIntoshs Road, c. 10 km SE of Woodenbong.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-28.4667_degS_and_152.5333_degE:
     latitude (deg): -28.4667
     longitude (deg): 152.5333
     locality: Urbenville, Council Sewage Works depot, near North Obelisk Mountain.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-28.4667_degS_and_152.55_degE:
     latitude (deg): -28.4667
     longitude (deg): 152.55
     locality: Tooloom Falls, 3 km SSE of Urbenville.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-28.4775_degS_and_114.6331_degE:
     latitude (deg): -28.4775
     longitude (deg): 114.6331
     locality: 35 km N of Geraldton on North West Coastal Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.4839_degS_and_114.6333_degE:
     latitude (deg): -28.4839
     longitude (deg): 114.6333
     locality: 36 km from Geraldton towards Northampton, along Great Northern Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-28.49_degS_and_115.7564_degE:
     latitude (deg): -28.49
     longitude (deg): 115.7564
     locality: 25 km E of Mullewa toward Pindar on Geraldton - Mt Magnet Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.4906_degS_and_115.7558_degE:
     latitude (deg): -28.4906
     longitude (deg): 115.7558
     locality: 26 km E of Mullewa toward Pindar on Mt Margaret Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.5_degS_and_115.5833_degE:
     latitude (deg): -28.5
     longitude (deg): 115.5833
     locality: 6 miles 9.5 km from Mullewa towards Pindar.
-    collector: Burns, C.A.
+    recorded by: Burns, C.A.
   site_at_-28.5114_degS_and_115.6714_degE:
     latitude (deg): -28.5114
     longitude (deg): 115.6714
     locality: 16 km from Mullewa towards Pindar (from Morawa turnoff), & on opposite
       side of old railway line.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-28.5167_degS_and_152.7333_degE:
     latitude (deg): -28.5167
     longitude (deg): 152.7333
     locality: Richmond Range State Forest, off Buckadon Road, 30 km NW of Kyogle.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-28.5333_degS_and_114.6167_degE:
     latitude (deg): -28.5333
     longitude (deg): 114.6167
     locality: 25 km N of Geraldton.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-28.5333_degS_and_114.6333_degE:
     latitude (deg): -28.5333
     longitude (deg): 114.6333
     locality: 25 km N of Geraldton.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-28.5361_degS_and_141.9547_degE:
     latitude (deg): -28.5361
     longitude (deg): 141.9547
     locality: 133 km S of Nockatunga on road to Tibooburra.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-28.5833_degS_and_153.1_degE:
     latitude (deg): -28.5833
     longitude (deg): 153.1
     locality: Lamington National Park, Green Mountain, vehicular access road to Morans
       Creek near intersection with Red Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-28.5833_degS_and_153.3833_degE:
     latitude (deg): -28.5833
     longitude (deg): 153.3833
     locality: Nightcap Range, Whian Whian State Forest, 0.3 km down North Rock Road
       from Peates Mountain Road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.5917_degS_and_115.4314_degE:
     latitude (deg): -28.5917
     longitude (deg): 115.4314
     locality: 89 km E of Geraldton toward Mullewa.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.6383_degS_and_152.2731_degE:
     latitude (deg): -28.6383
     longitude (deg): 152.2731
     locality: c. 19 km direct E of Liston, c. 26 km along Rivertree Road from Liston
       towards Rivertree, beside road above the upper reaches of the Clarence River.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.6497_degS_and_115.6525_degE:
     latitude (deg): -28.6497
     longitude (deg): 115.6525
     locality: Ca 19 km along Mullewa-Wubin road from Mullewa towards Morowa. (Map
       ref. Sheet 2040 Mullewa Ed.1-AAS)
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.7133_degS_and_115.0172_degE:
     latitude (deg): -28.7133
     longitude (deg): 115.0172
     locality: 46.5 km E of Geraldton on Geraldton Mount Magnet road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.7172_degS_and_114.9989_degE:
     latitude (deg): -28.7172
     longitude (deg): 114.9989
     locality: 45 km E of Geraldton on Geraldton - Mt Magnet road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.7969_degS_and_152.1667_degE:
     latitude (deg): -28.7969
     longitude (deg): 152.1667
     locality: c. 30 km direct NNE of Tenterfield, Boonoo Boonoo N.P. National Park,
       c. 100 m along walking track from the falls viewing platform down towards Boonoo
       Boonoo River.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.7983_degS_and_152.1653_degE:
     latitude (deg): -28.7983
     longitude (deg): 152.1653
     locality: c. 30 km direct NNE of Tenterfield, Boonoo Boonoo National Park, near
       falls viewing platform.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.7992_degS_and_152.1633_degE:
     latitude (deg): -28.7992
     longitude (deg): 152.1633
     locality: Boonoo Boonoo, track to Top Pool at Falls.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28.8_degS_and_141.9167_degE:
     latitude (deg): -28.8
     longitude (deg): 141.9167
     locality: Ca. 22.7 km N of Warri Gate, Tibooburra-Innamincka road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-28.8439_degS_and_152.1517_degE:
     latitude (deg): -28.8439
     longitude (deg): 152.1517
     locality: Boonoo Boonoo river, c. 3 km upstream from falls.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28.85_degS_and_152.0167_degE:
     latitude (deg): -28.85
     longitude (deg): 152.0167
     locality: Paling yard Creek, N of Wallangarra.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.85_degS_and_152.0333_degE:
     latitude (deg): -28.85
     longitude (deg): 152.0333
     locality: Bald Rock, 13 km NE of Wallangarra
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.85_degS_and_152.15_degE:
     latitude (deg): -28.85
     longitude (deg): 152.15
     locality: 7.2 km along the road to Boonoo Boonoo Falls from the Mt Lindsay Highway.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-28.8622_degS_and_151.96_degE:
     latitude (deg): -28.8622
     longitude (deg): 151.96
     locality: Mt Norman, base of vertical cliff 150 m before the Needle.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28.8667_degS_and_151.9667_degE:
     latitude (deg): -28.8667
     longitude (deg): 151.9667
     locality: Mt Norman, 7 km NE of Wallangarra.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-28.8678_degS_and_151.9625_degE:
     latitude (deg): -28.8678
     longitude (deg): 151.9625
     locality: c. 500 m SE downslopes from Mt Norman peak.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28.87_degS_and_151.9642_degE:
     latitude (deg): -28.87
     longitude (deg): 151.9642
     locality: SE slope on track to the Needle, Mt Norman. Darling Downs District.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28.8769_degS_and_151.8839_degE:
     latitude (deg): -28.8769
     longitude (deg): 151.8839
     locality: c. 3 km along New England Highway from Wallangarra towards Stanthorpe.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-28.8833_degS_and_150.15_degE:
     latitude (deg): -28.8833
     longitude (deg): 150.15
     locality: 47 km from Goondiwindi toward Moree, near Tackinbri Camp.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-28.9_degS_and_149.0833_degE:
     latitude (deg): -28.9
     longitude (deg): 149.0833
     locality: Nearby Barwon River, c. 10 km upstream from Mungindi.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-28.9025_degS_and_152.5981_degE:
     latitude (deg): -28.9025
     longitude (deg): 152.5981
     locality: Casino, 52km west of, at junction of Bruxner Highway and road to Grafton.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-28.9044_degS_and_115.8328_degE:
     latitude (deg): -28.9044
     longitude (deg): 115.8328
     locality: 43 km N of Morowa towards Mullewa, on Mullewa - Wubin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-28.9667_degS_and_152.0811_degE:
     latitude (deg): -28.9667
     longitude (deg): 152.0811
     locality: Great Dividing Range, 12.5 km from Tenterfield along Mt Lindsay Highway.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-28_degS_and_152.6_degE:
     latitude (deg): -28.0
     longitude (deg): 152.6
     locality: Mt French, 0.8 km towards town from intersection on Kent Pocket Road,
       Boonah.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-29.0036_degS_and_167.9433_degE:
     latitude (deg): -29.0036
     longitude (deg): 167.9433
     locality: CULTIVATED Norfolk Island National Park; Captain Cook Reserve, carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0072_degS_and_167.9406_degE:
     latitude (deg): -29.0072
     longitude (deg): 167.9406
     locality: Norfolk Island National Park; Cooks Point road, 1 km from cattle grate
       entrance.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0125_degS_and_167.9425_degE:
     latitude (deg): -29.0125
     longitude (deg): 167.9425
     locality: Norfolk Island National Park; Mount Bates Track, c. 100 m from junction
       with Mount Pitt Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0131_degS_and_167.9231_degE:
     latitude (deg): -29.0131
     longitude (deg): 167.9231
     locality: Anson Bay beach track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0131_degS_and_167.9392_degE:
     latitude (deg): -29.0131
     longitude (deg): 167.9392
     locality: Norfolk Island National Park; Summit Track, E of Mount Pitt.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-29.0142_degS_and_167.9456_degE:
     latitude (deg): -29.0142
     longitude (deg): 167.9456
     locality: Norfolk Island National Park; start of Palm Glen loop track.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-29.0153_degS_and_167.9369_degE:
     latitude (deg): -29.0153
     longitude (deg): 167.9369
     locality: Norfolk Island National Park; Mount Pitt Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0158_degS_and_167.9369_degE:
     latitude (deg): -29.0158
     longitude (deg): 167.9369
     locality: Norfolk Island National Park; Mount Pitt lookout.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0161_degS_and_167.9386_degE:
     latitude (deg): -29.0161
     longitude (deg): 167.9386
     locality: Mt. Bates track. Norfolk Island National Park.
-    collector: Sattler, G.
+    recorded by: Sattler, G.
   site_at_-29.0167_degS_and_141.9667_degE:
     latitude (deg): -29.0167
     longitude (deg): 141.9667
     locality: 4 km E of Tibooburra-Naryilco road, beside Queensland-New South Wales
       border fence.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-29.0244_degS_and_167.9275_degE:
     latitude (deg): -29.0244
     longitude (deg): 167.9275
     locality: CULTIVATED Norfolk Island National Park; nursery.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0258_degS_and_167.9411_degE:
     latitude (deg): -29.0258
     longitude (deg): 167.9411
     locality: CULTIVATED Norfolk Island Botanic Gardens.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0333_degS_and_167.95_degE:
     latitude (deg): -29.0333
     longitude (deg): 167.95
     locality: PHILIP ISLAND South Pacific, near Norfolk Island.
-    collector: Boden, R.W.
+    recorded by: Boden, R.W.
   site_at_-29.0497_degS_and_167.9697_degE:
     latitude (deg): -29.0497
     longitude (deg): 167.9697
     locality: CULTIVATED Norfolk Island; private property of Duncan Sanderson.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-29.0531_degS_and_167.9706_degE:
     latitude (deg): -29.0531
     longitude (deg): 167.9706
     locality: Duncan Sandersons property, Rooty Hill Road; lowest gully on the farm.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.0878_degS_and_141.2136_degE:
     latitude (deg): -29.0878
     longitude (deg): 141.2136
     locality: Fort Grey Camping Ground. Sturt National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-29.1194_degS_and_167.9464_degE:
     latitude (deg): -29.1194
     longitude (deg): 167.9464
     locality: Norfolk Island National Park; Phillip Island, W end.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.1219_degS_and_167.9508_degE:
     latitude (deg): -29.1219
     longitude (deg): 167.9508
     locality: Norfolk Island National Park; Phillip Island; 20 m E of Summit track,
       400 m from Parks Hut.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.125_degS_and_167.9494_degE:
     latitude (deg): -29.125
     longitude (deg): 167.9494
     locality: Norfolk Island National Park; Phillip Island; Red Stone Peak.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-29.1667_degS_and_152.7667_degE:
     latitude (deg): -29.1667
     longitude (deg): 152.7667
     locality: c. 35 km (direct) SW of Casino, Mt Belmore State Forest (SF 361), c.
       4 km SSW along Bennetts Road from Wyan Creek homestead.
-    collector: Makinson, R.O.
+    recorded by: Makinson, R.O.
   site_at_-29.1833_degS_and_151.9833_degE:
     latitude (deg): -29.1833
     longitude (deg): 151.9833
     locality: Bluff Rock, 37.5 km from Deepwater.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-29.2014_degS_and_151.5392_degE:
     latitude (deg): -29.2014
     longitude (deg): 151.5392
     locality: Torrington National Park, roadside, base of Jonquill Hill on south side.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-29.21_degS_and_115.1989_degE:
     latitude (deg): -29.21
     longitude (deg): 115.1989
     locality: 28.6 km W along the Midlands Road from Dongara.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.2175_degS_and_152.6717_degE:
     latitude (deg): -29.2175
     longitude (deg): 152.6717
     locality: Mt Neville, N side, Richmond Range, 19 km WNW of Whiporie on Casino
       Road.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-29.2306_degS_and_151.69_degE:
     latitude (deg): -29.2306
     longitude (deg): 151.69
     locality: Torrington National Park, 5.3 km from base of Jonquil HIll, main road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-29.2581_degS_and_146.3081_degE:
     latitude (deg): -29.2581
     longitude (deg): 146.3081
     locality: Wilganea, 10 km towards Jobs Gate along Nulty Springs Road. 85 km NE
       of Bourke.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.2736_degS_and_117.6708_degE:
     latitude (deg): -29.2736
     longitude (deg): 117.6708
     locality: 1.3 km SW of Paynes Find toward Wubin on Great Northern Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.2833_degS_and_117.6453_degE:
     latitude (deg): -29.2833
     longitude (deg): 117.6453
     locality: 4.4 km SW of Paynes Find towards Wubin, on Great Northern Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.2833_degS_and_146.31_degE:
     latitude (deg): -29.2833
     longitude (deg): 146.31
     locality: Wilganea, 3.7 km towards Jobs Gate along Nulty Springs Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.3_degS_and_142.0333_degE:
     latitude (deg): -29.3
     longitude (deg): 142.0333
     locality: c. 17.4 km N of Tibooburra on road to Warri Gate.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-29.3019_degS_and_151.6497_degE:
     latitude (deg): -29.3019
     longitude (deg): 151.6497
     locality: At the turnoff to Mystery Face, Torrington National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-29.3117_degS_and_146.15_degE:
     latitude (deg): -29.3117
     longitude (deg): 146.15
     locality: Beulah claypan, Lednapper Crossing area, NE of Bourke.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.32_degS_and_151.6667_degE:
     latitude (deg): -29.32
     longitude (deg): 151.6667
     locality: Torrington Recreation Area, West Town Fire Trail.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-29.3222_degS_and_117.3469_degE:
     latitude (deg): -29.3222
     longitude (deg): 117.3469
     locality: 35 km SW of Paynes Find toward Wubin on Great Northern Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.3333_degS_and_151.8833_degE:
     latitude (deg): -29.3333
     longitude (deg): 151.8833
     locality: c. 16 km from Deepwater along road to Tenterfield, c. 1.5 km NE of Little
       Bolivia Hill, c. 400 m W of road.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-29.3333_degS_and_153_degE:
     latitude (deg): -29.3333
     longitude (deg): 153.0
     locality: 40 km N of Grafton on Grafton-Casino road.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-29.3417_degS_and_115.8467_degE:
     latitude (deg): -29.3417
     longitude (deg): 115.8467
     locality: 26km E of Arrino towards Morawa.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-29.35_degS_and_151.9167_degE:
     latitude (deg): -29.35
     longitude (deg): 151.9167
     locality: Bolivia Mountain, N Side, beside road.
-    collector: Murray, L.
+    recorded by: Murray, L.
   site_at_-29.35_degS_and_152.0667_degE:
     latitude (deg): -29.35
     longitude (deg): 152.0667
     locality: Mt Spirabo State Forest 529
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.355_degS_and_151.9_degE:
     latitude (deg): -29.355
     longitude (deg): 151.9
     locality: Bolivia Hill Nature Reserve, 2 km SE of Bolivia Hill.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-29.3667_degS_and_117.8167_degE:
     latitude (deg): -29.3667
     longitude (deg): 117.8167
     locality: 1 km N of Maranalgo Homestead on Maroubra Road, towards Paynes Find.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-29.3667_degS_and_146.1333_degE:
     latitude (deg): -29.3667
     longitude (deg): 146.1333
     locality: 2.1 km from Beulah entrance along access road towards Lednapper Crossing
       Road.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.3831_degS_and_146.1494_degE:
     latitude (deg): -29.3831
     longitude (deg): 146.1494
     locality: Lednapper Nature Reserve, Beulah gate. 90 km ENE of Bourke.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.4047_degS_and_142.0275_degE:
     latitude (deg): -29.4047
     longitude (deg): 142.0275
     locality: 2.5 km N of the Dead Horse Gully on the Silver City Highway. Sturt National
       Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-29.4169_degS_and_146.1531_degE:
     latitude (deg): -29.4169
     longitude (deg): 146.1531
     locality: 6.7 km from Beulah homestead on access track, towards Lednapper Crossing
       Road.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.4333_degS_and_141.8333_degE:
     latitude (deg): -29.4333
     longitude (deg): 141.8333
     locality: 9.9 km from Silver City Highway, near Camerons Corner-Tibooburra road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-29.4333_degS_and_142.0167_degE:
     latitude (deg): -29.4333
     longitude (deg): 142.0167
     locality: Tibooburra, 400 m N of Pub.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.4333_degS_and_142.145_degE:
     latitude (deg): -29.4333
     longitude (deg): 142.145
     locality: Tibooburra airport.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.4333_degS_and_146.1186_degE:
     latitude (deg): -29.4333
     longitude (deg): 146.1186
     locality: Lednapper Crossing Road, 1 km from Enngonia turnoff, towards Bourke.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.4417_degS_and_151.35_degE:
     latitude (deg): -29.4417
     longitude (deg): 151.35
     locality: Severn River Nature Reserve, 7.5 km W of Pindari Dam Wall, through access
       road on Claytons Chase.
-    collector: Paul, J.
+    recorded by: Paul, J.
   site_at_-29.45_degS_and_124.8_degE:
     latitude (deg): -29.45
     longitude (deg): 124.8
     locality: c. 35 km W of Plumridge Lakes, 8.5 km WNW of Salt Creek airstrip.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-29.45_degS_and_141.8833_degE:
     latitude (deg): -29.45
     longitude (deg): 141.8833
     locality: 7.4 km from Silver City Highway, Camerons Corner - Tibooburra road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-29.4653_degS_and_152.8528_degE:
     latitude (deg): -29.4653
     longitude (deg): 152.8528
     locality: Grafton to Coledale Road, 14.4 km N of Coledale turnoff, 35 km to Whiteman
       Creek Bridge.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-29.4833_degS_and_152.3167_degE:
     latitude (deg): -29.4833
     longitude (deg): 152.3167
     locality: Gibraltar Range National Park, The Granites picnic area, 2.0 km ENE
       of Waratah Trig.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-29.5103_degS_and_153.3594_degE:
     latitude (deg): -29.5103
     longitude (deg): 153.3594
     locality: Angourie, along walking track to Shelleys Beach at edge of Bold Knob,
       150 m from Shelleys Beach.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-29.5164_degS_and_152.3578_degE:
     latitude (deg): -29.5164
     longitude (deg): 152.3578
     locality: c. 65 km direct ENE of Glen Innes, Gibraltar Range National Park, along
       walking track c. 500 m direct NW of Mulligans Hut.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-29.5167_degS_and_153.35_degE:
     latitude (deg): -29.5167
     longitude (deg): 153.35
     locality: c. 2 km S of Angourie.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-29.5419_degS_and_152.2675_degE:
     latitude (deg): -29.5419
     longitude (deg): 152.2675
     locality: Gibraltar Range National Park, Tin Ore Creek.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-29.5508_degS_and_116.8325_degE:
     latitude (deg): -29.5508
     longitude (deg): 116.8325
     locality: km along Wanarra east Road from Mount Gibson towards Perenjori.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-29.5581_degS_and_146.0869_degE:
     latitude (deg): -29.5581
     longitude (deg): 146.0869
     locality: Lednapper Crossing - 4.2 km SW towards Mitchell Highway along Nulty
       Springs Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.5667_degS_and_124.8333_degE:
     latitude (deg): -29.5667
     longitude (deg): 124.8333
     locality: c.  35 km W of Plumridge Lakes, 8.5 km WNW of Salt Creek airstrip.
-    collector: Taylor, J.; Crisp, M.D.; Jackson, R.
+    recorded by: Taylor, J.; Crisp, M.D.; Jackson, R.
   site_at_-29.5667_degS_and_124.8667_degE:
     latitude (deg): -29.5667
     longitude (deg): 124.8667
     locality: C. 35 km W of Plumridge Lakes, 4 km NW of Salt Creek airstrip.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-29.5772_degS_and_117.1589_degE:
     latitude (deg): -29.5772
     longitude (deg): 117.1589
     locality: Mt Gibson area on NW side of Mt Gibson Range.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.5819_degS_and_151.3861_degE:
     latitude (deg): -29.5819
     longitude (deg): 151.3861
     locality: Kings Plains National Park, Kings Plain Creek, adjacent to carpark.
-    collector: Paul, J.
+    recorded by: Paul, J.
   site_at_-29.5861_degS_and_151.3872_degE:
     latitude (deg): -29.5861
     longitude (deg): 151.3872
     locality: Kings Plains National Park, Kings Plain Creek, adjacent to carpark.
-    collector: Paul, J.
+    recorded by: Paul, J.
   site_at_-29.6167_degS_and_121.1333_degE:
     latitude (deg): -29.6167
     longitude (deg): 121.1333
     locality: WA goldfields district, 7.8 km N of Menzies, both sides of road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-29.6167_degS_and_152.4833_degE:
     latitude (deg): -29.6167
     longitude (deg): 152.4833
     locality: Cangai State Forest.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.65_degS_and_125.1_degE:
     latitude (deg): -29.65
     longitude (deg): 125.1
     locality: 12 km WNW along track from S end of Plumridge Lakes.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-29.6667_degS_and_115.2333_degE:
     latitude (deg): -29.6667
     longitude (deg): 115.2333
     locality: 18.7 km N of Eneabba, beside Brand Highway.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-29.6833_degS_and_152.9667_degE:
     latitude (deg): -29.6833
     longitude (deg): 152.9667
     locality: without locality
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.72_degS_and_145.9947_degE:
     latitude (deg): -29.72
     longitude (deg): 145.9947
     locality: Lednapper Crossing Road, 4.8 km NE of Mitchell Highway between Bourke
       and Enngonia.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.7667_degS_and_121.05_degE:
     latitude (deg): -29.7667
     longitude (deg): 121.05
     locality: 5 miles 8 km from Menzies towards Kalgoorlie.
-    collector: Phillips, M.E.
+    recorded by: Phillips, M.E.
   site_at_-29.7833_degS_and_115.2667_degE:
     latitude (deg): -29.7833
     longitude (deg): 115.2667
     locality: Beside Brand Highway, 3.9 km N of Eneabba.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-29.7922_degS_and_141.9167_degE:
     latitude (deg): -29.7922
     longitude (deg): 141.9167
     locality: 23 km S of Milparinka turnoff, on Silvercity Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-29.8_degS_and_115.8472_degE:
     latitude (deg): -29.8
     longitude (deg): 115.8472
     locality: Yarra Yarra Lakes, 0.5 km S of intersection of Winchester Road and Winchester
       South Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.8167_degS_and_153.25_degE:
     latitude (deg): -29.8167
     longitude (deg): 153.25
     locality: 1km east of junction of Wooli/Diggers Camp Rd, on Diggers Camp Road.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-29.8167_degS_and_153.2667_degE:
     latitude (deg): -29.8167
     longitude (deg): 153.2667
     locality: 1.5 km W of Bare Point (Diggers Headland).
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-29.8306_degS_and_115.2564_degE:
     latitude (deg): -29.8306
     longitude (deg): 115.2564
     locality: 200 m S of Lake Indoon turnoff, Brand Highway, 2.8 km S of Eneabba.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.8411_degS_and_115.2578_degE:
     latitude (deg): -29.8411
     longitude (deg): 115.2578
     locality: 1.8 km S of Eneabba turn off on Brand Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.875_degS_and_152.1228_degE:
     latitude (deg): -29.875
     longitude (deg): 152.1228
     locality: c. 20 km direct NNE of Tenterfield, c. 2.7km along road to Boonoo Boonoo
       National Park  from the Mount Lindsay Highway, at Swamp Creek, c. 100m upstream.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-29.9083_degS_and_153.0667_degE:
     latitude (deg): -29.9083
     longitude (deg): 153.0667
     locality: Wells Crossing, 2 km N. of Halfway Ck. on the Pacific Highway. (N. side
       of bridge).
-    collector: Pryor, L.D.
+    recorded by: Pryor, L.D.
   site_at_-29.9133_degS_and_116.1008_degE:
     latitude (deg): -29.9133
     longitude (deg): 116.1008
     locality: Intersection of Jones and South Wadi Roads, 18 km SE of Coorow. Point
       plots c. 9 km by road ~SE of Coorow.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-29.9458_degS_and_151.0306_degE:
     latitude (deg): -29.9458
     longitude (deg): 151.0306
     locality: Howell, 20 km SSW of Inverell, 300 m N of Howell Dam.
-    collector: Copeland, L.M.
+    recorded by: Copeland, L.M.
   site_at_-29.9481_degS_and_116.2783_degE:
     latitude (deg): -29.9481
     longitude (deg): 116.2783
     locality: E block of Koobabbie Farm.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-29.9489_degS_and_116.1733_degE:
     latitude (deg): -29.9489
     longitude (deg): 116.1733
     locality: On the N side of Koobabbie Lake on Koobabbie Farm via Coorow.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-29.9494_degS_and_116.2861_degE:
     latitude (deg): -29.9494
     longitude (deg): 116.2861
     locality: Koolbabbie Farm. East block NE corner. NE of Marchagee.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-29.95_degS_and_115.7333_degE:
     latitude (deg): -29.95
     longitude (deg): 115.7333
     locality: c. 3 km S of Launer Road on Brand Mudge Road, Coorow Shire.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-29.95_degS_and_116.0667_degE:
     latitude (deg): -29.95
     longitude (deg): 116.0667
     locality: 9 km from Coorow along road to Marchagee.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-29.95_degS_and_153.25_degE:
     latitude (deg): -29.95
     longitude (deg): 153.25
     locality: 40 km N of Coffs Harbour, 3 km NE along Station Creek Reserve Road from
       Pacific Highway/Yuragir National National Park turnoff.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-29.9667_degS_and_115.4_degE:
     latitude (deg): -29.9667
     longitude (deg): 115.4
     locality: Beside Brand Highway, 34.4 km N of junction with Coomallo-Marchagee
       road, c. 18 km S of Eneabba.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-29.9753_degS_and_117.6739_degE:
     latitude (deg): -29.9753
     longitude (deg): 117.6739
     locality: 57 km N of Cleary towards Paynes Find on Maroubra Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.0222_degS_and_151.3667_degE:
     latitude (deg): -30.0222
     longitude (deg): 151.3667
     locality: Single National Park, road between Guyra and Tingha.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-30.0333_degS_and_116.75_degE:
     latitude (deg): -30.0333
     longitude (deg): 116.75
     locality: 15 km NE of Wubin.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-30.05_degS_and_150.1_degE:
     latitude (deg): -30.05
     longitude (deg): 150.1
     locality: Mt Kaputar National Park. Waa Gorge, 300 m on walking track above car
       park. Plants above pools.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-30.0633_degS_and_138.1114_degE:
     latitude (deg): -30.0633
     longitude (deg): 138.1114
     locality: Witchelina - Farina road, below Balowopina Creek crossing.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-30.0831_degS_and_151.9306_degE:
     latitude (deg): -30.0831
     longitude (deg): 151.9306
     locality: c. 29 km direct NE of Guyra, 5.7 km E along Paddys Gully Road from its
       intersection with Backwater Road.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.0833_degS_and_152.65_degE:
     latitude (deg): -30.0833
     longitude (deg): 152.65
     locality: Clouds Creek, Armidale
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.1042_degS_and_115.1208_degE:
     latitude (deg): -30.1042
     longitude (deg): 115.1208
     locality: Green Head, 19.2 km N along Cockleshell Gully Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.1167_degS_and_115.9333_degE:
     latitude (deg): -30.1167
     longitude (deg): 115.9333
     locality: 6.7 km W of E end of Coomallo-Marchagee road.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-30.1167_degS_and_138.5833_degE:
     latitude (deg): -30.1167
     longitude (deg): 138.5833
     locality: Mount Lyndhurst, 35 km NE of Lyndhurst, Northern Flinders Ranges.
-    collector: Sikkes, A.J.A.
+    recorded by: Sikkes, A.J.A.
   site_at_-30.1333_degS_and_150.0833_degE:
     latitude (deg): -30.1333
     longitude (deg): 150.0833
     locality: Nandewar Range, Mount Kaputar National Park, Sawn Rocks.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-30.1428_degS_and_117.6436_degE:
     latitude (deg): -30.1428
     longitude (deg): 117.6436
     locality: 36.2 km N of Cleary towards Paynes Find on Maroubra Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.1481_degS_and_115.3858_degE:
     latitude (deg): -30.1481
     longitude (deg): 115.3858
     locality: 2.1 km along Tootbardie Road, where gas pipeline and high voltage lines
       cross road (off Brand Highway).
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.1497_degS_and_115.3944_degE:
     latitude (deg): -30.1497
     longitude (deg): 115.3944
     locality: 2.8 km along Tootbardie Rd Road from Brand Highway, N of Badgingarra.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.15_degS_and_142.1_degE:
     latitude (deg): -30.15
     longitude (deg): 142.1
     locality: 62.3 km S of Milparinka turnoff, on Silver City Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-30.1564_degS_and_115.3792_degE:
     latitude (deg): -30.1564
     longitude (deg): 115.3792
     locality: 32.2km North of Badgingarra on Brand Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.1667_degS_and_115.7167_degE:
     latitude (deg): -30.1667
     longitude (deg): 115.7167
     locality: W of E end of Coomallo-Marchagee road.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-30.1667_degS_and_152.5_degE:
     latitude (deg): -30.1667
     longitude (deg): 152.5
     locality: Mt Hyland Flora Reserve.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-30.1833_degS_and_115.6667_degE:
     latitude (deg): -30.1833
     longitude (deg): 115.6667
     locality: 34.3 km W of E end of Coomallo-Marchagee road.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-30.1914_degS_and_146.2442_degE:
     latitude (deg): -30.1914
     longitude (deg): 146.2442
     locality: Mt Oxley, on access road off Bourke - Brewarrina road.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-30.1958_degS_and_153.1389_degE:
     latitude (deg): -30.1958
     longitude (deg): 153.1389
     locality: without locality
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.1986_degS_and_152.7875_degE:
     latitude (deg): -30.1986
     longitude (deg): 152.7875
     locality: eastern Dorrigo.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-30.2128_degS_and_153.1636_degE:
     latitude (deg): -30.2128
     longitude (deg): 153.1636
     locality: N of Coffs Harbour, Mooney Ponds Caravan Park, headland 500 m SE of
       inlet.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-30.2333_degS_and_152.5_degE:
     latitude (deg): -30.2333
     longitude (deg): 152.5
     locality: Ellis State Forest, 76 km from Grafton towards Armidale.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-30.2667_degS_and_150.15_degE:
     latitude (deg): -30.2667
     longitude (deg): 150.15
     locality: At West Kaputar Rock Lookout, on the way to Dawson Springs.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-30.2747_degS_and_150.1175_degE:
     latitude (deg): -30.2747
     longitude (deg): 150.1175
     locality: 5 km direct W of Mt Kaputar on south side of Narrabri.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-30.2833_degS_and_115.0833_degE:
     latitude (deg): -30.2833
     longitude (deg): 115.0833
     locality: 5.3 km E of Jurien.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-30.2833_degS_and_139.3833_degE:
     latitude (deg): -30.2833
     longitude (deg): 139.3833
     locality: Arkaroola hills, 500 m along Echo Creek Backtrack from Barraranna Gorge
       turnoff.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-30.2833_degS_and_150.1333_degE:
     latitude (deg): -30.2833
     longitude (deg): 150.1333
     locality: Mt Kaputar National Park. Walking track near The Governor.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-30.2886_degS_and_116.0961_degE:
     latitude (deg): -30.2886
     longitude (deg): 116.0961
     locality: 3.7km on Old Geraldton Road, from Merewara Road, E of Watheroo on Miling
       road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-30.2886_degS_and_116.0969_degE:
     latitude (deg): -30.2886
     longitude (deg): 116.0969
     locality: Watheroo, 3.7 km W along Old Geraldton Road from Merewana Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.3_degS_and_150.15_degE:
     latitude (deg): -30.3
     longitude (deg): 150.15
     locality: Mt Kaputar National Park, Nandewar Range, c. 2.5 km direct SW of Mt
       Kaputar at Doug Sky Lookout.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.3_degS_and_152.6833_degE:
     latitude (deg): -30.3
     longitude (deg): 152.6833
     locality: without locality
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.3111_degS_and_153.0958_degE:
     latitude (deg): -30.3111
     longitude (deg): 153.0958
     locality: without locality
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.3167_degS_and_152.8667_degE:
     latitude (deg): -30.3167
     longitude (deg): 152.8667
     locality: Dorrigo Plateau, Mt Moombil, c. 100 m SE of summit.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-30.3167_degS_and_153.1_degE:
     latitude (deg): -30.3167
     longitude (deg): 153.1
     locality: Boambee, property of A.Floyd.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-30.3333_degS_and_151.6833_degE:
     latitude (deg): -30.3333
     longitude (deg): 151.6833
     locality: N of Armidale, approaching Chanders Pass on North England Highway.
-    collector: Phillips, M.E.
+    recorded by: Phillips, M.E.
   site_at_-30.3417_degS_and_139.3375_degE:
     latitude (deg): -30.3417
     longitude (deg): 139.3375
     locality: N of Mount Warren Hastings along the Oppaminda Trail.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-30.3744_degS_and_117.6556_degE:
     latitude (deg): -30.3744
     longitude (deg): 117.6556
     locality: 8.7 km N of Cleary towards Paynes Find on Maroubra Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.3808_degS_and_117.6511_degE:
     latitude (deg): -30.3808
     longitude (deg): 117.6511
     locality: 7.3 km N of Cleary towards Paynes Find on Maroubra Road adjacent to
       water tank.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.3917_degS_and_136.8833_degE:
     latitude (deg): -30.3917
     longitude (deg): 136.8833
     locality: 8km NE of Roxby Downs township, 7km NE of intersection of Olympic Way
       on Borefield Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.4167_degS_and_121.3333_degE:
     latitude (deg): -30.4167
     longitude (deg): 121.3333
     locality: WA goldfields district, 64.5 km S of Menzies on road to Kalgoorlie,
       E side of road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.4167_degS_and_152.4833_degE:
     latitude (deg): -30.4167
     longitude (deg): 152.4833
     locality: Barrier Mountain, 12 km E of Ebor.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.4167_degS_and_153.0333_degE:
     latitude (deg): -30.4167
     longitude (deg): 153.0333
     locality: S of Sawtell, 1 km NNE of Tuckers Rocks.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-30.4189_degS_and_150.8853_degE:
     latitude (deg): -30.4189
     longitude (deg): 150.8853
     locality: c. 25 km direct E of Barraba, upper reaches of Nangahrah Creek on Linton
       North station.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.4333_degS_and_152.6667_degE:
     latitude (deg): -30.4333
     longitude (deg): 152.6667
     locality: 14.7 km from road junction at Thora along Upper Thora Rd. at Richardsons
       Crossing.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-30.4431_degS_and_152.3014_degE:
     latitude (deg): -30.4431
     longitude (deg): 152.3014
     locality: c. 6 km direct SW of Ebor, Cathedral Rock National Park, c. 1km along
       the road into the park from the Armidale to Dorrigo road. Besides road.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.4453_degS_and_139.2969_degE:
     latitude (deg): -30.4453
     longitude (deg): 139.2969
     locality: Vulkathunha - Gammon Ranges National Park, along road to Grindells Hut,
       0.5 km from park boundary.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-30.45_degS_and_142.2667_degE:
     latitude (deg): -30.45
     longitude (deg): 142.2667
     locality: Ca 17 km SE of Cobham and c. 32 km NE of Packsaddle, N extremity of
       Koonenberry Range.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-30.4667_degS_and_117.45_degE:
     latitude (deg): -30.4667
     longitude (deg): 117.45
     locality: 17 km E of Kulja and 40 km W of Beacon.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-30.4667_degS_and_131.9333_degE:
     latitude (deg): -30.4667
     longitude (deg): 131.9333
     locality: 8 km E of Ooldea, along Trans-Australian Railway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.4833_degS_and_152.4167_degE:
     latitude (deg): -30.4833
     longitude (deg): 152.4167
     locality: New England National Park, Point Lookout.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-30.4853_degS_and_152.4086_degE:
     latitude (deg): -30.4853
     longitude (deg): 152.4086
     locality: New England National Park, on large outcropping rock besides walking
       track from the carpark to Point Lookout.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.4969_degS_and_115.4556_degE:
     latitude (deg): -30.4969
     longitude (deg): 115.4556
     locality: Tip, 3 km W along Bibby Road, from Brand Highway towards Cervantes.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.5_degS_and_149.65_degE:
     latitude (deg): -30.5
     longitude (deg): 149.65
     locality: Plumbs Well, 29 km SW of Narrabri.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.5_degS_and_152.4_degE:
     latitude (deg): -30.5
     longitude (deg): 152.4
     locality: New England National Park, track to Wrights Lookout, c. 2 km SW of Point
       Lookout.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-30.5167_degS_and_117.4167_degE:
     latitude (deg): -30.5167
     longitude (deg): 117.4167
     locality: 35 km N of Koorda, 5.5 km S of Jingymia.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-30.5189_degS_and_138.7375_degE:
     latitude (deg): -30.5189
     longitude (deg): 138.7375
     locality: Angepena - Copley road, about 7 km E of turnoff to Depot Springs homestead.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-30.5306_degS_and_139.3058_degE:
     latitude (deg): -30.5306
     longitude (deg): 139.3058
     locality: Vulkathunha-Gammon Ranges National Park, between park headquarters and
       park boundary along Innnamincka road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-30.5364_degS_and_151.1822_degE:
     latitude (deg): -30.5364
     longitude (deg): 151.1822
     locality: Roadside. 8 km along the road from Kingstown to Uralla.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   site_at_-30.5367_degS_and_151.1786_degE:
     latitude (deg): -30.5367
     longitude (deg): 151.1786
     locality: c. 8 km along the road from Kingstown towards Uralla, beside road.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.5383_degS_and_138.5706_degE:
     latitude (deg): -30.5383
     longitude (deg): 138.5706
     locality: Balcanoona - Copley road, about 12 km W of turnoff to Depot Springs
       homestead.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-30.55_degS_and_121.4333_degE:
     latitude (deg): -30.55
     longitude (deg): 121.4333
     locality: 22.3 km N of Kalgoorlie, 16.6 km SE of Broad Arrow.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-30.55_degS_and_152.25_degE:
     latitude (deg): -30.55
     longitude (deg): 152.25
     locality: Styx River State Forest near Raspberry Mountain, Compartment 62 (NSW
       Forestry Commission).
-    collector: Seedstore
+    recorded by: Seedstore
   site_at_-30.5597_degS_and_130.8886_degE:
     latitude (deg): -30.5597
     longitude (deg): 130.8886
     locality: 25 km E of Cook along Trans-Australian Railway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.5667_degS_and_139.2333_degE:
     latitude (deg): -30.5667
     longitude (deg): 139.2333
     locality: Italowie Creek, 13 km NW of Wertaloona homestead.
-    collector: Sikkes, A.J.A.
+    recorded by: Sikkes, A.J.A.
   site_at_-30.5683_degS_and_145.8006_degE:
     latitude (deg): -30.5683
     longitude (deg): 145.8006
     locality: Gundabooka National Park, 6.5 km from park access road towards Mulgowan
       art site.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-30.5706_degS_and_145.7_degE:
     latitude (deg): -30.5706
     longitude (deg): 145.7
     locality: Gundabooka National Park, Ben Lomond Gorge.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-30.5881_degS_and_116.4858_degE:
     latitude (deg): -30.5881
     longitude (deg): 116.4858
     locality: 14 km from Bindi Bindi toward Ballidu, on Ballidu - Bindi Bindi Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.5917_degS_and_145.8925_degE:
     latitude (deg): -30.5917
     longitude (deg): 145.8925
     locality: 103 km from Cobar on road to Bourke.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-30.6058_degS_and_116.7544_degE:
     latitude (deg): -30.6058
     longitude (deg): 116.7544
     locality: Ballidu, 500 m towards Wongan Hills.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.6058_degS_and_116.7708_degE:
     latitude (deg): -30.6058
     longitude (deg): 116.7708
     locality: In road verge directly opposite Ballidu Recreation Centre, 500m S of
       Ballidu turnoff on road between Ballidu and Wongan Hills. Wongan 1100K map sheet.
-    collector: Monro, A.M.
+    recorded by: Monro, A.M.
   site_at_-30.66_degS_and_134.0489_degE:
     latitude (deg): -30.66
     longitude (deg): 134.0489
     locality: 3 km E of dog fence between Tarcoola & Wynbring, on Trans Australian
       Railway track.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.6764_degS_and_151.7269_degE:
     latitude (deg): -30.6764
     longitude (deg): 151.7269
     locality: c.19 km direct SSE of Armidale, Oxley Wild Rivers National Park, Dangars
       Falls, just above the top of the falls.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-30.7_degS_and_149.15_degE:
     latitude (deg): -30.7
     longitude (deg): 149.15
     locality: Pilliga Scrub, 16 km. N.E. of Kenebri.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.7006_degS_and_115.4919_degE:
     latitude (deg): -30.7006
     longitude (deg): 115.4919
     locality: 86.5 km N of Gingin on Brand Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.7667_degS_and_149.4833_degE:
     latitude (deg): -30.7667
     longitude (deg): 149.4833
     locality: 61 km from Coonabarabran on Narrabri road.
-    collector: Striemann, H.
+    recorded by: Striemann, H.
   site_at_-30.7711_degS_and_115.5644_degE:
     latitude (deg): -30.7711
     longitude (deg): 115.5644
     locality: 75.5 km N of Gingin on Brand Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.8_degS_and_149.75_degE:
     latitude (deg): -30.8
     longitude (deg): 149.75
     locality: Willala Hills, 55 km S of Narrabri.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.8167_degS_and_117.85_degE:
     latitude (deg): -30.8167
     longitude (deg): 117.85
     locality: 2 km N of Bencubbin.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-30.8167_degS_and_149.4667_degE:
     latitude (deg): -30.8167
     longitude (deg): 149.4667
     locality: 56 km from Coonabarabran on Narrabri Rd.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.8333_degS_and_116.6333_degE:
     latitude (deg): -30.8333
     longitude (deg): 116.6333
     locality: 25 km from Piawaning along road to Wongan Hills town, 1 km S of road.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-30.8333_degS_and_117.25_degE:
     latitude (deg): -30.8333
     longitude (deg): 117.25
     locality: 24 km W of Koorda on the Wongan Hills road.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-30.8333_degS_and_142.4667_degE:
     latitude (deg): -30.8333
     longitude (deg): 142.4667
     locality: 51 km towards White Cliffs from Mootwingee turnoff, 1 km off to right
       of road.
-    collector: Tyrrel, A.
+    recorded by: Tyrrel, A.
   site_at_-30.8333_degS_and_149.4667_degE:
     latitude (deg): -30.8333
     longitude (deg): 149.4667
     locality: 56 km from Coonabarabran on Narrabri Road.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.8336_degS_and_115.5967_degE:
     latitude (deg): -30.8336
     longitude (deg): 115.5967
     locality: 67.8 km N of Gingin on Brand Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.8378_degS_and_116.6378_degE:
     latitude (deg): -30.8378
     longitude (deg): 116.6378
     locality: Mount OBrien lookout.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.8383_degS_and_116.6561_degE:
     latitude (deg): -30.8383
     longitude (deg): 116.6561
     locality: Wongan Valley Hills foothills.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.8433_degS_and_121.1497_degE:
     latitude (deg): -30.8433
     longitude (deg): 121.1497
     locality: Bonnie Vale Railway Station, 15 km N of Coolgardie.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.8486_degS_and_152.1794_degE:
     latitude (deg): -30.8486
     longitude (deg): 152.1794
     locality: Oxley Wild Rivers National Park; Carrai Creek.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-30.8556_degS_and_116.7222_degE:
     latitude (deg): -30.8556
     longitude (deg): 116.7222
     locality: 5.4 km N of Wongan Hills at nature reserve.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.8558_degS_and_135.0058_degE:
     latitude (deg): -30.8558
     longitude (deg): 135.0058
     locality: 49.6 km E of Tarcoola towards Kingoonya on Kingoonya Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.8581_degS_and_120.735_degE:
     latitude (deg): -30.8581
     longitude (deg): 120.735
     locality: 9.4 km W of Stewart on West Rail line towards Koolyanobbing.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.8667_degS_and_116.9758_degE:
     latitude (deg): -30.8667
     longitude (deg): 116.9758
     locality: Dingo Rock, 9.5 km W of Manmanning on Wongan Hills - Manmanning Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.8733_degS_and_118.0761_degE:
     latitude (deg): -30.8733
     longitude (deg): 118.0761
     locality: 15 km W of Mukinbudin.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30.8767_degS_and_120.5636_degE:
     latitude (deg): -30.8767
     longitude (deg): 120.5636
     locality: 27 km W of Stewart on West Rail line towards Koolyanobbing.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.8833_degS_and_121.0206_degE:
     latitude (deg): -30.8833
     longitude (deg): 121.0206
     locality: c. 8 km W from Bonnie Vale Railway Station on West Rail track to Koolyanobbing
       adjacent to railway marker 609.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.8833_degS_and_150.5_degE:
     latitude (deg): -30.8833
     longitude (deg): 150.5
     locality: Namoi River, Little Klori Hill, 1.75 km SSE of Keepit Dam spillway.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-30.8956_degS_and_121.8314_degE:
     latitude (deg): -30.8956
     longitude (deg): 121.8314
     locality: 67 km W of Karonie on Trans Access Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.9017_degS_and_135.2453_degE:
     latitude (deg): -30.9017
     longitude (deg): 135.2453
     locality: 8 km W of Kingoonya towards Tarcoola on Trans Australian Railway Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.9192_degS_and_151.8522_degE:
     latitude (deg): -30.9192
     longitude (deg): 151.8522
     locality: Oxley Wild Rivers National Park, Spring Creek.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-30.9281_degS_and_122.5494_degE:
     latitude (deg): -30.9281
     longitude (deg): 122.5494
     locality: 5 km N of Karonie towards Cardunia Rocks.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.9333_degS_and_135.5333_degE:
     latitude (deg): -30.9333
     longitude (deg): 135.5333
     locality: 20 km W of Glendambo towards Kingoonya on Trans Australian Railway Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-30.9333_degS_and_149.4167_degE:
     latitude (deg): -30.9333
     longitude (deg): 149.4167
     locality: 40 km from Coonabarabran on Narrabri Rd.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-30.9447_degS_and_151.8736_degE:
     latitude (deg): -30.9447
     longitude (deg): 151.8736
     locality: Oxley Wild Rivers National Park; Table Top Hut.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-30.9456_degS_and_122.6558_degE:
     latitude (deg): -30.9456
     longitude (deg): 122.6558
     locality: Near Dingo Rock, E of Karonie (turn N at Karonie, cross rly, then immediately
       turn right, follow road for 13.3 km).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-30.95_degS_and_122.5333_degE:
     latitude (deg): -30.95
     longitude (deg): 122.5333
     locality: Road to Cardunia Rocks, 7.2 km W of Karonie on Trans Access Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-30.9667_degS_and_116.9833_degE:
     latitude (deg): -30.9667
     longitude (deg): 116.9833
     locality: Watten Gutten concrete tank, 17 km SW of Manmanning by air.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-30.9831_degS_and_118.9194_degE:
     latitude (deg): -30.9831
     longitude (deg): 118.9194
     locality: 3.5 km W along Corintha East Road toward Koorda-Southern Cross Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-30_degS_and_151.2_degE:
     latitude (deg): -30.0
     longitude (deg): 151.2
     locality: Tingha district
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.0022_degS_and_118.8261_degE:
     latitude (deg): -31.0022
     longitude (deg): 118.8261
     locality: 7 km along Corintha East Road toward Koorda - Southern Cross Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.0086_degS_and_150.1914_degE:
     latitude (deg): -31.0086
     longitude (deg): 150.1914
     locality: Collected and transferred by Whitehaven Coal under Australia National
       Botanic Gardens Permit.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-31.0114_degS_and_120.8731_degE:
     latitude (deg): -31.0114
     longitude (deg): 120.8731
     locality: Granite outcrop beside Bullabulling Roadhouse, at base on north side.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.0236_degS_and_121.5889_degE:
     latitude (deg): -31.0236
     longitude (deg): 121.5889
     locality: 33 km S of Kalgoorlie from intersection of Great Eastern Highway and
       Celebration Road, via Eastern Bypass Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.0269_degS_and_118.4833_degE:
     latitude (deg): -31.0269
     longitude (deg): 118.4833
     locality: 33 km E of Mukinbudin.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.0333_degS_and_118.5333_degE:
     latitude (deg): -31.0333
     longitude (deg): 118.5333
     locality: 2.6 km E of Campion and the Rabbit Proof Fence, and 7.1 km W ofWarralakin.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-31.0333_degS_and_124.15_degE:
     latitude (deg): -31.0333
     longitude (deg): 124.15
     locality: Transcontinental Railway line, 5 km W of Kitchener.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.0389_degS_and_120.8269_degE:
     latitude (deg): -31.0389
     longitude (deg): 120.8269
     locality: 5 km E of Bullabulling on Great Eastern Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-31.0389_degS_and_120.8294_degE:
     latitude (deg): -31.0389
     longitude (deg): 120.8294
     locality: 4.5 km W of Bullabulling on Great Eastern Highway, towards Yellowdale.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.0469_degS_and_118.0342_degE:
     latitude (deg): -31.0469
     longitude (deg): 118.0342
     locality: 3.5 km along Billyacatting Road from Kwelkan North Road, c. 10km NE
       of Kununappin.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.0667_degS_and_141.7667_degE:
     latitude (deg): -31.0667
     longitude (deg): 141.7667
     locality: Ca 6 km direct NE of Fowlers Gap, c. 5 km along track from the Silver
       City Highway towards Planet Camp Bore.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.0833_degS_and_121.0167_degE:
     latitude (deg): -31.0833
     longitude (deg): 121.0167
     locality: 26 km SSW of Coolgardie along road to Gnarlbine Rock.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-31.0833_degS_and_141.8_degE:
     latitude (deg): -31.0833
     longitude (deg): 141.8
     locality: c. 110 km along the Silver City Highway from Broken Hill towards Tibooburra,
       Fowlers Gap, at rest area just N of where highway crosses Fowlers Creek.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.0833_degS_and_149.3833_degE:
     latitude (deg): -31.0833
     longitude (deg): 149.3833
     locality: 24 km from Coonabarabran on Narrabri Rd.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.0883_degS_and_138.8542_degE:
     latitude (deg): -31.0883
     longitude (deg): 138.8542
     locality: Wirrealpa - Blinman road, c. 13 km W from Wirrealpa - Balcanoota road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.0972_degS_and_138.5311_degE:
     latitude (deg): -31.0972
     longitude (deg): 138.5311
     locality: Glass Gorge Road, about 5 km E then N from turnoff on Parachilna - Blinman
       Road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.1_degS_and_121_degE:
     latitude (deg): -31.1
     longitude (deg): 121.0
     locality: 22 km SSW of Coolgardie along road to Gnarlbine Rock.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.1_degS_and_152.35_degE:
     latitude (deg): -31.1
     longitude (deg): 152.35
     locality: Mt Boss State Forest, Forbes River crossing on Racecourse Trail, 51
       km NW of Wauchope.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-31.1211_degS_and_138.9592_degE:
     latitude (deg): -31.1211
     longitude (deg): 138.9592
     locality: Wirrealpa - Blinman road, c. 1 km W from Wirrealpa - Balcanoota road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.1222_degS_and_138.5242_degE:
     latitude (deg): -31.1222
     longitude (deg): 138.5242
     locality: Glass Gorge Road, about 1 km E from turnoff on Parachilna - Blinman
       Road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.1225_degS_and_119.2844_degE:
     latitude (deg): -31.1225
     longitude (deg): 119.2844
     locality: 3 km W along Corintha East Road toward Koorda-Southern Cross Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.1333_degS_and_120.9333_degE:
     latitude (deg): -31.1333
     longitude (deg): 120.9333
     locality: ca. 30 km SSW of Coolgardie, 3 km NW of Gnarlbine Rock, near sand mine.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.1333_degS_and_120.95_degE:
     latitude (deg): -31.1333
     longitude (deg): 120.95
     locality: Gnarlbine Rocks (19 miles 30.5 km SW. of Coolgardie).
-    collector: Phillips, M.E.
+    recorded by: Phillips, M.E.
   site_at_-31.15_degS_and_120.95_degE:
     latitude (deg): -31.15
     longitude (deg): 120.95
     locality: 29 km SSW of Coolgardie along road to Gnarlbine Rock.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.1833_degS_and_123.6167_degE:
     latitude (deg): -31.1833
     longitude (deg): 123.6167
     locality: 17 km S of Zanthus along road to Balladonia.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.2167_degS_and_152.4167_degE:
     latitude (deg): -31.2167
     longitude (deg): 152.4167
     locality: Mt. Boss State Forest, Banda Banda Mt., 44 km NW of Wauchope 100 m S
       of summit.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-31.2333_degS_and_118.7667_degE:
     latitude (deg): -31.2333
     longitude (deg): 118.7667
     locality: 10 km NE of Westonia, Sanford Rock.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.2333_degS_and_152.8167_degE:
     latitude (deg): -31.2333
     longitude (deg): 152.8167
     locality: Kempsey-Wauchope.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.2414_degS_and_121.6033_degE:
     latitude (deg): -31.2414
     longitude (deg): 121.6033
     locality: 6.5 km S on Kambalda Road from Celebration Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.245_degS_and_152.4642_degE:
     latitude (deg): -31.245
     longitude (deg): 152.4642
     locality: Willi Willi National Park. Hastings Forest Way.BANDA BANDA 9335-15 431490.
-    collector: Murray, W.
+    recorded by: Murray, W.
   site_at_-31.2464_degS_and_119.2986_degE:
     latitude (deg): -31.2464
     longitude (deg): 119.2986
     locality: 18 km from Moonie Rock towards Southern Cross.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.2492_degS_and_149.2878_degE:
     latitude (deg): -31.2492
     longitude (deg): 149.2878
     locality: Coonabarabran cemetery.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.25_degS_and_136.35_degE:
     latitude (deg): -31.25
     longitude (deg): 136.35
     locality: Along Stewart Highway, near southern tip of Lake Hart, c. 37 km W of
       Pimba.
-    collector: Verdon, D.
+    recorded by: Verdon, D.
   site_at_-31.25_degS_and_149.15_degE:
     latitude (deg): -31.25
     longitude (deg): 149.15
     locality: Timor Rock, 12 km W of Coonabarabran.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.2614_degS_and_115.445_degE:
     latitude (deg): -31.2614
     longitude (deg): 115.445
     locality: 2 km from Seabird Post Office towards Wanneroo Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.2667_degS_and_120.0333_degE:
     latitude (deg): -31.2667
     longitude (deg): 120.0333
     locality: 37 km E of Yellowdine along Great Eastern Highway towards Coolgardie.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.2667_degS_and_148.95_degE:
     latitude (deg): -31.2667
     longitude (deg): 148.95
     locality: Warrumbungle N.P.-Toorawenah Rd.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.2667_degS_and_149.05_degE:
     latitude (deg): -31.2667
     longitude (deg): 149.05
     locality: Mt. Woorut, Warrumbungle Ra., 21 km. W. of Coonabarabran.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.2719_degS_and_120.0025_degE:
     latitude (deg): -31.2719
     longitude (deg): 120.0025
     locality: 66 km E of Southern Cross on Great Eastern Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.2747_degS_and_119.5106_degE:
     latitude (deg): -31.2747
     longitude (deg): 119.5106
     locality: 15.5 km E of Yellowdine.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.2833_degS_and_119.5167_degE:
     latitude (deg): -31.2833
     longitude (deg): 119.5167
     locality: 17 km E of Southern Cross along Great Eastern Highway towards Coolgardie.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-31.2836_degS_and_119.825_degE:
     latitude (deg): -31.2836
     longitude (deg): 119.825
     locality: c. 16 km E of Yellowdine.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.2853_degS_and_115.4456_degE:
     latitude (deg): -31.2853
     longitude (deg): 115.4456
     locality: 1.3 km from Seabird P.O. along coastal track.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.2917_degS_and_145.3167_degE:
     latitude (deg): -31.2917
     longitude (deg): 145.3167
     locality: c. 50 km WNW of Cobar, 4.9 km N of Mt. Grenfell.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.3_degS_and_148.9833_degE:
     latitude (deg): -31.3
     longitude (deg): 148.9833
     locality: Fans Horizon, Warrumbungle Ra. Range, 28 km. W of Coonabarabran.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.3_degS_and_149_degE:
     latitude (deg): -31.3
     longitude (deg): 149.0
     locality: Mount Wombelong, Warrumbungle Range, 30 km W of Coonabarabran.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.3333_degS_and_148.9833_degE:
     latitude (deg): -31.3333
     longitude (deg): 148.9833
     locality: Warrumbungle Range. 50 m below Grand High Tops along walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-31.335_degS_and_138.3686_degE:
     latitude (deg): -31.335
     longitude (deg): 138.3686
     locality: Flinders Ranges National Park; Geological Trail, about 1 km E from western
       park boundary in Brachina Gorge.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.35_degS_and_142.05_degE:
     latitude (deg): -31.35
     longitude (deg): 142.05
     locality: c. 100 km by road from Broken Hill towards Mootwingee National Park,
       c. 10 km direct NE of The Bluff (a hill), roadside.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.3814_degS_and_118.6742_degE:
     latitude (deg): -31.3814
     longitude (deg): 118.6742
     locality: Intersection of Goldfields Road and Carrabin SDG Road, at Carrabin.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.3833_degS_and_138.7333_degE:
     latitude (deg): -31.3833
     longitude (deg): 138.7333
     locality: Ca 4 km E of Oraparinna Homestead on short-cut road to Martins Well
       (just off main Martins Well-Wilpena road on the Oraparinna road).
-    collector: Craven, L.A.; Grace, J.P.; Brown, A.H.D.; Hurka, H.
+    recorded by: Craven, L.A.; Grace, J.P.; Brown, A.H.D.; Hurka, H.
   site_at_-31.3833_degS_and_141.6_degE:
     latitude (deg): -31.3833
     longitude (deg): 141.6
     locality: c. 40 km along the Silver City Highway from Fowlers Gap towards Broken
       Hill, Barrier Ranges, summit of Mount Pintapah.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.3833_degS_and_148.8667_degE:
     latitude (deg): -31.3833
     longitude (deg): 148.8667
     locality: Warrumbungle-Toorawenah Rd.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.3981_degS_and_117.2761_degE:
     latitude (deg): -31.3981
     longitude (deg): 117.2761
     locality: 30 km from Wyalkatchem towards Cunderdin.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.4_degS_and_118.8333_degE:
     latitude (deg): -31.4
     longitude (deg): 118.8333
     locality: WA wheatbelt district, 7 km W of Bodallin between old railway bed and
       pipeline, Great Eastern Highway.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.45_degS_and_118.25_degE:
     latitude (deg): -31.45
     longitude (deg): 118.25
     locality: 4.1 km NW of Merredin on road to Nungarin just before granite outcrop
       on N side of road.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-31.45_degS_and_141.55_degE:
     latitude (deg): -31.45
     longitude (deg): 141.55
     locality: 62 km along Silver City Highway from Broken Hill (17 km along highway
       from Pine Creek crossing) towards Wentworth, roadside near the hill Wendi 128.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.4625_degS_and_117.2792_degE:
     latitude (deg): -31.4625
     longitude (deg): 117.2792
     locality: 24.5 km from Cunderdin towards Wyalkatchem, on side road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.4667_degS_and_120.8333_degE:
     latitude (deg): -31.4667
     longitude (deg): 120.8333
     locality: 66 km SSW of Coolgardie along road past Queen Victoria Rock.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-31.4667_degS_and_139.1_degE:
     latitude (deg): -31.4667
     longitude (deg): 139.1
     locality: Martins Well Station, E of Blinman.
-    collector: Fagg, M.
+    recorded by: Fagg, M.
   site_at_-31.4886_degS_and_139.3681_degE:
     latitude (deg): -31.4886
     longitude (deg): 139.3681
     locality: Erudina homestead - Curnamona homestead road, just S of Wilpena Creek
       crossing.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.4975_degS_and_121.5783_degE:
     latitude (deg): -31.4975
     longitude (deg): 121.5783
     locality: Opposite Widgiemooltha roadhouse.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.5_degS_and_117.5667_degE:
     latitude (deg): -31.5
     longitude (deg): 117.5667
     locality: 15 km N of Kellerberrin on rd. to Trayning.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-31.5094_degS_and_145.7667_degE:
     latitude (deg): -31.5094
     longitude (deg): 145.7667
     locality: 3 km W of Cobar on Wilcannia Road.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-31.5167_degS_and_159.0667_degE:
     latitude (deg): -31.5167
     longitude (deg): 159.0667
     locality: Anderson Road.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-31.5228_degS_and_118.8014_degE:
     latitude (deg): -31.5228
     longitude (deg): 118.8014
     locality: 6.2 km along a gravel road from intersection of Della Road, 6.6 km from
       Hodgson Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.5333_degS_and_119.6167_degE:
     latitude (deg): -31.5333
     longitude (deg): 119.6167
     locality: 27 km S of Yellowdine, 2 km SE of Pathfinder homestead.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.5333_degS_and_159.0833_degE:
     latitude (deg): -31.5333
     longitude (deg): 159.0833
     locality: Transit Hill walking track.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-31.55_degS_and_145.8833_degE:
     latitude (deg): -31.55
     longitude (deg): 145.8833
     locality: Western Plains, 7.5 km SE of Cobar.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.5592_degS_and_118.8536_degE:
     latitude (deg): -31.5592
     longitude (deg): 118.8536
     locality: 5 km along Ivey Road from intersection with Antonio Road, S of Bodallin.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.5667_degS_and_143.2167_degE:
     latitude (deg): -31.5667
     longitude (deg): 143.2167
     locality: 17 km along the Barrier Highway from Wilcannia towards Broken Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.5783_degS_and_118.7397_degE:
     latitude (deg): -31.5783
     longitude (deg): 118.7397
     locality: 10.3 km along Della Road, from intersection of Goldfields Road and Carrabin
       SDG Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.5833_degS_and_148.75_degE:
     latitude (deg): -31.5833
     longitude (deg): 148.75
     locality: 13 km. N.E. of Gilgandra.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-31.6094_degS_and_118.8533_degE:
     latitude (deg): -31.6094
     longitude (deg): 118.8533
     locality: 5 km along Ivey Road from intersection with Antonio Road, S of Bodallin.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.6222_degS_and_129.4303_degE:
     latitude (deg): -31.6222
     longitude (deg): 129.4303
     locality: 142.5 km W of Nullabor Roadhouse, on Eyre Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.6333_degS_and_142.95_degE:
     latitude (deg): -31.6333
     longitude (deg): 142.95
     locality: 43 km along the Barrier Highway from Wilcannia towards Broken Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.6406_degS_and_116.3947_degE:
     latitude (deg): -31.6406
     longitude (deg): 116.3947
     locality: Toodyay Road, 5 km towards Toodyay from intersection with Fernie Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.6447_degS_and_115.9097_degE:
     latitude (deg): -31.6447
     longitude (deg): 115.9097
     locality: Nth boundary bombing range, Muchea Air Weapons Range, RAAF.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-31.6544_degS_and_117.4864_degE:
     latitude (deg): -31.6544
     longitude (deg): 117.4864
     locality: York Road, S of Tammin, towards Charles Gardner Nature Reserve.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.6667_degS_and_129_degE:
     latitude (deg): -31.6667
     longitude (deg): 129.0
     locality: At W.A./S.A. border, 4 km seaward and S of Eyre Highway on track toWilsons
       Bluff, 1.7 km inland from Wilsons Bluff.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-31.6667_degS_and_141.3667_degE:
     latitude (deg): -31.6667
     longitude (deg): 141.3667
     locality: 51.2 km from central Broken Hill on road to Mt Robe, near ephemeral
       stream close to road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-31.6667_degS_and_142.7833_degE:
     latitude (deg): -31.6667
     longitude (deg): 142.7833
     locality: 57 km from Wilcannia to Broken Hill.
-    collector: Tyrrel, A.
+    recorded by: Tyrrel, A.
   site_at_-31.6667_degS_and_148.7531_degE:
     latitude (deg): -31.6667
     longitude (deg): 148.7531
     locality: Gilgandra Flora Reserve.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.675_degS_and_152.5167_degE:
     latitude (deg): -31.675
     longitude (deg): 152.5167
     locality: Coorabakh National Park. Cave track above Newbys Cave (above).
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-31.7_degS_and_148.6667_degE:
     latitude (deg): -31.7
     longitude (deg): 148.6667
     locality: Gilgandra district.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.7_degS_and_152.5083_degE:
     latitude (deg): -31.7
     longitude (deg): 152.5083
     locality: Coorabakh National Park, Northern slopes of Little Nellie.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-31.7167_degS_and_142.5333_degE:
     latitude (deg): -31.7167
     longitude (deg): 142.5333
     locality: 85 km along the Barrier Highway from Wilcannia towards Broken Hill,
       where road crosses unnamed watercourse.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.7167_degS_and_142.6667_degE:
     latitude (deg): -31.7167
     longitude (deg): 142.6667
     locality: 70 km along the Barrier Highway from Wilcannia towards Broken Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.7167_degS_and_148.6667_degE:
     latitude (deg): -31.7167
     longitude (deg): 148.6667
     locality: Gilgandra.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.7167_degS_and_152.5167_degE:
     latitude (deg): -31.7167
     longitude (deg): 152.5167
     locality: Coorabakh National Park, at Newbys Cave.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-31.75_degS_and_142.4333_degE:
     latitude (deg): -31.75
     longitude (deg): 142.4333
     locality: 105 km along the Barrier Highway from Wilcannia towards Broken Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.75_degS_and_143.3333_degE:
     latitude (deg): -31.75
     longitude (deg): 143.3333
     locality: 104 km from Menindee toward Wilcannia.
-    collector: Tyrrel, A.
+    recorded by: Tyrrel, A.
   site_at_-31.7508_degS_and_118.0761_degE:
     latitude (deg): -31.7508
     longitude (deg): 118.0761
     locality: 3.5 km W on Belka West Road from intersection of Hines Hill Rd.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.7508_degS_and_118.0817_degE:
     latitude (deg): -31.7508
     longitude (deg): 118.0817
     locality: 3.5 km W on Belka West Road from intersection with Hines Hill Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.7614_degS_and_118.5106_degE:
     latitude (deg): -31.7614
     longitude (deg): 118.5106
     locality: 4.5km W of Muntadgin, on Muntadgin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.7667_degS_and_117.4667_degE:
     latitude (deg): -31.7667
     longitude (deg): 117.4667
     locality: Charles Gardner Reserve (= Tammin Reserve), 19 km S of Tammin on the
       York-Quairading road.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-31.7747_degS_and_138.8014_degE:
     latitude (deg): -31.7747
     longitude (deg): 138.8014
     locality: Black Range, ENE of Hawker, Warcowie - Willipa road, about 12 km W from
       turn off to Holowillena and junction to Willipa homestead.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.7789_degS_and_117.4733_degE:
     latitude (deg): -31.7789
     longitude (deg): 117.4733
     locality: c. 15 km direct S of Tammin, at Charles Gardner Nature Reserve.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.7794_degS_and_117.4839_degE:
     latitude (deg): -31.7794
     longitude (deg): 117.4839
     locality: Charles Gardner Nature Reserve, S of Tammin.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.7956_degS_and_138.7686_degE:
     latitude (deg): -31.7956
     longitude (deg): 138.7686
     locality: Black Range, ENE of Hawker, off Warcowie - Willipa road along side track
       to the south.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.8_degS_and_141.4333_degE:
     latitude (deg): -31.8
     longitude (deg): 141.4333
     locality: 15.8 km from the outskirts of Broken Hill on road to Mt Robe, roadside.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-31.8333_degS_and_138.3833_degE:
     latitude (deg): -31.8333
     longitude (deg): 138.3833
     locality: 5 km from Hawker-Marree road on road to Neuroodla.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-31.8667_degS_and_133.0833_degE:
     latitude (deg): -31.8667
     longitude (deg): 133.0833
     locality: 9 km NE of Penong.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.8833_degS_and_133.4_degE:
     latitude (deg): -31.8833
     longitude (deg): 133.4
     locality: ca 30 km NW of Ceduna, 2 km NW of Koonibba Hill.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.8833_degS_and_141.7667_degE:
     latitude (deg): -31.8833
     longitude (deg): 141.7667
     locality: 170 km along the Barrier Highway from Wilcannia towards Broken Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.9167_degS_and_141.5667_degE:
     latitude (deg): -31.9167
     longitude (deg): 141.5667
     locality: 195 km along the Barrier Highway from Wilcannia towards Broken Hill,
       small rise c. 300 m N of road at Willy Willong Creek No. 1.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-31.9189_degS_and_121.6436_degE:
     latitude (deg): -31.9189
     longitude (deg): 121.6436
     locality: 52 km S of Widgiemooltha towards Norseman.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.95_degS_and_115.8333_degE:
     latitude (deg): -31.95
     longitude (deg): 115.8333
     locality: CULTIVATED Kings Park, Perth.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-31.95_degS_and_116.15_degE:
     latitude (deg): -31.95
     longitude (deg): 116.15
     locality: Mundaring Weir.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-31.9556_degS_and_151.4319_degE:
     latitude (deg): -31.9556
     longitude (deg): 151.4319
     locality: Barrington Tops, edge of Polblue Swamp.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-31.9625_degS_and_126.6831_degE:
     latitude (deg): -31.9625
     longitude (deg): 126.6831
     locality: 56 km E of Cocklebiddy towards Majura.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-31.9667_degS_and_115.9667_degE:
     latitude (deg): -31.9667
     longitude (deg): 115.9667
     locality: Perth Herbarium, in grounds climbing on Douglas Street side fence.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-31.9667_degS_and_141.45_degE:
     latitude (deg): -31.9667
     longitude (deg): 141.45
     locality: Ca. 1.7 km from the edge of suburban Broken Hill on road to Mt Robe,
       roadside.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-31.9667_degS_and_145.75_degE:
     latitude (deg): -31.9667
     longitude (deg): 145.75
     locality: E end of Gundaroo Hills in Sandy Creek.
-    collector: Windsor, R.A.
+    recorded by: Windsor, R.A.
   site_at_-31.9833_degS_and_120.8667_degE:
     latitude (deg): -31.9833
     longitude (deg): 120.8667
     locality: c. 90 km WNW of Norseman, 8 km E along road from T junction between
       Bank Rock & salt lake.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-31.9833_degS_and_126.5667_degE:
     latitude (deg): -31.9833
     longitude (deg): 126.5667
     locality: 46 km E of Cocklebiddy on Eyre Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-31.985_degS_and_140.5156_degE:
     latitude (deg): -31.985
     longitude (deg): 140.5156
     locality: Boolcoomatta Bush Heritage Reserve, camp site area off Noonflower Track.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-31.9881_degS_and_118.3944_degE:
     latitude (deg): -31.9881
     longitude (deg): 118.3944
     locality: 0.3 km S of Roach Rd along Merredin - Narembeen Rd.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.0136_degS_and_115.4833_degE:
     latitude (deg): -32.0136
     longitude (deg): 115.4833
     locality: Rottnest Island, NW side between lighthouse and trail to Geordie Bay.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-32.0167_degS_and_116.0333_degE:
     latitude (deg): -32.0167
     longitude (deg): 116.0333
     locality: Wattle Grove.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.02_degS_and_115.9797_degE:
     latitude (deg): -32.02
     longitude (deg): 115.9797
     locality: Kenwick Swamp.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-32.05_degS_and_138.3_degE:
     latitude (deg): -32.05
     longitude (deg): 138.3
     locality: 24 km SW of Hawker towards Quorn.
-    collector: Sikkes, A.J.A.
+    recorded by: Sikkes, A.J.A.
   site_at_-32.0619_degS_and_151.6711_degE:
     latitude (deg): -32.0619
     longitude (deg): 151.6711
     locality: Gloucester Tops Road, at junction with Sharpes Creek walking trail.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-32.0667_degS_and_122.5833_degE:
     latitude (deg): -32.0667
     longitude (deg): 122.5833
     locality: 84 km from Norseman along Eyre highway towards Balladonia.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.0667_degS_and_151.65_degE:
     latitude (deg): -32.0667
     longitude (deg): 151.65
     locality: Gloucester Tops, 5 km N of Mt McKenzie on Gloucester Tops Rd.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-32.0722_degS_and_122.5036_degE:
     latitude (deg): -32.0722
     longitude (deg): 122.5036
     locality: c. 117 km W of Balladonia.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-32.0944_degS_and_150.9889_degE:
     latitude (deg): -32.0944
     longitude (deg): 150.9889
     locality: 0.3 km from Brushy Hill lookout at Glenbawn Dam, 13.7 km from Scone.
-    collector: Zich, F.A.
+    recorded by: Zich, F.A.
   site_at_-32.0944_degS_and_151.4758_degE:
     latitude (deg): -32.0944
     longitude (deg): 151.4758
     locality: Beside Careys Peak Walking Trail, Chichester State Forest. Near Barrington
       Tops.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-32.0989_degS_and_151.6003_degE:
     latitude (deg): -32.0989
     longitude (deg): 151.6003
     locality: Barrington Tops National Park, beside Gloucester Falls walking track.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-32.0997_degS_and_151.6167_degE:
     latitude (deg): -32.0997
     longitude (deg): 151.6167
     locality: Gloucester Tops 500 m south east of Picnic area on river path to Falls
       Lookout.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-32.1114_degS_and_121.9169_degE:
     latitude (deg): -32.1114
     longitude (deg): 121.9169
     locality: Near Dundas Hills (c. 200 m from highway), c. 15 km E of Norseman.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.1189_degS_and_123.1697_degE:
     latitude (deg): -32.1189
     longitude (deg): 123.1697
     locality: Newmans Rock 50 km W of Balladonia on Eyre Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.1247_degS_and_121.9206_degE:
     latitude (deg): -32.1247
     longitude (deg): 121.9206
     locality: Near Dundas Hills (c. 2 km from highway), c. 15 km E of Norseman.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.1333_degS_and_142.8_degE:
     latitude (deg): -32.1333
     longitude (deg): 142.8
     locality: NSF/NNF 41 km from Menindee to Wilcannia on east side of Darling River.
-    collector: Tyrrel, A.
+    recorded by: Tyrrel, A.
   site_at_-32.15_degS_and_121.8167_degE:
     latitude (deg): -32.15
     longitude (deg): 121.8167
     locality: 7 km NNE of Norseman, Jimberlana Hill.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.1525_degS_and_121.7367_degE:
     latitude (deg): -32.1525
     longitude (deg): 121.7367
     locality: 8 km N of Norseman.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-32.1558_degS_and_121.7408_degE:
     latitude (deg): -32.1558
     longitude (deg): 121.7408
     locality: Lake Cowan, 5 km N from Norseman.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.1661_degS_and_126.2958_degE:
     latitude (deg): -32.1661
     longitude (deg): 126.2958
     locality: 20.5 km towards Eyre Bird Obseratory from Eyre Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.1667_degS_and_115.8167_degE:
     latitude (deg): -32.1667
     longitude (deg): 115.8167
     locality: 24 km S of Perth, S of Thompsons Lake on Russell road.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-32.1667_degS_and_121.7_degE:
     latitude (deg): -32.1667
     longitude (deg): 121.7
     locality: 6 km from Norseman along Eyre Highway towards Coolgardie.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.185_degS_and_121.4658_degE:
     latitude (deg): -32.185
     longitude (deg): 121.4658
     locality: 25.5 km along new Norseman to Hyden road, 10 km N of Norseman.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.2_degS_and_126.0667_degE:
     latitude (deg): -32.2
     longitude (deg): 126.0667
     locality: 20 km SSW of Cocklebiddy along track to Twilight Cove.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.2_degS_and_138.0333_degE:
     latitude (deg): -32.2
     longitude (deg): 138.0333
     locality: c. 18 km N of Quorn toward Warren Gorge.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-32.2_degS_and_142.1333_degE:
     latitude (deg): -32.2
     longitude (deg): 142.1333
     locality: C. 38 km from Menindee toward Broken Hill in ditch beside road.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-32.2333_degS_and_115.7667_degE:
     latitude (deg): -32.2333
     longitude (deg): 115.7667
     locality: Kwinana.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-32.25_degS_and_152.5333_degE:
     latitude (deg): -32.25
     longitude (deg): 152.5333
     locality: Booti Booti National Park.
-    collector: Wardlaw, I.
+    recorded by: Wardlaw, I.
   site_at_-32.2672_degS_and_123.4528_degE:
     latitude (deg): -32.2672
     longitude (deg): 123.4528
     locality: 17.7 km W of Balladonia.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-32.2833_degS_and_116.2_degE:
     latitude (deg): -32.2833
     longitude (deg): 116.2
     locality: 41 km NW of North Bannister along Albany Highway.
-    collector: Taylor, J.M.
+    recorded by: Taylor, J.M.
   site_at_-32.2833_degS_and_118.3333_degE:
     latitude (deg): -32.2833
     longitude (deg): 118.3333
     locality: 27 km from Narembeen along road to Kondinin.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.2897_degS_and_116.1908_degE:
     latitude (deg): -32.2897
     longitude (deg): 116.1908
     locality: 2 km N of Jarrahdale turnoff on Albany Highway. Gleneagle Rest Area.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.3_degS_and_150.05_degE:
     latitude (deg): -32.3
     longitude (deg): 150.05
     locality: Goulburn River National Park, 38.4 km SW of Merriwa on the Merriwa-Mudgee
       road.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-32.3178_degS_and_125.1403_degE:
     latitude (deg): -32.3178
     longitude (deg): 125.1403
     locality: 24.8 km W of Cocklebiddy on Eyre Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-32.32_degS_and_150.6689_degE:
     latitude (deg): -32.32
     longitude (deg): 150.6689
     locality: Upper Hunter Valley; Mangoola Coal Mine Offset site, Wybong Road .
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6714_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6714
@@ -4079,7 +4079,7 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6717_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6717
@@ -4087,7 +4087,7 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6719_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6719
@@ -4095,7 +4095,7 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6722_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6722
@@ -4103,7 +4103,7 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6725_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6725
@@ -4111,7 +4111,7 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3206_degS_and_150.6728_degE:
     latitude (deg): -32.3206
     longitude (deg): 150.6728
@@ -4119,3135 +4119,3135 @@ sites:
       limb of Addy Hill. 6.3 km S from the Wybong Road entrance at a T intersection.
       Population is in a dry gully 400 m SE of the intersection and extends to top
       of escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3306_degS_and_116.1128_degE:
     latitude (deg): -32.3306
     longitude (deg): 116.1128
     locality: 10 km W along Jarrahdale Road from Albany Highway towards Jarrahdale.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.3333_degS_and_138.0333_degE:
     latitude (deg): -32.3333
     longitude (deg): 138.0333
     locality: CULTIVATED Main street of Quorn.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-32.3333_degS_and_150.4667_degE:
     latitude (deg): -32.3333
     longitude (deg): 150.4667
     locality: Mt Dangar.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.3458_degS_and_139.455_degE:
     latitude (deg): -32.3458
     longitude (deg): 139.455
     locality: Yunta - Koonamore road, about 30 km N from Yunta.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.3539_degS_and_123.615_degE:
     latitude (deg): -32.3539
     longitude (deg): 123.615
     locality: Balladonia Roadhouse.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.3542_degS_and_150.6281_degE:
     latitude (deg): -32.3542
     longitude (deg): 150.6281
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3544_degS_and_150.6275_degE:
     latitude (deg): -32.3544
     longitude (deg): 150.6275
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3544_degS_and_150.6278_degE:
     latitude (deg): -32.3544
     longitude (deg): 150.6278
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3547_degS_and_150.6267_degE:
     latitude (deg): -32.3547
     longitude (deg): 150.6267
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3547_degS_and_150.6272_degE:
     latitude (deg): -32.3547
     longitude (deg): 150.6272
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3556_degS_and_150.6244_degE:
     latitude (deg): -32.3556
     longitude (deg): 150.6244
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3556_degS_and_150.6281_degE:
     latitude (deg): -32.3556
     longitude (deg): 150.6281
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3556_degS_and_150.6283_degE:
     latitude (deg): -32.3556
     longitude (deg): 150.6283
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3556_degS_and_150.6286_degE:
     latitude (deg): -32.3556
     longitude (deg): 150.6286
     locality: Myambat Explosive Depot, 1.6 km N on Rosemount road from depot entrance,
       then 500 m NE up gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3583_degS_and_135.4167_degE:
     latitude (deg): -32.3583
     longitude (deg): 135.4167
     locality: Gawler Ranges, 11 km W of Yardea Homestead on Hiltaba road.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-32.3667_degS_and_118.3_degE:
     latitude (deg): -32.3667
     longitude (deg): 118.3
     locality: Roe District; 1.2 km N of Bendering, near crossing of Bendering Hall
       Rd over Railway line.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.3667_degS_and_149.8667_degE:
     latitude (deg): -32.3667
     longitude (deg): 149.8667
     locality: 7 km N of Munghorn Gap Nature Reserve on Wollar-Mudgee Road.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-32.3703_degS_and_150.6642_degE:
     latitude (deg): -32.3703
     longitude (deg): 150.6642
     locality: Myambat Explosives Depot ~SW of Muswellbrook, at eastern end of property
       in cleared area.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3708_degS_and_150.6664_degE:
     latitude (deg): -32.3708
     longitude (deg): 150.6664
     locality: Upper Hunter Valley; Myambat Explosives Depot, at eastern end in NW-facing
       gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3708_degS_and_150.6667_degE:
     latitude (deg): -32.3708
     longitude (deg): 150.6667
     locality: Upper Hunter Valley; Myambat Explosives Depot, at eastern end in NW-facing
       gully.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3722_degS_and_141.4833_degE:
     latitude (deg): -32.3722
     longitude (deg): 141.4833
     locality: 45.5 km S of Broken Hill on Silvercity Silver City Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-32.3772_degS_and_150.6617_degE:
     latitude (deg): -32.3772
     longitude (deg): 150.6617
     locality: Upper Hunter Valley; Myambat Explosives Depot, side of road in SE of
       property, in N-facing valley.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3775_degS_and_150.6636_degE:
     latitude (deg): -32.3775
     longitude (deg): 150.6636
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3775_degS_and_150.6639_degE:
     latitude (deg): -32.3775
     longitude (deg): 150.6639
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3775_degS_and_150.6642_degE:
     latitude (deg): -32.3775
     longitude (deg): 150.6642
     locality: Myambat Explosive Depot. On edge of lower cliff at SE end of the depot
       area, next to Denman Park.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3775_degS_and_150.6644_degE:
     latitude (deg): -32.3775
     longitude (deg): 150.6644
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3778_degS_and_150.6636_degE:
     latitude (deg): -32.3778
     longitude (deg): 150.6636
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3778_degS_and_150.6642_degE:
     latitude (deg): -32.3778
     longitude (deg): 150.6642
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3781_degS_and_150.6628_degE:
     latitude (deg): -32.3781
     longitude (deg): 150.6628
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3781_degS_and_150.6631_degE:
     latitude (deg): -32.3781
     longitude (deg): 150.6631
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3781_degS_and_150.6636_degE:
     latitude (deg): -32.3781
     longitude (deg): 150.6636
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3783_degS_and_150.6625_degE:
     latitude (deg): -32.3783
     longitude (deg): 150.6625
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3783_degS_and_150.6633_degE:
     latitude (deg): -32.3783
     longitude (deg): 150.6633
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3783_degS_and_150.6636_degE:
     latitude (deg): -32.3783
     longitude (deg): 150.6636
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3783_degS_and_150.6639_degE:
     latitude (deg): -32.3783
     longitude (deg): 150.6639
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3783_degS_and_150.6644_degE:
     latitude (deg): -32.3783
     longitude (deg): 150.6644
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3786_degS_and_150.6622_degE:
     latitude (deg): -32.3786
     longitude (deg): 150.6622
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3786_degS_and_150.6628_degE:
     latitude (deg): -32.3786
     longitude (deg): 150.6628
     locality: Upper Hunter Valley; Myambat Explosives Depot, 250 m SE up slopes of
       escarpment.from road at SE end of depot area.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3786_degS_and_150.6636_degE:
     latitude (deg): -32.3786
     longitude (deg): 150.6636
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50 m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3786_degS_and_150.6644_degE:
     latitude (deg): -32.3786
     longitude (deg): 150.6644
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50+ m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3786_degS_and_150.6647_degE:
     latitude (deg): -32.3786
     longitude (deg): 150.6647
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50+ m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3789_degS_and_150.6633_degE:
     latitude (deg): -32.3789
     longitude (deg): 150.6633
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3789_degS_and_150.6642_degE:
     latitude (deg): -32.3789
     longitude (deg): 150.6642
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50+ m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3789_degS_and_150.6647_degE:
     latitude (deg): -32.3789
     longitude (deg): 150.6647
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50+ m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3792_degS_and_150.6639_degE:
     latitude (deg): -32.3792
     longitude (deg): 150.6639
     locality: Upper Hunter Valley; Myambat Explosives Depot, c. 250 m SE up slopes
       of escarpment.from road at SE end of depot area; above cliff line.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3792_degS_and_150.6644_degE:
     latitude (deg): -32.3792
     longitude (deg): 150.6644
     locality: Upper Hunter Valley; Myambat Explosives Depot, far SE end of property,
       then 150 m S along fire break and 50+ m up steep slope towards escarpment.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3803_degS_and_150.6622_degE:
     latitude (deg): -32.3803
     longitude (deg): 150.6622
     locality: Upper Hunter Valley; Myambat Explosives Depot, 350 m S from road at
       SE end of depot area.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.3808_degS_and_150.6619_degE:
     latitude (deg): -32.3808
     longitude (deg): 150.6619
     locality: Upper Hunter Valley; Myambat Explosives Depot, 350 m S from road at
       SE end of depot area.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-32.4_degS_and_118.3_degE:
     latitude (deg): -32.4
     longitude (deg): 118.3
     locality: 41 km from Narembeen along road to Kondinin, Bendering.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.4167_degS_and_119.1167_degE:
     latitude (deg): -32.4167
     longitude (deg): 119.1167
     locality: 23 km E of Hyden, 11 km SSW of King Rock.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.4333_degS_and_117.7167_degE:
     latitude (deg): -32.4333
     longitude (deg): 117.7167
     locality: 5 km SW of Stirling Range Drive, Cranbrook-Mt Barker intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.4333_degS_and_123.6167_degE:
     latitude (deg): -32.4333
     longitude (deg): 123.6167
     locality: 8 km S of Balladonia motel along road to Mt Ragged.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.4364_degS_and_152.1917_degE:
     latitude (deg): -32.4364
     longitude (deg): 152.1917
     locality: S of Bulahdelah, at the junction of the Pacific Highway and the Booral
       turnoff.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-32.4406_degS_and_116.3064_degE:
     latitude (deg): -32.4406
     longitude (deg): 116.3064
     locality: 24 km S of Jarrahdale turnoff on Albany Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.4444_degS_and_152.5183_degE:
     latitude (deg): -32.4444
     longitude (deg): 152.5183
     locality: Seal Rocks, near Myall Lakes.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-32.45_degS_and_116.8667_degE:
     latitude (deg): -32.45
     longitude (deg): 116.8667
     locality: Boyagin Rock Reserve, 4.0 km E of Beverley - Williams road, then 2.8
       km N along track into reserve.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.45_degS_and_118.5333_degE:
     latitude (deg): -32.45
     longitude (deg): 118.5333
     locality: 5 km N from the Kondinin-Karlgarin road on the Karlgarin Nature Reserve-Bendering
       road.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-32.45_degS_and_152.4_degE:
     latitude (deg): -32.45
     longitude (deg): 152.4
     locality: 8 miles 13 km from Seal Rocks, near Myall Lakes along Rutile road.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-32.4508_degS_and_118.5458_degE:
     latitude (deg): -32.4508
     longitude (deg): 118.5458
     locality: 5 km from the Kondinin-Hyden road along Kalgarin Hill road, c. 4 km
       direct N of Kalgarin Hill. Map ref. Hyden 2633.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-32.4667_degS_and_116.9_degE:
     latitude (deg): -32.4667
     longitude (deg): 116.9
     locality: Boyagin Rock Nature Reserve.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.5_degS_and_115.8_degE:
     latitude (deg): -32.5
     longitude (deg): 115.8
     locality: 12.6 km W of Dandalup, on Nambellup Road.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-32.5_degS_and_118.4333_degE:
     latitude (deg): -32.5
     longitude (deg): 118.4333
     locality: Kondinin.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.5164_degS_and_149.0917_degE:
     latitude (deg): -32.5164
     longitude (deg): 149.0917
     locality: Poggy Cottage, about 16 km ENE of Wellington on Poggy Cottage property
       (2.6 km SE along the Uungula Road from Gulgong Road).
-    collector: Carmen, P.
+    recorded by: Carmen, P.
   site_at_-32.5167_degS_and_149.1_degE:
     latitude (deg): -32.5167
     longitude (deg): 149.1
     locality: About 16 km ENE of Wellington on Bulbudgeree station (3.3 km SE of Uungula
       Rd from Gulgong Rd then 0.8 km E on track).
-    collector: Carmen, P.
+    recorded by: Carmen, P.
   site_at_-32.5367_degS_and_148.8875_degE:
     latitude (deg): -32.5367
     longitude (deg): 148.8875
     locality: Mt Arthur Reserve; 10 km W of Wellington on Bushranger Creek Road, then
       700 m direct ~N of Longs Row carpark. Quadrat 377.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-32.5372_degS_and_148.8861_degE:
     latitude (deg): -32.5372
     longitude (deg): 148.8861
     locality: Mt Arthur Reserve; 10 km W of Wellington on Bushranger Creek Road, then
       600 m direct N of Longs Row carpark. Quadrat 383-388.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-32.5414_degS_and_148.8842_degE:
     latitude (deg): -32.5414
     longitude (deg): 148.8842
     locality: Mt Arthur Reserve, 10 km W of Wellington on Bushranger Creek Road, 100
       m NW of Longs Row carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-32.5425_degS_and_148.8875_degE:
     latitude (deg): -32.5425
     longitude (deg): 148.8875
     locality: Mt Arthur Reserve, 10 km W of Wellington on Bushranger Creek Road, 100
       m E of Longs Row carpark. Quadrat 391.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-32.55_degS_and_136.7_degE:
     latitude (deg): -32.55
     longitude (deg): 136.7
     locality: Siam.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-32.5806_degS_and_116.5078_degE:
     latitude (deg): -32.5806
     longitude (deg): 116.5078
     locality: 300 m along dirt track on N side of Wandering Road, 6 km E of North
       Bannister.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-32.5833_degS_and_118.2333_degE:
     latitude (deg): -32.5833
     longitude (deg): 118.2333
     locality: 11 km S of Kondinin along road to Kulin.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.5833_degS_and_150.8667_degE:
     latitude (deg): -32.5833
     longitude (deg): 150.8667
     locality: Wollemi National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.5839_degS_and_116.4844_degE:
     latitude (deg): -32.5839
     longitude (deg): 116.4844
     locality: 3.4 km E of North Bannister on North Bannister - Wandering Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-32.6333_degS_and_121.4833_degE:
     latitude (deg): -32.6333
     longitude (deg): 121.4833
     locality: c. 55 km SSW of Norseman, 5 km from highway towards Peak Charles.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.6403_degS_and_142.1333_degE:
     latitude (deg): -32.6403
     longitude (deg): 142.1333
     locality: Adjacent to Lake Tandau, 57.9 km along road to Menindee, off Silvercity
       Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-32.65_degS_and_138.1_degE:
     latitude (deg): -32.65
     longitude (deg): 138.1
     locality: Near Wilmington, towards Alligator Gorge.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-32.65_degS_and_151.9667_degE:
     latitude (deg): -32.65
     longitude (deg): 151.9667
     locality: 1 km E of Karuah.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.65_degS_and_151.9833_degE:
     latitude (deg): -32.65
     longitude (deg): 151.9833
     locality: 2 miles 3.2 km NE of Karuah along Pacific Highway.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-32.6672_degS_and_151.0253_degE:
     latitude (deg): -32.6672
     longitude (deg): 151.0253
     locality: Western edge of The Putty Road, 1.8 km S of Bulga.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-32.6744_degS_and_118.1631_degE:
     latitude (deg): -32.6744
     longitude (deg): 118.1631
     locality: 0.8 km SE of Kulin on Lake Grace road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.6833_degS_and_149.1_degE:
     latitude (deg): -32.6833
     longitude (deg): 149.1
     locality: CULTIVATED Burrendong Arboretum.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-32.7_degS_and_141.9906_degE:
     latitude (deg): -32.7
     longitude (deg): 141.9906
     locality: 36.5 km along Menindee road, off Silvercity Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-32.7_degS_and_151.55_degE:
     latitude (deg): -32.7
     longitude (deg): 151.55
     locality: 35 km S of Singleton, Putty Road.
-    collector: D'Aubert 625, G.
+    recorded by: D'Aubert 625, G.
   site_at_-32.7011_degS_and_149.085_degE:
     latitude (deg): -32.7011
     longitude (deg): 149.085
     locality: 2.1 km E from the Burrendong Way and Tara Road intersection.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-32.7028_degS_and_149.1025_degE:
     latitude (deg): -32.7028
     longitude (deg): 149.1025
     locality: Burrendong Arboretum above the Western Beds.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-32.7167_degS_and_121.3333_degE:
     latitude (deg): -32.7167
     longitude (deg): 121.3333
     locality: 24 km SW of Norseman-Esperance highway along road to Peak Charles, 10
       km SW of Moir Rock.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.7167_degS_and_145.6333_degE:
     latitude (deg): -32.7167
     longitude (deg): 145.6333
     locality: Merrimerriwa Range, c. 42 km from Roto toward Gilgunnia.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-32.7217_degS_and_142.0333_degE:
     latitude (deg): -32.7217
     longitude (deg): 142.0333
     locality: 42.2 km along Menindee road, off Silvercity Highway.
-    collector: Bell, B.A.
+    recorded by: Bell, B.A.
   site_at_-32.7311_degS_and_134.8128_degE:
     latitude (deg): -32.7311
     longitude (deg): 134.8128
     locality: Poochera - Streaky Bay road, about 2 km W from Poochera.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.7333_degS_and_118.2833_degE:
     latitude (deg): -32.7333
     longitude (deg): 118.2833
     locality: c. 18.5 km ESE of Kulin near NE corner of Kulin Reserve.
-    collector: Hnatiuk, R.
+    recorded by: Hnatiuk, R.
   site_at_-32.75_degS_and_149.1333_degE:
     latitude (deg): -32.75
     longitude (deg): 149.1333
     locality: Nearby regeneration area at Burrendong Arboretum.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-32.75_degS_and_151.9833_degE:
     latitude (deg): -32.75
     longitude (deg): 151.9833
     locality: Corner of Lemon Tree Passage Road and Oyster Cove Road.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-32.7525_degS_and_121.365_degE:
     latitude (deg): -32.7525
     longitude (deg): 121.365
     locality: Peak Charles, 4 km along Kumarl, from Lake Grace to Norseman Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.7561_degS_and_121.445_degE:
     latitude (deg): -32.7561
     longitude (deg): 121.445
     locality: 11.5 km along Kumarl Road from Lake King Norseman Road, turn left up
       track for c. 1 km Edge of salt lake.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.7567_degS_and_121.2981_degE:
     latitude (deg): -32.7567
     longitude (deg): 121.2981
     locality: Peak Charles turn off on Lake King - Norseman Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.7667_degS_and_121.2833_degE:
     latitude (deg): -32.7667
     longitude (deg): 121.2833
     locality: 19 km NE of Peak Charles along road to Norseman.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-32.8333_degS_and_144.3_degE:
     latitude (deg): -32.8333
     longitude (deg): 144.3
     locality: 1 km N of Ivanhoe on Wilcannia road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.8392_degS_and_135.4658_degE:
     latitude (deg): -32.8392
     longitude (deg): 135.4658
     locality: Barns Road, 17 km N from junction with Edmonds Road, N of Pygery, Eyre
       Peninsula.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.8486_degS_and_144.1142_degE:
     latitude (deg): -32.8486
     longitude (deg): 144.1142
     locality: 3 km along road to Menindee Lakes from Ivanhoe-Wilcannia road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.85_degS_and_144.1167_degE:
     latitude (deg): -32.85
     longitude (deg): 144.1167
     locality: 21 km from Ivanhoe towards Menindee.
-    collector: Tyrrel, A.
+    recorded by: Tyrrel, A.
   site_at_-32.85_degS_and_150.2_degE:
     latitude (deg): -32.85
     longitude (deg): 150.2
     locality: Wollemi National Park, S side of Dunns Swamp, N end of Dunns Swamp Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-32.86_degS_and_117.6531_degE:
     latitude (deg): -32.86
     longitude (deg): 117.6531
     locality: 700 m E of second railway crossing between Toolibin & Hammersmith on
       Line Rd (S side of railway line).
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.87_degS_and_121.1647_degE:
     latitude (deg): -32.87
     longitude (deg): 121.1647
     locality: Peak Charles, about two thirds up the SE side.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.8731_degS_and_121.1431_degE:
     latitude (deg): -32.8731
     longitude (deg): 121.1431
     locality: Base of 402 m peak, NW of Peak Charles.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.8744_degS_and_121.1392_degE:
     latitude (deg): -32.8744
     longitude (deg): 121.1392
     locality: 402 m granite outcrop, c.1km NW of Peak Charles.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.8831_degS_and_121.1706_degE:
     latitude (deg): -32.8831
     longitude (deg): 121.1706
     locality: Peak Charles carpark.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.8833_degS_and_134.3833_degE:
     latitude (deg): -32.8833
     longitude (deg): 134.3833
     locality: c. 20 km SE of Streaky Bay on Flinders Highway.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-32.8833_degS_and_147.3167_degE:
     latitude (deg): -32.8833
     longitude (deg): 147.3167
     locality: Near Boxdale homestead. (Map ref 300624, Boona Mountain 1100,000).
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-32.8833_degS_and_150.3333_degE:
     latitude (deg): -32.8833
     longitude (deg): 150.3333
     locality: Coricudgy State Forest, Mt Darcy, c. 2 km E from summit on The Army
       Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-32.8867_degS_and_121.1647_degE:
     latitude (deg): -32.8867
     longitude (deg): 121.1647
     locality: Peak Charles, about two thirds of the way up the SE side.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.8997_degS_and_123.5056_degE:
     latitude (deg): -32.8997
     longitude (deg): 123.5056
     locality: 63.5 km from Balladonia towards Israelite Bay.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.9_degS_and_116.7_degE:
     latitude (deg): -32.9
     longitude (deg): 116.7
     locality: 22 km from Williams along Albany Highway towards Perth.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-32.9_degS_and_120.3833_degE:
     latitude (deg): -32.9
     longitude (deg): 120.3833
     locality: 74.4 km E from Lake King along Norseman road.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.9186_degS_and_144.7125_degE:
     latitude (deg): -32.9186
     longitude (deg): 144.7125
     locality: Trida Road, between Hillston and Ivanhoe, just W of turnoff to Conoble
       Station homestead.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-32.9333_degS_and_150.3667_degE:
     latitude (deg): -32.9333
     longitude (deg): 150.3667
     locality: 18 km SE along The Army Road towards Gospers Mountain.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-32.9356_degS_and_121.0408_degE:
     latitude (deg): -32.9356
     longitude (deg): 121.0408
     locality: Lake Sharpe, S end, along track.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-32.95_degS_and_121.4667_degE:
     latitude (deg): -32.95
     longitude (deg): 121.4667
     locality: 2 km N. of Salmon Gums, toward Norseman.
-    collector: Clements, M.A.
+    recorded by: Clements, M.A.
   site_at_-32.9636_degS_and_117.1003_degE:
     latitude (deg): -32.9636
     longitude (deg): 117.1003
     locality: 8 km E of Williams towards Narrogin on Williams - Kondinin Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-32.9833_degS_and_146.2_degE:
     latitude (deg): -32.9833
     longitude (deg): 146.2
     locality: Round Hill Nature Reserve.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-32_degS_and_115.5_degE:
     latitude (deg): -32.0
     longitude (deg): 115.5
     locality: Rottnest Island, 100 m W past Vlamingh Memorial on Heritage Walk.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-32_degS_and_115.7667_degE:
     latitude (deg): -32.0
     longitude (deg): 115.7667
     locality: At Devils Elbow, Peppermint Grove (western suburb of Perth, opposite
       McNeil St.). Above and W of Freshwater Bay.
-    collector: West, J.
+    recorded by: West, J.
   site_at_-32_degS_and_152.3833_degE:
     latitude (deg): -32.0
     longitude (deg): 152.3833
     locality: Kiwarrak State Forest, Taree
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.0042_degS_and_120.9428_degE:
     latitude (deg): -33.0042
     longitude (deg): 120.9428
     locality: 11.5 km WSW of Dog Rock, Peak Charles National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.0167_degS_and_134.1667_degE:
     latitude (deg): -33.0167
     longitude (deg): 134.1667
     locality: Sceale Bay, 1.1. km W of the settlement along the cliff top track.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-33.0167_degS_and_145.6833_degE:
     latitude (deg): -33.0167
     longitude (deg): 145.6833
     locality: 18 km E of Roto beside Parkes-Broken Hill railway line.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-33.0167_degS_and_151.1667_degE:
     latitude (deg): -33.0167
     longitude (deg): 151.1667
     locality: 15 km from Wollombi, Watagan Creek.
-    collector: Walton, S.
+    recorded by: Walton, S.
   site_at_-33.03_degS_and_150.1431_degE:
     latitude (deg): -33.03
     longitude (deg): 150.1431
     locality: Capertee valley; on the E N bank of the Capertee River, c. 2.1 km ~NW
       of the Glenowlan Road bridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-33.0328_degS_and_150.1483_degE:
     latitude (deg): -33.0328
     longitude (deg): 150.1483
     locality: Capertee valley; on the E bank of the Capertee River, c. 1.5 km ~NW
       of the Glenowlan Road bridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-33.0333_degS_and_145.05_degE:
     latitude (deg): -33.0333
     longitude (deg): 145.05
     locality: 3 km E of Trida towards Roto.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.0333_degS_and_145.3167_degE:
     latitude (deg): -33.0333
     longitude (deg): 145.3167
     locality: Ca 82 km direct NW of Hillston, 16 km by road from Trida towards Roto.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.0333_degS_and_145.5333_degE:
     latitude (deg): -33.0333
     longitude (deg): 145.5333
     locality: 6 km E of Roto along railway line.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.0372_degS_and_150.1594_degE:
     latitude (deg): -33.0372
     longitude (deg): 150.1594
     locality: Capertee valley; on the E bank of the Capertee River, c. 570 m ~N of
       the Glenowlan Road bridge.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-33.05_degS_and_136.55_degE:
     latitude (deg): -33.05
     longitude (deg): 136.55
     locality: 5.5 km N of the Eyre Highway at Barna Tank, then c. 4 km W on property
       of A. & T. Eatts.
-    collector: Eatts, A.; Eatts, T.
+    recorded by: Eatts, A.; Eatts, T.
   site_at_-33.05_degS_and_145.35_degE:
     latitude (deg): -33.05
     longitude (deg): 145.35
     locality: Ca 70 km direct NNW of Hillston, 35 km by road from Trida towards Roto,
       c. 100 m S of railway line.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.05_degS_and_145.8_degE:
     latitude (deg): -33.05
     longitude (deg): 145.8
     locality: Nombinnie Nature Reserve, 10 km from Roto towards Matakana.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-33.0581_degS_and_137.4758_degE:
     latitude (deg): -33.0581
     longitude (deg): 137.4758
     locality: 10 km W of Whyalla on Lincoln Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.0822_degS_and_121.6836_degE:
     latitude (deg): -33.0822
     longitude (deg): 121.6836
     locality: N shore of salt alek, 12 km S of Salmon Gums on highway, on W side of
       road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.0833_degS_and_120.0333_degE:
     latitude (deg): -33.0833
     longitude (deg): 120.0333
     locality: Ravensthorpe Caravan Park-just N of Ravensthorpe.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-33.0833_degS_and_151.45_degE:
     latitude (deg): -33.0833
     longitude (deg): 151.45
     locality: Cooranbong, just W. of Lake Macquarie.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-33.0919_degS_and_119.5233_degE:
     latitude (deg): -33.0919
     longitude (deg): 119.5233
     locality: 15 km from Lake King crossroads towards Newdegate.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.0925_degS_and_119.4747_degE:
     latitude (deg): -33.0925
     longitude (deg): 119.4747
     locality: 19.5 km from Lake King towards Newdegate.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.0944_degS_and_119.3481_degE:
     latitude (deg): -33.0944
     longitude (deg): 119.3481
     locality: 31 km from Lake King towards Newdegate.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.0992_degS_and_119.0175_degE:
     latitude (deg): -33.0992
     longitude (deg): 119.0175
     locality: 0.6 km from Newdegate P.O. towards Lake Grace.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.1_degS_and_121.1667_degE:
     latitude (deg): -33.1
     longitude (deg): 121.1667
     locality: 14 km along Fields Road from Rolland Road, ca 53 km WNW of Grass Patch.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-33.1033_degS_and_118.7617_degE:
     latitude (deg): -33.1033
     longitude (deg): 118.7617
     locality: 24.5 km from Newdegate P.O. towards Lake Grace.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.1114_degS_and_118.3522_degE:
     latitude (deg): -33.1114
     longitude (deg): 118.3522
     locality: c. 10 km along road from Lake Grace towards Dumbleyung at Lake Grace
       Lookout.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.1119_degS_and_120.1319_degE:
     latitude (deg): -33.1119
     longitude (deg): 120.1319
     locality: 112 km NW of Cascades along Cascades to Lake King Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.1158_degS_and_136.6203_degE:
     latitude (deg): -33.1158
     longitude (deg): 136.6203
     locality: 20 km from Kimba towards Iron Knob.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.1167_degS_and_118.1667_degE:
     latitude (deg): -33.1167
     longitude (deg): 118.1667
     locality: Tarin Rock Nature Reserve, 28 km W of Lake Grace on the Dumbleyung road.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-33.1167_degS_and_150.2667_degE:
     latitude (deg): -33.1167
     longitude (deg): 150.2667
     locality: About 40 km N of Lithgow. 1.5 km SW of Glen Davis, in Green Gully.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.1333_degS_and_137.1833_degE:
     latitude (deg): -33.1333
     longitude (deg): 137.1833
     locality: 72.6km from Kimba toward Whyalla, in Sinclairs Pass.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.1333_degS_and_150.0333_degE:
     latitude (deg): -33.1333
     longitude (deg): 150.0333
     locality: 3.4 km E along Capertee to Glen Davis road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.175_degS_and_136.5667_degE:
     latitude (deg): -33.175
     longitude (deg): 136.5667
     locality: Curtinye Hill, c. 7.5 km ESE of Kimba.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-33.2167_degS_and_123.45_degE:
     latitude (deg): -33.2167
     longitude (deg): 123.45
     locality: 100 km S of Balladonia motel along road to Mount Ragged, Juranda Rock
       Hole.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.2167_degS_and_145.1_degE:
     latitude (deg): -33.2167
     longitude (deg): 145.1
     locality: Willandra National Park along Merton Motor Trail to SW; c. 5 km from
       shearers quarters.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.2167_degS_and_150.9833_degE:
     latitude (deg): -33.2167
     longitude (deg): 150.9833
     locality: 2.6 ml. 4 km from Fernances toward St. Albans (close to creek).
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-33.2169_degS_and_120.6619_degE:
     latitude (deg): -33.2169
     longitude (deg): 120.6619
     locality: 78 km NW of Cascades along Cascades to Lake King Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.2236_degS_and_123.1219_degE:
     latitude (deg): -33.2236
     longitude (deg): 123.1219
     locality: Near NW base of Mt Buraminya.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.2239_degS_and_118.8397_degE:
     latitude (deg): -33.2239
     longitude (deg): 118.8397
     locality: 8 km along Burngup Road from Newdegate Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.2253_degS_and_123.1211_degE:
     latitude (deg): -33.2253
     longitude (deg): 123.1211
     locality: Mt Buraminya.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.2306_degS_and_119.7247_degE:
     latitude (deg): -33.2306
     longitude (deg): 119.7247
     locality: 17 km S of Lake King toward Ravensthorpe.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.25_degS_and_150.1_degE:
     latitude (deg): -33.25
     longitude (deg): 150.1
     locality: c. 25 km NNW of Lithgow, Wolgan State Forest, Wolgan Gap, road to Cape
       Horn.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.2733_degS_and_120.8_degE:
     latitude (deg): -33.2733
     longitude (deg): 120.8
     locality: Cascades, 113 km NW of West Point Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.2833_degS_and_119.6667_degE:
     latitude (deg): -33.2833
     longitude (deg): 119.6667
     locality: Ravensthorpe area, 7 km W of Ravensthorpe - Lake King road, 20 km S
       of Lake King.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.2833_degS_and_122.1167_degE:
     latitude (deg): -33.2833
     longitude (deg): 122.1167
     locality: Mount Ridley (foot).
-    collector: ANBG
+    recorded by: ANBG
   site_at_-33.2936_degS_and_118.8767_degE:
     latitude (deg): -33.2936
     longitude (deg): 118.8767
     locality: c. 19 km S on Newdegate Road from Old Ravensthorpe Road towards Pingrup.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.2978_degS_and_117.3239_degE:
     latitude (deg): -33.2978
     longitude (deg): 117.3239
     locality: 1.7 km from turnoff to Narrogin, from Wagin towards Narrogin.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.3_degS_and_146.4_degE:
     latitude (deg): -33.3
     longitude (deg): 146.4
     locality: Lake Cargelligo to Hillston, 2 miles 3 km from Hillston.
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-33.3167_degS_and_122.4333_degE:
     latitude (deg): -33.3167
     longitude (deg): 122.4333
     locality: near Mt Ney; 10 km S from campsite.
-    collector: Clements, M.A.
+    recorded by: Clements, M.A.
   site_at_-33.3167_degS_and_149_degE:
     latitude (deg): -33.3167
     longitude (deg): 149.0
     locality: Warrumbungle Ranges.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.3225_degS_and_149.4414_degE:
     latitude (deg): -33.3225
     longitude (deg): 149.4414
     locality: Bathurst district; Fremantle Road, c. 12 km NW of Eglinton which is
       c. 6.5 km NW of Bathurst.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-33.3283_degS_and_150.105_degE:
     latitude (deg): -33.3283
     longitude (deg): 150.105
     locality: Ben Bullen State Forest, beside Wolgan Gap Fire Trail, 300 m from its
       junction with the Lidsdale to Newnes Road.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-33.3439_degS_and_151.4156_degE:
     latitude (deg): -33.3439
     longitude (deg): 151.4156
     locality: Glenning Valley, NNE of Gosford, northern end of Rutherford Drive in
       council conservation reserve. Population either side of foot track ascending
       into reserve.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.3594_degS_and_116.6219_degE:
     latitude (deg): -33.3594
     longitude (deg): 116.6219
     locality: 12.5 km W of Darken towards Collie, on Coalfields Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.3719_degS_and_140.8611_degE:
     latitude (deg): -33.3719
     longitude (deg): 140.8611
     locality: Region 9-Murray. Danggali Conservation Park. 3.5km NE of Tarawi.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.3753_degS_and_151.3558_degE:
     latitude (deg): -33.3753
     longitude (deg): 151.3558
     locality: Niagara Park; Alan Road Reserve; along track from northern end near
       culvert.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.3761_degS_and_151.3472_degE:
     latitude (deg): -33.3761
     longitude (deg): 151.3472
     locality: Niagara Park; 600 m SE from end of Glen Road, at entrance to Council
       Conservation area.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.3781_degS_and_151.2469_degE:
     latitude (deg): -33.3781
     longitude (deg): 151.2469
     locality: NE of Gosford. Side of Brieses Trail below Mooney Mooney Dam in creekline
       and extending downstream 450 m along both banks.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.4008_degS_and_119.9108_degE:
     latitude (deg): -33.4008
     longitude (deg): 119.9108
     locality: 77km N of Ravensthorpe toward Lake King.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.4139_degS_and_150.2806_degE:
     latitude (deg): -33.4139
     longitude (deg): 150.2806
     locality: Bunboori Ck via Waratah Ridge. Blue Mountains Natl Park.
-    collector: Hind, P.
+    recorded by: Hind, P.
   site_at_-33.4267_degS_and_119.9867_degE:
     latitude (deg): -33.4267
     longitude (deg): 119.9867
     locality: N base of Mt Short.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.4306_degS_and_150.8283_degE:
     latitude (deg): -33.4306
     longitude (deg): 150.8283
     locality: c. 24 km direct NNW of Richmond, Colo River, c. 800 m E along Lower
       Colo Road from its junction with The Putty Road.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.4339_degS_and_151.2789_degE:
     latitude (deg): -33.4339
     longitude (deg): 151.2789
     locality: Brisbane Water National Park, W of Gosford. Girrakool Picnic Area. Access
       off Quarry Road, Somersby. Densest section of population is 300 m SE of car
       park, across creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.4358_degS_and_150.2253_degE:
     latitude (deg): -33.4358
     longitude (deg): 150.2253
     locality: Newnes State Forest, Clarence Road, 3 km N of junction with Mid-Western
       Highway.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-33.4392_degS_and_121.7931_degE:
     latitude (deg): -33.4392
     longitude (deg): 121.7931
     locality: c. 7 km direct E from Scadden, junction of Lagoon and Kendall Roads.
       (Map ref. Scadden 3231)
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.4444_degS_and_123.4419_degE:
     latitude (deg): -33.4444
     longitude (deg): 123.4419
     locality: 2.1 km from Mt Ragged carpark towards Balladonia - Israelite Bay road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.4458_degS_and_123.4656_degE:
     latitude (deg): -33.4458
     longitude (deg): 123.4656
     locality: Base of Mt Ragged, NW side, along track to summit.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.4467_degS_and_123.4725_degE:
     latitude (deg): -33.4467
     longitude (deg): 123.4725
     locality: Upper slopes of Mt Ragged.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.4467_degS_and_123.4753_degE:
     latitude (deg): -33.4467
     longitude (deg): 123.4753
     locality: Saddle at base of Tower Peak, Mt Ragged.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.4475_degS_and_123.4675_degE:
     latitude (deg): -33.4475
     longitude (deg): 123.4675
     locality: Mid track on Tower Peak, Mount Ragged.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.45_degS_and_121.75_degE:
     latitude (deg): -33.45
     longitude (deg): 121.75
     locality: 10 km E of Scaddan on Norwood Road (off Esperance Highway).
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.45_degS_and_123.4667_degE:
     latitude (deg): -33.45
     longitude (deg): 123.4667
     locality: Mt Ragged; summit.
-    collector: Clements, M.A.
+    recorded by: Clements, M.A.
   site_at_-33.4558_degS_and_150.4725_degE:
     latitude (deg): -33.4558
     longitude (deg): 150.4725
     locality: Blue Mountains, Tesselate Hill, 4 km (direct) NNE of southern highest
       point of Mt Irvine (897 m), N end of ridge.
-    collector: Whalen, A.J.
+    recorded by: Whalen, A.J.
   site_at_-33.4589_degS_and_119.9639_degE:
     latitude (deg): -33.4589
     longitude (deg): 119.9639
     locality: Junction of Lake King to Ravensthorpe Road & Mt Short Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.4603_degS_and_122.1403_degE:
     latitude (deg): -33.4603
     longitude (deg): 122.1403
     locality: Ca 35 km direct E of Scaddan, Wittenoom Hills Nature Reserve, at Mt
       Burdett.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.4667_degS_and_123.45_degE:
     latitude (deg): -33.4667
     longitude (deg): 123.45
     locality: Mt Ragged, foot track near camp site.
-    collector: Taylor, J.M.
+    recorded by: Taylor, J.M.
   site_at_-33.4667_degS_and_123.4667_degE:
     latitude (deg): -33.4667
     longitude (deg): 123.4667
     locality: Mt Ragged Range, 2.5 km S of Tower Peak.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.4667_degS_and_123.4833_degE:
     latitude (deg): -33.4667
     longitude (deg): 123.4833
     locality: SW slopes of Mt Ragged 1/2 way up.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.4667_degS_and_136.2_degE:
     latitude (deg): -33.4667
     longitude (deg): 136.2
     locality: Darke Peak; near rubbish tip.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.4667_degS_and_145.5_degE:
     latitude (deg): -33.4667
     longitude (deg): 145.5
     locality: 2 km from Hillston on road towards Roto.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-33.475_degS_and_151.2658_degE:
     latitude (deg): -33.475
     longitude (deg): 151.2658
     locality: Brisbane Water National Park; Myron Brook. Population extends ~300 m
       downstream of Great North Walk crossing on both banks.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.5_degS_and_123.4667_degE:
     latitude (deg): -33.5
     longitude (deg): 123.4667
     locality: 1.5 km S of Mt Ragged (Tower Peak) range along road to Israelite Bay.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.5_degS_and_150.2833_degE:
     latitude (deg): -33.5
     longitude (deg): 150.2833
     locality: Great Western Highway, c. 1 km ESE of Clarence, 50 m along track SW
       side of highway.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.5078_degS_and_151.4189_degE:
     latitude (deg): -33.5078
     longitude (deg): 151.4189
     locality: Bouddii National Park, 600 m along the 3rd fire trail from the end of
       Beachview Esplanade, MacMasters Beach.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-33.5167_degS_and_118.15_degE:
     latitude (deg): -33.5167
     longitude (deg): 118.15
     locality: Stirling district; 3 km N of Nyabing.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.5242_degS_and_141.2397_degE:
     latitude (deg): -33.5242
     longitude (deg): 141.2397
     locality: 72 km NE of Renmark, on Springwood Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.5333_degS_and_115.0167_degE:
     latitude (deg): -33.5333
     longitude (deg): 115.0167
     locality: 2.5 km SE of Cape Naturaliste on road to Eagle Bay (0.9 km on Eagle
       Bay road from main Cape Naturaliste road.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-33.5342_degS_and_150.42_degE:
     latitude (deg): -33.5342
     longitude (deg): 150.42
     locality: Blue Mountains, 100 m from Bells Line of Road along Tomah Spur track,
       1 km (direct) N of Tomah Trig.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.55_degS_and_115.05_degE:
     latitude (deg): -33.55
     longitude (deg): 115.05
     locality: Eagle Bay, near Cape Naturaliste.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-33.55_degS_and_135.55_degE:
     latitude (deg): -33.55
     longitude (deg): 135.55
     locality: c. 21 km from Lock toward Elliston.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.55_degS_and_150.4_degE:
     latitude (deg): -33.55
     longitude (deg): 150.4
     locality: Blue Mountains National Park, Bells Line of Road, Haystack Ridge, 1.5
       km NE of Mt. Charles.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.55_degS_and_151.3_degE:
     latitude (deg): -33.55
     longitude (deg): 151.3
     locality: Gosford Brisbane Water National Park. Patonga on road to Tony Doyle
       Lookout 500 m from car park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-33.5528_degS_and_123.5364_degE:
     latitude (deg): -33.5528
     longitude (deg): 123.5364
     locality: 14.7 km along track to Israelite Bay from intersection with Balladonia-Esperance
       road (which is just past the Mt Ragged turnoff).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.5667_degS_and_145.5667_degE:
     latitude (deg): -33.5667
     longitude (deg): 145.5667
     locality: 10 km from Hillston along road towards Monia Gap.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-33.5756_degS_and_118.7825_degE:
     latitude (deg): -33.5756
     longitude (deg): 118.7825
     locality: c. 42 km N along Needilup Road from Jerramungup Road, at intersection
       with Townsend Road, NE of Ongerup.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.5833_degS_and_120.1333_degE:
     latitude (deg): -33.5833
     longitude (deg): 120.1333
     locality: Ravensthorpe Range, 8 km E of Ravensthorpe.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.5833_degS_and_150.8833_degE:
     latitude (deg): -33.5833
     longitude (deg): 150.8833
     locality: Intersection of the Old Stock Route Road and Dural Road (on the E side
       of Dural Road), in proposed Longneck Lagoon National Park.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-33.5833_degS_and_151.1667_degE:
     latitude (deg): -33.5833
     longitude (deg): 151.1667
     locality: Cowan Quarry (disused), c. 1 km N of Cowan, Sydney. Dirt road leading
       down to quarry coming off Pacific Highway.
-    collector: Whalen, A.J.
+    recorded by: Whalen, A.J.
   site_at_-33.5947_degS_and_123.5889_degE:
     latitude (deg): -33.5947
     longitude (deg): 123.5889
     locality: 21.5 km along track to Israelite Bay from intersection with Balladonia-Esperance
       road (which is just past the Mt Ragged turnoff).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.5972_degS_and_150.3358_degE:
     latitude (deg): -33.5972
     longitude (deg): 150.3358
     locality: Blue Mountains National Park, Blackheath, end of Anvil Ridge at Anvil
       Rock.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.5981_degS_and_120.3458_degE:
     latitude (deg): -33.5981
     longitude (deg): 120.3458
     locality: c. 30 km E of Ravensthorpe, at parking bay.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.5992_degS_and_120.1781_degE:
     latitude (deg): -33.5992
     longitude (deg): 120.1781
     locality: 13.5 km E of Ravensthorpe, near turnoff to Mt Desmond.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.6031_degS_and_123.6233_degE:
     latitude (deg): -33.6031
     longitude (deg): 123.6233
     locality: 25 km along track to Israelite Bay from intersection with Balladonia-Esperance
       road (which is just past the Mt Ragged turnoff).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.6092_degS_and_120.1692_degE:
     latitude (deg): -33.6092
     longitude (deg): 120.1692
     locality: 1.4 km along Elverdton Road from South Coast Highway (turnoff c. 14
       km E of Ravensthorpe).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.6147_degS_and_120.1511_degE:
     latitude (deg): -33.6147
     longitude (deg): 120.1511
     locality: Mount Desmond lookout, near Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.6167_degS_and_120.1333_degE:
     latitude (deg): -33.6167
     longitude (deg): 120.1333
     locality: Ravensthorpe Range, 1.5 km SW of Mt Desmond.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.6167_degS_and_120.15_degE:
     latitude (deg): -33.6167
     longitude (deg): 120.15
     locality: Ravensthorpe Range, Mt Desmond, 11 km SE of Ravensthorpe.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.6167_degS_and_123.8333_degE:
     latitude (deg): -33.6167
     longitude (deg): 123.8333
     locality: 3 km W of Israelite Bay ruins.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.6222_degS_and_120.1464_degE:
     latitude (deg): -33.6222
     longitude (deg): 120.1464
     locality: 0.5km on Elvardton Road from Hopetoun Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.6333_degS_and_119.8833_degE:
     latitude (deg): -33.6333
     longitude (deg): 119.8833
     locality: Phillips River crossing on Ravensthorpe/ Jerramungup road.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-33.6333_degS_and_123.8167_degE:
     latitude (deg): -33.6333
     longitude (deg): 123.8167
     locality: 6 km SW of Israelite Bay ruins.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.6333_degS_and_150.3333_degE:
     latitude (deg): -33.6333
     longitude (deg): 150.3333
     locality: Govetts Leap Lookout, c. 75 m along track down into Grose Valley.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-33.6397_degS_and_150.2736_degE:
     latitude (deg): -33.6397
     longitude (deg): 150.2736
     locality: Blue Mountains National Park. Blackheath. Centennial Glen walking trail,
       50 m along from NW entrance of this looping trail. Just off Centennial Glen
       Rd, just off Shipley Rd.
-    collector: Whalen, A.J.
+    recorded by: Whalen, A.J.
   site_at_-33.6486_degS_and_123.7092_degE:
     latitude (deg): -33.6486
     longitude (deg): 123.7092
     locality: 34 km along track to Israelite Bay from intersection with Balladonia-Esperance
       road (which is just past the Mt Ragged turnoff).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.65_degS_and_120.15_degE:
     latitude (deg): -33.65
     longitude (deg): 120.15
     locality: Ravensthorpe-Hopetoun road, 13 km S of Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.65_degS_and_137.9333_degE:
     latitude (deg): -33.65
     longitude (deg): 137.9333
     locality: c. 22.6 km from Alford toward Port Broughton, near homestead.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.6525_degS_and_123.7689_degE:
     latitude (deg): -33.6525
     longitude (deg): 123.7689
     locality: 40 km along track to Israelite Bay from intersection with Balladonia-Esperance
       road (which is just past the Mt Ragged turnoff).
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.6536_degS_and_123.7792_degE:
     latitude (deg): -33.6536
     longitude (deg): 123.7792
     locality: 8.6 km from Israelite Bay Cemetary to Esperance, on Fisheries Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.6561_degS_and_149.0669_degE:
     latitude (deg): -33.6561
     longitude (deg): 149.0669
     locality: Railway land c. 2 km S of Mandurama, next to Olympic Highway Mid Western
       Highway.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-33.6578_degS_and_120.5036_degE:
     latitude (deg): -33.6578
     longitude (deg): 120.5036
     locality: Parking bay, 136 km from Esperance towards Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.6639_degS_and_121.3208_degE:
     latitude (deg): -33.6639
     longitude (deg): 121.3208
     locality: 1 km E along Ashdale Road from intersection with Sears Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.6667_degS_and_120_degE:
     latitude (deg): -33.6667
     longitude (deg): 120.0
     locality: Ravensthorpe, 12.2 km S along Moir Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.6667_degS_and_138.9333_degE:
     latitude (deg): -33.6667
     longitude (deg): 138.9333
     locality: Burra.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-33.6667_degS_and_151.25_degE:
     latitude (deg): -33.6667
     longitude (deg): 151.25
     locality: Kuring-gai Chase National Park, bridge at McCarris Creek, 5 km along
       McCarrs Creek Road from Mona Vale Road.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-33.6672_degS_and_151.2531_degE:
     latitude (deg): -33.6672
     longitude (deg): 151.2531
     locality: Sydney area, Kuring-gai Chase, near McCarrs Creek.
-    collector: Muffet, B.
+    recorded by: Muffet, B.
   site_at_-33.6722_degS_and_120.6708_degE:
     latitude (deg): -33.6722
     longitude (deg): 120.6708
     locality: 200 m E of the Oldfield River crossing, Esperance-Ravensthorpe road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.68_degS_and_120.8019_degE:
     latitude (deg): -33.68
     longitude (deg): 120.8019
     locality: 108.2 km from Esperance towards Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.6833_degS_and_119.9833_degE:
     latitude (deg): -33.6833
     longitude (deg): 119.9833
     locality: 16 km S of Ravensthorpe along road to Hamersley River estuary.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.6833_degS_and_150.6_degE:
     latitude (deg): -33.6833
     longitude (deg): 150.6
     locality: Yellow Rock Lookout Rd, Springwood, Blue Mtns.
-    collector: Muffet, B.
+    recorded by: Muffet, B.
   site_at_-33.7_degS_and_119.9667_degE:
     latitude (deg): -33.7
     longitude (deg): 119.9667
     locality: Ravensthorpe area, 16 km S of Ravensthorpe along road to Hamersley River
       estuary.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.7_degS_and_120.0833_degE:
     latitude (deg): -33.7
     longitude (deg): 120.0833
     locality: Ravensthorpe-Hopetoun road, 12.8 km S of Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7_degS_and_120.8667_degE:
     latitude (deg): -33.7
     longitude (deg): 120.8667
     locality: 106 km W of Esperance at Munglinup River crossing.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.7_degS_and_150.3167_degE:
     latitude (deg): -33.7
     longitude (deg): 150.3167
     locality: Blue Mountains National Park, Olympian Rock, Olympian Place, Leura.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7_degS_and_150.4333_degE:
     latitude (deg): -33.7
     longitude (deg): 150.4333
     locality: Blue Mountains National Park, c.70 m past Scenic Railway, Cliff Walk
       to Echo Point, Katoomba.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7_degS_and_150.5_degE:
     latitude (deg): -33.7
     longitude (deg): 150.5
     locality: Linden Ridge, c. 3 km along Glossop Road-Linden Ridge Fire Trail from
       turnoff at Great Western Highway, c. 2 km NNW of LInden.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-33.7_degS_and_150.5833_degE:
     latitude (deg): -33.7
     longitude (deg): 150.5833
     locality: Valley Heights, gully reserve S of railway station, c. 750 m from station.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.7_degS_and_150.75_degE:
     latitude (deg): -33.7
     longitude (deg): 150.75
     locality: 5.9 km S of Richmond Rd along The Northern Rd. Castlereagh State Forest.
       Central coast.
-    collector: Hind, P.
+    recorded by: Hind, P.
   site_at_-33.7017_degS_and_120.1883_degE:
     latitude (deg): -33.7017
     longitude (deg): 120.1883
     locality: Junction of Hopetoun Road and Jerdacuttup road, south of Ravensthorpe.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7019_degS_and_120.1881_degE:
     latitude (deg): -33.7019
     longitude (deg): 120.1881
     locality: Intersection of Hopetoun Road & Jerdacuttup Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7078_degS_and_123.5733_degE:
     latitude (deg): -33.7078
     longitude (deg): 123.5733
     locality: 30 km W of Israelite Bay Cemetary, towards Esperance, on Fisheries Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7081_degS_and_120.865_degE:
     latitude (deg): -33.7081
     longitude (deg): 120.865
     locality: 500 m W of the Munglinup River crossing, between Esperance and Ravensthorpe.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7094_degS_and_119.5908_degE:
     latitude (deg): -33.7094
     longitude (deg): 119.5908
     locality: 66.5 km E of Jerramungup towards Ravensthorpe, on South Coast Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7167_degS_and_120.8833_degE:
     latitude (deg): -33.7167
     longitude (deg): 120.8833
     locality: Esperance-Ravensthorpe highway, Munglinup River crossing.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7167_degS_and_150.3167_degE:
     latitude (deg): -33.7167
     longitude (deg): 150.3167
     locality: Katoomba, Scenic Railway.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7167_degS_and_150.3667_degE:
     latitude (deg): -33.7167
     longitude (deg): 150.3667
     locality: National Pass Track, above Wentworth Falls, top of the first drop of
       Wentworth Falls, c. 1.5 km S of Wentworth Falls.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-33.7167_degS_and_150.3833_degE:
     latitude (deg): -33.7167
     longitude (deg): 150.3833
     locality: Wentworth Falls, Little Switzerland Track, 100 m NW of junction with
       Horden Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.7183_degS_and_123.4075_degE:
     latitude (deg): -33.7183
     longitude (deg): 123.4075
     locality: 22 km E from Israelite Bay, towards Esperance.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7314_degS_and_150.3708_degE:
     latitude (deg): -33.7314
     longitude (deg): 150.3708
     locality: Wentworth Falls cliff walk, 300 m down S side.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7333_degS_and_121.25_degE:
     latitude (deg): -33.7333
     longitude (deg): 121.25
     locality: Lort River crossing, ca 70 km W of Esperance along road to Ravensthrope.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.7333_degS_and_122.2667_degE:
     latitude (deg): -33.7333
     longitude (deg): 122.2667
     locality: 43 km from Esperance along road to Israelite Bay, 8 km NE of Colinup
       Swamp.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.7333_degS_and_123.0333_degE:
     latitude (deg): -33.7333
     longitude (deg): 123.0333
     locality: Boyatup Hill.
-    collector: Clements, M.A.
+    recorded by: Clements, M.A.
   site_at_-33.7333_degS_and_149.6667_degE:
     latitude (deg): -33.7333
     longitude (deg): 149.6667
     locality: Essington State Forest, tributary of Chain of Ponds Creek, 17 km W of
       Oberon.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-33.7431_degS_and_150.3133_degE:
     latitude (deg): -33.7431
     longitude (deg): 150.3133
     locality: Across Wentworth Falls and 300 m down cliff walk.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7436_degS_and_150.315_degE:
     latitude (deg): -33.7436
     longitude (deg): 150.315
     locality: Katoomba, between bases of Giant Staircase and Echo Point.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7444_degS_and_121.2672_degE:
     latitude (deg): -33.7444
     longitude (deg): 121.2672
     locality: 62.5 km from Esperance on South Coast Highway, near Lort River crossing.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.745_degS_and_121.2536_degE:
     latitude (deg): -33.745
     longitude (deg): 121.2536
     locality: 100 m W of the Lort River crossing, 64 km along South Coast Highway
       from Esperance towards Raventhorpe.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7458_degS_and_122.9986_degE:
     latitude (deg): -33.7458
     longitude (deg): 122.9986
     locality: Esperance - Israelite Bay road, just before entrance to Cape Arid National
       Park.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.75_degS_and_119.45_degE:
     latitude (deg): -33.75
     longitude (deg): 119.45
     locality: Fitzgerald Primary School.
-    collector: Smart, R.C.
+    recorded by: Smart, R.C.
   site_at_-33.75_degS_and_122.3333_degE:
     latitude (deg): -33.75
     longitude (deg): 122.3333
     locality: 145 km from Israelite Bay along road to Esperance.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.75_degS_and_122.65_degE:
     latitude (deg): -33.75
     longitude (deg): 122.65
     locality: 116 km from Israelite Bay along road to Esperance.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.7542_degS_and_123.2592_degE:
     latitude (deg): -33.7542
     longitude (deg): 123.2592
     locality: Cape Arid National Park, 1.5 km from farmland at border of park towards
       Israelite Bay.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7569_degS_and_123.3028_degE:
     latitude (deg): -33.7569
     longitude (deg): 123.3028
     locality: 57 km W of Israelite Bay Cemetary towards Esperance, on Fisheries Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7581_degS_and_116.8753_degE:
     latitude (deg): -33.7581
     longitude (deg): 116.8753
     locality: 4 km along Round Pool Rd from Riverdale Rd, N of Muradup.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7581_degS_and_120.0006_degE:
     latitude (deg): -33.7581
     longitude (deg): 120.0006
     locality: Near No Tree Hill, John Forrest Road, Fitzgerald River National Park.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7614_degS_and_121.1483_degE:
     latitude (deg): -33.7614
     longitude (deg): 121.1483
     locality: 100 m W of Young River crossing, South Coast Highway.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.7633_degS_and_140.3492_degE:
     latitude (deg): -33.7633
     longitude (deg): 140.3492
     locality: Claypan on Gluepot-Calperum fence line.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7689_degS_and_118.5225_degE:
     latitude (deg): -33.7689
     longitude (deg): 118.5225
     locality: 5.2 km SE along 2nd Rabbit Fence Road towards Jerramungup from Ongerup-Pingrup
       road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7719_degS_and_120.0339_degE:
     latitude (deg): -33.7719
     longitude (deg): 120.0339
     locality: Near No Tree Hill, John Forrest Road, Fitzgerald River National Park.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.7722_degS_and_140.5356_degE:
     latitude (deg): -33.7722
     longitude (deg): 140.5356
     locality: Bookmark Biosphere Reserve, Calperum, c. 3 km direct S of Hideaway Hut.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-33.7783_degS_and_118.5408_degE:
     latitude (deg): -33.7783
     longitude (deg): 118.5408
     locality: 7.2 km SE along 2nd Rabbit Fence Road towards Jerramungup, from Ongarup
       - Pingrup Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.7833_degS_and_142.9_degE:
     latitude (deg): -33.7833
     longitude (deg): 142.9
     locality: 12 km from Mungo Homestead (Mungo National Park) towards Mildura.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.7833_degS_and_150.4_degE:
     latitude (deg): -33.7833
     longitude (deg): 150.4
     locality: Kings Tableland.
-    collector: Beesley, P.
+    recorded by: Beesley, P.
   site_at_-33.8_degS_and_121.9667_degE:
     latitude (deg): -33.8
     longitude (deg): 121.9667
     locality: Great Coastal Drive, c. 10 km N of Esperance.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.8042_degS_and_120.0692_degE:
     latitude (deg): -33.8042
     longitude (deg): 120.0692
     locality: 14 km along John Forrest Road (E side) off Ravensthorpe - Hopetoun Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.8047_degS_and_119.3264_degE:
     latitude (deg): -33.8047
     longitude (deg): 119.3264
     locality: 41.5 km E of Jerramungup at intersection of South Coast Highway and
       Mallee Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.8153_degS_and_119.3072_degE:
     latitude (deg): -33.8153
     longitude (deg): 119.3072
     locality: On South Coast Highway, 4.8 km E of Fitzgerald River crossing.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.8167_degS_and_122.2333_degE:
     latitude (deg): -33.8167
     longitude (deg): 122.2333
     locality: 34 km E of Esperance toward Cape Arid.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-33.8167_degS_and_151.2_degE:
     latitude (deg): -33.8167
     longitude (deg): 151.2
     locality: Sydney Harbour National Park, North Quarantine Station at the Y junction,
       300 m from the boom gate.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-33.8269_degS_and_121.2947_degE:
     latitude (deg): -33.8269
     longitude (deg): 121.2947
     locality: 9 km S along Farrells Road to Quagi Beach.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.8297_degS_and_119.2597_degE:
     latitude (deg): -33.8297
     longitude (deg): 119.2597
     locality: Fitzgerald River crossing, Ravensthorpe-Jerramungup road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.8328_degS_and_140.3111_degE:
     latitude (deg): -33.8328
     longitude (deg): 140.3111
     locality: 2.4 km S of Claypan on Gluepot-Calperum fence line.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.8406_degS_and_117.02_degE:
     latitude (deg): -33.8406
     longitude (deg): 117.02
     locality: 13km W of Kojonup towards Boyup Brook.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.8469_degS_and_118.4775_degE:
     latitude (deg): -33.8469
     longitude (deg): 118.4775
     locality: 12 km N towards Pingrup along Ongerup-Pingrup road from Jerramungup
       Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.8489_degS_and_120.0925_degE:
     latitude (deg): -33.8489
     longitude (deg): 120.0925
     locality: 8.6 km along John Forest Road, off Hopetoun Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.85_degS_and_120.1667_degE:
     latitude (deg): -33.85
     longitude (deg): 120.1667
     locality: 13.8 km N of Hopetoun, 35 km SSE of Ravensthorpe.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-33.85_degS_and_121.8833_degE:
     latitude (deg): -33.85
     longitude (deg): 121.8833
     locality: Esperance.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-33.8636_degS_and_116.91_degE:
     latitude (deg): -33.8636
     longitude (deg): 116.91
     locality: 24.5 km W of Kojonup towards Boyup Brook, on Boyup Brook - Kojonup Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.8667_degS_and_143.7333_degE:
     latitude (deg): -33.8667
     longitude (deg): 143.7333
     locality: Hatfield near hotel.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.8667_degS_and_151.2667_degE:
     latitude (deg): -33.8667
     longitude (deg): 151.2667
     locality: Sydney Harbour National Park, Neilsen Park, c. 200 m SE from start of
       foreshore track.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-33.8725_degS_and_121.8922_degE:
     latitude (deg): -33.8725
     longitude (deg): 121.8922
     locality: Esperance, Rotary Lookout Trail, S and W slopes.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-33.88_degS_and_119.1186_degE:
     latitude (deg): -33.88
     longitude (deg): 119.1186
     locality: 14 km W of Fitzgerald River bridge, towards Jerramungup, on South Coast
       Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.8833_degS_and_144.6333_degE:
     latitude (deg): -33.8833
     longitude (deg): 144.6333
     locality: Near Booligal Woorandara Station (property of K. Turner) behind homestead
       near windmill.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.8833_degS_and_146.1333_degE:
     latitude (deg): -33.8833
     longitude (deg): 146.1333
     locality: Rankins Springs to Goolgowi, 8 miles 13 km from Rankins Springs.
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-33.8992_degS_and_119.9464_degE:
     latitude (deg): -33.8992
     longitude (deg): 119.9464
     locality: Sepulcralis Hill, Hammersely Drive, Fitzgerald River National Park.
       W side.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.8994_degS_and_119.9461_degE:
     latitude (deg): -33.8994
     longitude (deg): 119.9461
     locality: SW slope of East Mount Barren, Hammersley Drive, Fitzgerald River National
       Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9097_degS_and_123.3478_degE:
     latitude (deg): -33.9097
     longitude (deg): 123.3478
     locality: Poison Creek mouth, Cape Arid.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9167_degS_and_118.3333_degE:
     latitude (deg): -33.9167
     longitude (deg): 118.3333
     locality: 11 km N of the Gnowangerup - Ongerup road along the Borden - Lake Grace
       road.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-33.9167_degS_and_120.0167_degE:
     latitude (deg): -33.9167
     longitude (deg): 120.0167
     locality: East Mount Barren.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-33.9167_degS_and_120.0333_degE:
     latitude (deg): -33.9167
     longitude (deg): 120.0333
     locality: East Mt Barren.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.9167_degS_and_145.6667_degE:
     latitude (deg): -33.9167
     longitude (deg): 145.6667
     locality: 2.6 km from Goolgowie towards Hillston.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-33.9167_degS_and_147.1833_degE:
     latitude (deg): -33.9167
     longitude (deg): 147.1833
     locality: 8 ml. 13 km from West Wyalong toward Rankins Springs.
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-33.9203_degS_and_120.1358_degE:
     latitude (deg): -33.9203
     longitude (deg): 120.1358
     locality: At turnoff to rubbish tip, 3.8km N of Hopetoun on Hopetoun Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.9281_degS_and_120.0231_degE:
     latitude (deg): -33.9281
     longitude (deg): 120.0231
     locality: Fitzgerald River National Park, E Mt Barren, southern foot.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-33.9325_degS_and_139.5153_degE:
     latitude (deg): -33.9325
     longitude (deg): 139.5153
     locality: 22 km from Morgan towards Burra.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9328_degS_and_120.1281_degE:
     latitude (deg): -33.9328
     longitude (deg): 120.1281
     locality: 2.4 km N of Hopetoun at turnoff to lookout, on Hopetoun Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.9333_degS_and_119.9833_degE:
     latitude (deg): -33.9333
     longitude (deg): 119.9833
     locality: 11 km from East Mt Barren along track to Ravensthorpe via Kybulup Pool.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.9333_degS_and_147.2167_degE:
     latitude (deg): -33.9333
     longitude (deg): 147.2167
     locality: 2.5 km from West Wyalong P.O. on S side of railway line, adjacent to
       railway silos.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-33.9333_degS_and_147.25_degE:
     latitude (deg): -33.9333
     longitude (deg): 147.25
     locality: Temora to Wyalong, 40 miles 64 km from Temora. Distance between Temora
       and Wyalong is 40 miles.
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-33.9342_degS_and_120.0869_degE:
     latitude (deg): -33.9342
     longitude (deg): 120.0869
     locality: Seaview Road, 2 km W of Hopetoun towards Fitzgerald River National Park.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.9358_degS_and_120.1158_degE:
     latitude (deg): -33.9358
     longitude (deg): 120.1158
     locality: 1.3 km along Hamersely Drive from Hopetoun Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33.9494_degS_and_118.9178_degE:
     latitude (deg): -33.9494
     longitude (deg): 118.9178
     locality: 300 m E along powerline track off the road to Jerramungup Sporting Complex.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.95_degS_and_115.0667_degE:
     latitude (deg): -33.95
     longitude (deg): 115.0667
     locality: Margaret River crossing on Bussel Highway.
-    collector: Taylor, J.M.
+    recorded by: Taylor, J.M.
   site_at_-33.9539_degS_and_118.9078_degE:
     latitude (deg): -33.9539
     longitude (deg): 118.9078
     locality: Below high voltage powerline to east of Jerramungup Sporting Complex,
       100 m from cleared paddocks to north.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-33.9544_degS_and_118.8378_degE:
     latitude (deg): -33.9544
     longitude (deg): 118.8378
     locality: 23 km E towards Jerramungup along Gnowangerup - Jerramungup Road from
       Gleeson Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9597_degS_and_123.2331_degE:
     latitude (deg): -33.9597
     longitude (deg): 123.2331
     locality: Cape Arid National Park. 5.6 km along Thomas Fishery Track from Cape
       Arid.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9667_degS_and_140.9167_degE:
     latitude (deg): -33.9667
     longitude (deg): 140.9167
     locality: Murray River, near Victorian border, 1 km W of, Nelwood.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-33.9667_degS_and_146.1167_degE:
     latitude (deg): -33.9667
     longitude (deg): 146.1167
     locality: Between Griffith and Rankins Springs, at turnoff to Pulletop Nature
       Reserve.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-33.9719_degS_and_123.2211_degE:
     latitude (deg): -33.9719
     longitude (deg): 123.2211
     locality: Hill Springs, E slopes of Mt Arid.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-33.9814_degS_and_123.2278_degE:
     latitude (deg): -33.9814
     longitude (deg): 123.2278
     locality: Road to Thomas Fishery, about 3 km from fishery, near SE base of Mt
       Arid.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-33_degS_and_134.3667_degE:
     latitude (deg): -33.0
     longitude (deg): 134.3667
     locality: Calpatanna Waterhole Conservation Park, c. 26 km SSE of Streaky Bay.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-34.0333_degS_and_135.2833_degE:
     latitude (deg): -34.0333
     longitude (deg): 135.2833
     locality: Ca 12 km from Mt Hope toward Elliston, beside Lake Hamilton.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.0333_degS_and_151.15_degE:
     latitude (deg): -34.0333
     longitude (deg): 151.15
     locality: 1.2 km from Cronulla High School, W side of Captain Cook Drive.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-34.0417_degS_and_140.7097_degE:
     latitude (deg): -34.0417
     longitude (deg): 140.7097
     locality: On Calperum Station, 11 km directly NNE of Renmark.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-34.05_degS_and_144.1333_degE:
     latitude (deg): -34.05
     longitude (deg): 144.1333
     locality: 12 km N of Oxley along Oxley-Clare road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.0606_degS_and_140.7158_degE:
     latitude (deg): -34.0606
     longitude (deg): 140.7158
     locality: Bookmark Biosphere Reserve, Calperum, c.12km direct NNW of Renmark,
       on Reny Island.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-34.0736_degS_and_140.7203_degE:
     latitude (deg): -34.0736
     longitude (deg): 140.7203
     locality: Bookmark Biosphere Reserve, Calperum, c. 12 km direct NNW on Renmark,
       on Reny Island near Ral Ral Creek.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-34.0833_degS_and_138.5167_degE:
     latitude (deg): -34.0833
     longitude (deg): 138.5167
     locality: Halbury Scrub.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-34.0833_degS_and_150.8167_degE:
     latitude (deg): -34.0833
     longitude (deg): 150.8167
     locality: Wedderburn, S of Campbelltown.
-    collector: Ollerenshaw, P.
+    recorded by: Ollerenshaw, P.
   site_at_-34.1142_degS_and_140.6144_degE:
     latitude (deg): -34.1142
     longitude (deg): 140.6144
     locality: Bookmark Biosphere Reserve, Calperum, c. 14 km direct NW of Renmark,
       c. 3.5 km direct E of Stony Pinch dam.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-34.1167_degS_and_135.4_degE:
     latitude (deg): -34.1167
     longitude (deg): 135.4
     locality: 3 km from Mt Hope toward Cummins.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.1167_degS_and_136.3333_degE:
     latitude (deg): -34.1167
     longitude (deg): 136.3333
     locality: Lincoln Highway, at turnoff to Port Neill (c. 3 km from Port Neill).
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.1167_degS_and_150.8_degE:
     latitude (deg): -34.1167
     longitude (deg): 150.8
     locality: 4km S of Bradbury on Wedderburn Rd - side road 100m. West Cliff Colliery.
       500m in from road.
-    collector: Corsini, G.
+    recorded by: Corsini, G.
   site_at_-34.1333_degS_and_139.1667_degE:
     latitude (deg): -34.1333
     longitude (deg): 139.1667
     locality: Near Peep Hill, c. 8 km ENE (direct) from Eudunda.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-34.1389_degS_and_146.0833_degE:
     latitude (deg): -34.1389
     longitude (deg): 146.0833
     locality: 17km direct N of Griffith, 2.2km west of the Griffith to Rankin Springs
       road, 700m N of road to New Farms Road.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-34.155_degS_and_118.9364_degE:
     latitude (deg): -34.155
     longitude (deg): 118.9364
     locality: 24.5 km S of Jerramungup on Hassell Road.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.165_degS_and_149.0633_degE:
     latitude (deg): -34.165
     longitude (deg): 149.0633
     locality: Hall; c. 320 m NW of horse yards at corner of Gibbes and Hoskins Streets;
       NE corner of Gibbes Street horse paddocks.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-34.1667_degS_and_146.05_degE:
     latitude (deg): -34.1667
     longitude (deg): 146.05
     locality: 16.0 km N of Griffith (PO) along Lakes Road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-34.2167_degS_and_148.6333_degE:
     latitude (deg): -34.2167
     longitude (deg): 148.6333
     locality: C. 27.5 km NNW of Boorowa, Top Creek property, hill behind dam water
       header tank.
-    collector: Winsbury, M.J.
+    recorded by: Winsbury, M.J.
   site_at_-34.2333_degS_and_146.3667_degE:
     latitude (deg): -34.2333
     longitude (deg): 146.3667
     locality: 2.3 km from Binya towards Ardlethan, roadside.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.2403_degS_and_150.8342_degE:
     latitude (deg): -34.2403
     longitude (deg): 150.8342
     locality: Intersection of West Cliff Coal Mine turnoff and the Appin-Bulli road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.2456_degS_and_150.6453_degE:
     latitude (deg): -34.2456
     longitude (deg): 150.6453
     locality: Bargo area, Pheasants Nest Road, c. 500 m past Charles Road turnoff,
       W side of road, c. 90 m N of Carters Creek crossing; western edge of narrow
       gully next to road.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.2456_degS_and_150.6456_degE:
     latitude (deg): -34.2456
     longitude (deg): 150.6456
     locality: Bargo area, Pheasants Nest Road, c. 600 m past Charles Road turnoff,
       W side of road, c. 120 m N of Carters Creek crossing.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.2458_degS_and_150.6453_degE:
     latitude (deg): -34.2458
     longitude (deg): 150.6453
     locality: Bargo area, Pheasants Nest Road, c. 500 m past Charles Road turnoff,
       W side of road, c. 80 m N of Carters Creek crossing.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.25_degS_and_115.0833_degE:
     latitude (deg): -34.25
     longitude (deg): 115.0833
     locality: Margaret River, 400 m S of intersection of Margaret River road and Caves
       Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.25_degS_and_146.25_degE:
     latitude (deg): -34.25
     longitude (deg): 146.25
     locality: Binya State Forest, 23 km E of Griffith along road to Barellan.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.25_degS_and_150.6667_degE:
     latitude (deg): -34.25
     longitude (deg): 150.6667
     locality: 1km north of Pheasants Nest Mobile Service Station on Hume Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.2511_degS_and_115.0322_degE:
     latitude (deg): -34.2511
     longitude (deg): 115.0322
     locality: Cosy Corner.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-34.2564_degS_and_150.6119_degE:
     latitude (deg): -34.2564
     longitude (deg): 150.6119
     locality: Bargo area, c. 200 m point plot gives c. 90 m from Arina Road junction
       on Pheasants Nest Road; on W side of road.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.2614_degS_and_119.2692_degE:
     latitude (deg): -34.2614
     longitude (deg): 119.2692
     locality: Entrance to Marlamerup on Murray Road, 20 km NW of Bremer Bay.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.2631_degS_and_150.6014_degE:
     latitude (deg): -34.2631
     longitude (deg): 150.6014
     locality: Bargo area; management track, c. 300 m ~NW from end of Glengarrie Road;
       c. 200 m E of Dog Trap Creek.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.2667_degS_and_143_degE:
     latitude (deg): -34.2667
     longitude (deg): 143.0
     locality: 24 km along Prungle Mail Road off Sturt Highway, towards Arumpo Station.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-34.2667_degS_and_144.1667_degE:
     latitude (deg): -34.2667
     longitude (deg): 144.1667
     locality: Jim Barren enclosure, 5 km SE of Oxley on Maude road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.2764_degS_and_150.5936_degE:
     latitude (deg): -34.2764
     longitude (deg): 150.5936
     locality: Bargo area; Government Road, c. 150 m from E end of road before waste
       depot; narrow strip of roadside vegetation.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-34.2833_degS_and_150.6_degE:
     latitude (deg): -34.2833
     longitude (deg): 150.6
     locality: Near Bargo, Wirrimbirra Sanctuary, Ockenden Pool.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-34.2989_degS_and_150.4219_degE:
     latitude (deg): -34.2989
     longitude (deg): 150.4219
     locality: Nattai National Park, near edge, approaching old Starlight trail, 10.2
       km along railway due N of post office at Hill Top.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.2989_degS_and_150.4233_degE:
     latitude (deg): -34.2989
     longitude (deg): 150.4233
     locality: Wattle farm, Captain Starlight track, 10 km NW of Hilltop Post Office.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-34.3_degS_and_146.7167_degE:
     latitude (deg): -34.3
     longitude (deg): 146.7167
     locality: Moombooldool, 1.5 km from Moombooldool towards Temora.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-34.305_degS_and_119.3172_degE:
     latitude (deg): -34.305
     longitude (deg): 119.3172
     locality: 10 km along Doubtful Islands Road from Devils Creek Road South towards
       Fitzgerald River National Park.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.3167_degS_and_146.7167_degE:
     latitude (deg): -34.3167
     longitude (deg): 146.7167
     locality: 7.5 km from Moombooldool towards Ardlethan, LHS side of road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.3167_degS_and_149.975_degE:
     latitude (deg): -34.3167
     longitude (deg): 149.975
     locality: Wombeyan Caves, 5 m N of entrance to Wollondilly Cave.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.3167_degS_and_150.05_degE:
     latitude (deg): -34.3167
     longitude (deg): 150.05
     locality: Wombeyan Caves, 100 m from Junction Cave along access track.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.3333_degS_and_146.75_degE:
     latitude (deg): -34.3333
     longitude (deg): 146.75
     locality: 3 km E of Moombooldool on road to Ardlethan.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.3333_degS_and_146.7833_degE:
     latitude (deg): -34.3333
     longitude (deg): 146.7833
     locality: Kamarah.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-34.35_degS_and_118.6333_degE:
     latitude (deg): -34.35
     longitude (deg): 118.6333
     locality: Chillilup Pool on Pallinup River.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.3667_degS_and_118.3333_degE:
     latitude (deg): -34.3667
     longitude (deg): 118.3333
     locality: Stirling Ranges, Bluff Knoll track, 150 m from start.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.3667_degS_and_118.3667_degE:
     latitude (deg): -34.3667
     longitude (deg): 118.3667
     locality: Boundary of Stirling Range National Park, 4.5 km ESE of Ellen Peak.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.3667_degS_and_138.9_degE:
     latitude (deg): -34.3667
     longitude (deg): 138.9
     locality: Orchard Bridge on Ross Creek, 3 km SW of Kapunda.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.3833_degS_and_118.3_degE:
     latitude (deg): -34.3833
     longitude (deg): 118.3
     locality: Stirling district; Stirling Range, 2.5 km S of Pyungoorup Peak.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.3833_degS_and_119.4_degE:
     latitude (deg): -34.3833
     longitude (deg): 119.4
     locality: Bremer Bay, John Cove.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.3867_degS_and_119.2883_degE:
     latitude (deg): -34.3867
     longitude (deg): 119.2883
     locality: 1.9 km along Swamp Road from Bremer Bay Road, from Bremer Bay towards
       Fitzgerald River National Park.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.3867_degS_and_119.2889_degE:
     latitude (deg): -34.3867
     longitude (deg): 119.2889
     locality: 2 km N along Swamp Road from Bremer Bay Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4_degS_and_117.7833_degE:
     latitude (deg): -34.4
     longitude (deg): 117.7833
     locality: Turnoff to Red Gum Pass, near Stirling Range National Park.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.4_degS_and_139.1667_degE:
     latitude (deg): -34.4
     longitude (deg): 139.1667
     locality: Mt Lofty Range, 4 km from Truro along Sturt Highway towards Blanchetown.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.4003_degS_and_150.4672_degE:
     latitude (deg): -34.4003
     longitude (deg): 150.4672
     locality: Colovale access road to Mount Flora, Draper Creek access road at end
       of bitumen.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.4033_degS_and_119.2828_degE:
     latitude (deg): -34.4033
     longitude (deg): 119.2828
     locality: 1.3km S towards Bremer Bay along Bremer Bay Road from Dillon Bay Road
       intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4167_degS_and_118.25_degE:
     latitude (deg): -34.4167
     longitude (deg): 118.25
     locality: Stirling Range, junction of East Pillenorup and South Bluff Tracks.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-34.4167_degS_and_118.2833_degE:
     latitude (deg): -34.4167
     longitude (deg): 118.2833
     locality: Stirling Range, East Pillenorup Track, 3 km E of junction with South
       Bluff Track.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.4167_degS_and_118.7333_degE:
     latitude (deg): -34.4167
     longitude (deg): 118.7333
     locality: Pallinup River crossing (Mara Bridge) on Albany-Jerramungup road.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.4167_degS_and_142.4333_degE:
     latitude (deg): -34.4167
     longitude (deg): 142.4333
     locality: 49 km from Mildura (VIC) along rd to Euston.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.4233_degS_and_116.0744_degE:
     latitude (deg): -34.4233
     longitude (deg): 116.0744
     locality: 7 km NE of Pemberton on Vasse Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4281_degS_and_119.2706_degE:
     latitude (deg): -34.4281
     longitude (deg): 119.2706
     locality: 1.8 km S towards Dillon Bay along Dillon Bay Road from Bremer Bay Road
       intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4439_degS_and_119.2708_degE:
     latitude (deg): -34.4439
     longitude (deg): 119.2708
     locality: 4.2 km S towards Dillon Bay along Dillon Bay Road from Bremer Bay intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4464_degS_and_119.2711_degE:
     latitude (deg): -34.4464
     longitude (deg): 119.2711
     locality: 4.7 km S towards Dillon Bay along Dillon Bay Road from Bremer Bay intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4547_degS_and_118.9086_degE:
     latitude (deg): -34.4547
     longitude (deg): 118.9086
     locality: Beaufort Inlet, Millers Point, ca 110 km NE of Albany.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-34.4597_degS_and_119.2761_degE:
     latitude (deg): -34.4597
     longitude (deg): 119.2761
     locality: Dillon Bay, 25 km W of Bremer Bay.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.4667_degS_and_148.9833_degE:
     latitude (deg): -34.4667
     longitude (deg): 148.9833
     locality: 11.2 km from Rye Park, 0.2 km from Rye Park-Rugby road, along Maryvale
       Road, toward Bevendale.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.4906_degS_and_118.6078_degE:
     latitude (deg): -34.4906
     longitude (deg): 118.6078
     locality: 500 m NE of Wellstead.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.5_degS_and_135.6167_degE:
     latitude (deg): -34.5
     longitude (deg): 135.6167
     locality: 5 km WNW along road to Wangary from Port Lincoln - Cummins road at Wanilla.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-34.5_degS_and_137.6167_degE:
     latitude (deg): -34.5
     longitude (deg): 137.6167
     locality: 27.9 km from Minlaton toward Maitland. Along roadside.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.5333_degS_and_118.0167_degE:
     latitude (deg): -34.5333
     longitude (deg): 118.0167
     locality: 62 km S of Borden on the Albany road.
-    collector: Craven, L.A.; Zich, F.A.; Lyne, A.M.
+    recorded by: Craven, L.A.; Zich, F.A.; Lyne, A.M.
   site_at_-34.5333_degS_and_144.7167_degE:
     latitude (deg): -34.5333
     longitude (deg): 144.7167
     locality: 15 km from Hay towards Balranald.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-34.5333_degS_and_150.0083_degE:
     latitude (deg): -34.5333
     longitude (deg): 150.0083
     locality: Big Hill Travelling Stock Reserve, 36 km directly NE of Goulburn, on
       Bannaby - Brayton Road, S of Tarlo River.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-34.5431_degS_and_118.23_degE:
     latitude (deg): -34.5431
     longitude (deg): 118.23
     locality: Intersection of South Stirling Road and Chillingup Road, S of Stirling
       Range National Park.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.5486_degS_and_118.2306_degE:
     latitude (deg): -34.5486
     longitude (deg): 118.2306
     locality: 20 km E along Chillinup Rd at South Stirling Road intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.55_degS_and_118.1433_degE:
     latitude (deg): -34.55
     longitude (deg): 118.1433
     locality: 11.5 km along Chillinup Road from Chester Pass Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.55_degS_and_149.1_degE:
     latitude (deg): -34.55
     longitude (deg): 149.1
     locality: 1 km from Bevendale junction toward Dalton, lay-by at side of road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.5614_degS_and_117.7392_degE:
     latitude (deg): -34.5614
     longitude (deg): 117.7392
     locality: 10 km along Woogonelup Rd, NE of Mt Barker,  towards Stirling Range.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.5639_degS_and_141.0981_degE:
     latitude (deg): -34.5639
     longitude (deg): 141.0981
     locality: 2.7 km south from the junction of Taparoo road and Settlement road,
       on Settlement road, Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.5833_degS_and_117.9931_degE:
     latitude (deg): -34.5833
     longitude (deg): 117.9931
     locality: 200 m along Woogenilup Road from Chester Pass Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.5833_degS_and_118.7333_degE:
     latitude (deg): -34.5833
     longitude (deg): 118.7333
     locality: Stirling district; 3.5 km NW of Cape Riche.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-34.5833_degS_and_150.8667_degE:
     latitude (deg): -34.5833
     longitude (deg): 150.8667
     locality: Shellharbour, headland N of boat harbour, steep bank N of Municipal
       Park, 35 m from ocean shoreline.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-34.5833_degS_and_150.9_degE:
     latitude (deg): -34.5833
     longitude (deg): 150.9
     locality: S of Port Kembla, Shellharbour-Bass Point Reserve, N side of road into
       shipwreck memorial carpark.
-    collector: Howe, F.W.
+    recorded by: Howe, F.W.
   site_at_-34.5908_degS_and_116.0714_degE:
     latitude (deg): -34.5908
     longitude (deg): 116.0714
     locality: 100m SW along Rifle Range Road from Pemberton-Northcliffe road intersection
       towards Warren Beach.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.5914_degS_and_118.7294_degE:
     latitude (deg): -34.5914
     longitude (deg): 118.7294
     locality: 1.7 km from Cape Riche towards Wellstead, on Sandalwood Road.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.5925_degS_and_118.7336_degE:
     latitude (deg): -34.5925
     longitude (deg): 118.7336
     locality: Cape Riche Whaling Station (now a carpark), 1 km from camp grounds.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.6_degS_and_135.5167_degE:
     latitude (deg): -34.6
     longitude (deg): 135.5167
     locality: Kellidie Bay Conservation Park, NW corner, 1.9 km N along road to Wangarry
       from the Coffin Bay-Port Lincoln road intersection.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-34.6167_degS_and_150.8189_degE:
     latitude (deg): -34.6167
     longitude (deg): 150.8189
     locality: Rocklow Road, Dunmore District. Ca 20 km S of Wollongong centre.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.6183_degS_and_116.1003_degE:
     latitude (deg): -34.6183
     longitude (deg): 116.1003
     locality: 1 km NW of Northcliffe on Pemberton-Northcliffe road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.6336_degS_and_150.1883_degE:
     latitude (deg): -34.6336
     longitude (deg): 150.1883
     locality: Penrose State Forest in fire break on eastern side of Hanging Rock Swamp
       Road, 300 m SE from where it is joined by unnamed track in from the Hume Highway.
       2.5 km S from Penrose Forest Way turnoff.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6383_degS_and_141.8286_degE:
     latitude (deg): -34.6383
     longitude (deg): 141.8286
     locality: 12.1 km from Nowingi line and Rocket Lake line junction across Lake
       centre on north eastern edge.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.6469_degS_and_117.7764_degE:
     latitude (deg): -34.6469
     longitude (deg): 117.7764
     locality: Intersection of Waterman Road & Mt Barker - Ponorgorup Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.65_degS_and_149.0333_degE:
     latitude (deg): -34.65
     longitude (deg): 149.0333
     locality: 1.4 km from Mahgunyah property near Blakney Creek - Yass road.
-    collector: Hallett, R.
+    recorded by: Hallett, R.
   site_at_-34.6556_degS_and_141.0981_degE:
     latitude (deg): -34.6556
     longitude (deg): 141.0981
     locality: On North South Settlement road.  14 km south of the junction of the
       North South Settlement road and Taparoo Track.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.6561_degS_and_117.8811_degE:
     latitude (deg): -34.6561
     longitude (deg): 117.8811
     locality: 21.8 km from Porongorup turnoff from Mt Barker, just before Porongorup.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.6631_degS_and_149.0267_degE:
     latitude (deg): -34.6631
     longitude (deg): 149.0267
     locality: End of Little Plains Road, turn left, 2 km to top of crest on Boorowa
       - Yass road Blakney Creek North Road. Ca 25 km directly ~WNW of Gunning, S of
       Blakney Creek.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.6667_degS_and_117.8333_degE:
     latitude (deg): -34.6667
     longitude (deg): 117.8333
     locality: Mt Barker-Porongurup road, 11.2 km E from turnoff at Mt Barker.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.6667_degS_and_141.75_degE:
     latitude (deg): -34.6667
     longitude (deg): 141.75
     locality: ca 62 km SW of Mildura, 3 km W of end of abandoned railway, near Rocket
       Lake.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.6667_degS_and_149.0167_degE:
     latitude (deg): -34.6667
     longitude (deg): 149.0167
     locality: c. 2.3 km from Mahjunyah (Blakney Creek hamlet) toward Yass.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.6667_degS_and_149.1667_degE:
     latitude (deg): -34.6667
     longitude (deg): 149.1667
     locality: 10 km from Bevendale turnoff in Dalton.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.6667_degS_and_150.75_degE:
     latitude (deg): -34.6667
     longitude (deg): 150.75
     locality: Escarpment above Minnamurra Falls Visitor Centre.
-    collector: Golson, T.
+    recorded by: Golson, T.
   site_at_-34.6672_degS_and_118.3306_degE:
     latitude (deg): -34.6672
     longitude (deg): 118.3306
     locality: 32 km from Cape Riche turnoff at Wellstead towards Albany along South
       Coast Highway.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.6728_degS_and_149.0447_degE:
     latitude (deg): -34.6728
     longitude (deg): 149.0447
     locality: 3 km W on Little Plain(s) Road, left hand crest. Coordinates plot 0.9
       km N of Rye Park - Dalton Road, c. 24 km ~WNW of Gunning.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.6747_degS_and_150.2925_degE:
     latitude (deg): -34.6747
     longitude (deg): 150.2925
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6747_degS_and_150.2928_degE:
     latitude (deg): -34.6747
     longitude (deg): 150.2928
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.675_degS_and_150.2925_degE:
     latitude (deg): -34.675
     longitude (deg): 150.2925
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6753_degS_and_150.2894_degE:
     latitude (deg): -34.6753
     longitude (deg): 150.2894
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6756_degS_and_150.2894_degE:
     latitude (deg): -34.6756
     longitude (deg): 150.2894
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6756_degS_and_150.2897_degE:
     latitude (deg): -34.6756
     longitude (deg): 150.2897
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6756_degS_and_150.29_degE:
     latitude (deg): -34.6756
     longitude (deg): 150.29
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6758_degS_and_150.2897_degE:
     latitude (deg): -34.6758
     longitude (deg): 150.2897
     locality: 350 m S from the Santi Forest Monastery, Coalmines road Bundanoon. Along
       the cliff edge near foot track, overlooking Coalmines Creek.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6761_degS_and_150.2856_degE:
     latitude (deg): -34.6761
     longitude (deg): 150.2856
     locality: 450 m SE from the Santi Forest Monastery, Coalmines road Bundanoon.
       Along a 4WD track that follows the cliff edge.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6764_degS_and_150.8097_degE:
     latitude (deg): -34.6764
     longitude (deg): 150.8097
     locality: Jerrara Dam, Jamberoo District.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.6833_degS_and_117.9167_degE:
     latitude (deg): -34.6833
     longitude (deg): 117.9167
     locality: Porongurup National Park, track to Castle Rock.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-34.6919_degS_and_117.9233_degE:
     latitude (deg): -34.6919
     longitude (deg): 117.9233
     locality: Halfway along track to Castle Rock, Porongorup National Park.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.6956_degS_and_149.0867_degE:
     latitude (deg): -34.6956
     longitude (deg): 149.0867
     locality: Blakney Creek Travelling Stock Reserve, 10 km W of Dalton on road to
       Boorowa Rye Park - Dalton Road; 200 m SE from main gate on creekline.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.6972_degS_and_141.1158_degE:
     latitude (deg): -34.6972
     longitude (deg): 141.1158
     locality: 1.8 km east of the North South Settlement road and Pheenys track junction,
       on Pheenys track.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.6997_degS_and_150.2297_degE:
     latitude (deg): -34.6997
     longitude (deg): 150.2297
     locality: Penrose, 2.7 km down a disused fire trail, from the end of Dunlop Lane.
       Then 300 m E to rock shelf above cliff along creek. Private property.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.6997_degS_and_150.23_degE:
     latitude (deg): -34.6997
     longitude (deg): 150.23
     locality: Penrose, 2.7 km down a disused fire trail, from the end of Dunlop Lane.
       Then 300 m E to rock shelf above cliff along creek. Private property.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.7_degS_and_117.95_degE:
     latitude (deg): -34.7
     longitude (deg): 117.95
     locality: 4 km SE of Porongorup.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-34.7042_degS_and_142.3369_degE:
     latitude (deg): -34.7042
     longitude (deg): 142.3369
     locality: Mournpall campground, Hattah-Kulkyne National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.7083_degS_and_137.7917_degE:
     latitude (deg): -34.7083
     longitude (deg): 137.7917
     locality: 21.5 km E of Minlaton on the bitumen road to Port Vincent, then 8.4
       km N on gravel road.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-34.7086_degS_and_141.4386_degE:
     latitude (deg): -34.7086
     longitude (deg): 141.4386
     locality: 33.5 km east of the North South Settlement road and Pheenys track junction,
       on Pheenys track.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.7097_degS_and_141.1389_degE:
     latitude (deg): -34.7097
     longitude (deg): 141.1389
     locality: 4.5 km east of the North South Settlement road and Pheenys track junction,
       on Pheenys track.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.7244_degS_and_149.1886_degE:
     latitude (deg): -34.7244
     longitude (deg): 149.1886
     locality: Dalton Cemetery, Dalton; near right hand side of front gate to cemetery.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.7333_degS_and_146.55_degE:
     latitude (deg): -34.7333
     longitude (deg): 146.55
     locality: 4 km N of Narrandera, near golf course.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.7333_degS_and_148.9833_degE:
     latitude (deg): -34.7333
     longitude (deg): 148.9833
     locality: Ca 12 km from Blakney Creek toward Yass and 2.5 km from Blackburn Lane
       toward Blakney Creek, near Homeville homestead.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.7333_degS_and_149.1833_degE:
     latitude (deg): -34.7333
     longitude (deg): 149.1833
     locality: Dalton Cemetery, fenced-off area of natural grasses at entrance.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.7333_degS_and_150.2167_degE:
     latitude (deg): -34.7333
     longitude (deg): 150.2167
     locality: Crown land 10 km ESE of Marulan adjacent to Wingello State Forest; 0.12
       km SW of end of Bull Ridge Forest Road, 2.6 km from junction with Gap Forest
       Road.
-    collector: Panter, S.N.
+    recorded by: Panter, S.N.
   site_at_-34.7406_degS_and_141.8039_degE:
     latitude (deg): -34.7406
     longitude (deg): 141.8039
     locality: Murray Sunset National Park. 9.8 km S along the Rocket Lake Track from
       the junction of the Rocket Lake Track and the Nowingi Line Track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.7447_degS_and_117.75_degE:
     latitude (deg): -34.7447
     longitude (deg): 117.75
     locality: 4.8 km along Yellanup Road from Albany Highway.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.7561_degS_and_116.4992_degE:
     latitude (deg): -34.7561
     longitude (deg): 116.4992
     locality: 28.8 km S of Middleton Road on South Western Highway towards Walpole.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.7667_degS_and_150.05_degE:
     latitude (deg): -34.7667
     longitude (deg): 150.05
     locality: Long Point Lookout, 5.6 km from junction of Long Point Rd and Penrose
       Rd.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-34.7694_degS_and_117.7078_degE:
     latitude (deg): -34.7694
     longitude (deg): 117.7078
     locality: Corner of Albany Highway and Yellanup Road, 17 km S of Mt Barker.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.79_degS_and_150.5797_degE:
     latitude (deg): -34.79
     longitude (deg): 150.5797
     locality: Cambewarra Mountain, c. 600 m SW of radio tower.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.8111_degS_and_148.6294_degE:
     latitude (deg): -34.8111
     longitude (deg): 148.6294
     locality: Bookham Cemetery; fenced area surrounding graves.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.8114_degS_and_150.0281_degE:
     latitude (deg): -34.8114
     longitude (deg): 150.0281
     locality: Bungonia State Recreation Area. Bungonia Lookdown.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-34.8131_degS_and_148.6297_degE:
     latitude (deg): -34.8131
     longitude (deg): 148.6297
     locality: Bookham Cemetery; NE corner of fenced area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.8167_degS_and_148.4667_degE:
     latitude (deg): -34.8167
     longitude (deg): 148.4667
     locality: c. 18 km from Bookham toward Jugiong, just at Benangaroo road turnoff.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.8167_degS_and_148.6167_degE:
     latitude (deg): -34.8167
     longitude (deg): 148.6167
     locality: Bookham Cemetery.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.8178_degS_and_149.8083_degE:
     latitude (deg): -34.8178
     longitude (deg): 149.8083
     locality: Pomaderris Nature Reserve, Mountain Ash Road (road to Bungonia); c.
       12 km by road SE of Goulburn.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.8333_degS_and_148.7722_degE:
     latitude (deg): -34.8333
     longitude (deg): 148.7722
     locality: c. 18 km from Yass along Black Range Road, next to entrance to Atherton.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.8333_degS_and_149.9833_degE:
     latitude (deg): -34.8333
     longitude (deg): 149.9833
     locality: 6.7 km from Bungonia towards Bungonia State Recreation Area. Bungonia
       Lookdown Rd.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-34.8667_degS_and_138.75_degE:
     latitude (deg): -34.8667
     longitude (deg): 138.75
     locality: In Torrens Gorge, 0.6 km W of Kangaroo Creek Dam Wall, 21 km NE of Adelaide.
-    collector: West, J.G.
+    recorded by: West, J.G.
   site_at_-34.8667_degS_and_150.6_degE:
     latitude (deg): -34.8667
     longitude (deg): 150.6
     locality: Nowra
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-34.8761_degS_and_141.8017_degE:
     latitude (deg): -34.8761
     longitude (deg): 141.8017
     locality: Murray Sunset National Park. Henschke Soak. 9.9 km S from Mopoke Hut
       along the Mopoke Track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.8833_degS_and_118.25_degE:
     latitude (deg): -34.8833
     longitude (deg): 118.25
     locality: Lower slopes of Mt Manypeaks.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-34.8833_degS_and_150.6_degE:
     latitude (deg): -34.8833
     longitude (deg): 150.6
     locality: CULTIVATED B. Muffet, Nowra, New South Wales.
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-34.8889_degS_and_117.7747_degE:
     latitude (deg): -34.8889
     longitude (deg): 117.7747
     locality: Albany Highway, 600m South of King River crossing.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.8892_degS_and_141.6169_degE:
     latitude (deg): -34.8892
     longitude (deg): 141.6169
     locality: 100m W from the Underbool track and Mt Crozier Track junction on the
       Mt. Crozier Track.  Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.8908_degS_and_117.7717_degE:
     latitude (deg): -34.8908
     longitude (deg): 117.7717
     locality: Opposite Phillips Brook Nature Reserve on Albany Highway, 30 m N of
       King River crossing.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.8972_degS_and_149.5122_degE:
     latitude (deg): -34.8972
     longitude (deg): 149.5122
     locality: Rowes Lagoon, Wollogorang. 26 km SE of Goulburn on southern side of
       Federal Highway.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-34.9083_degS_and_117.8033_degE:
     latitude (deg): -34.9083
     longitude (deg): 117.8033
     locality: 1 km along Hazzard Road, 2.6 km N of Albany airport, along Albany Highway.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.9167_degS_and_117.3333_degE:
     latitude (deg): -34.9167
     longitude (deg): 117.3333
     locality: 6.4 km from Denmark River Bridge towards Walpole.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.9233_degS_and_117.7897_degE:
     latitude (deg): -34.9233
     longitude (deg): 117.7897
     locality: 2.9 km along Albany Hwy to Perth from Albany airport turn off.
-    collector: Flowers, G.
+    recorded by: Flowers, G.
   site_at_-34.9397_degS_and_118.2047_degE:
     latitude (deg): -34.9397
     longitude (deg): 118.2047
     locality: Just above Bettys Beach, near Two Peoples Bay.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.95_degS_and_116.9_degE:
     latitude (deg): -34.95
     longitude (deg): 116.9
     locality: Warren district; ca 110 km W of Albany, 5 km along Valley of the Giants
       Road from Bow Bridge turnoff.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.95_degS_and_117.85_degE:
     latitude (deg): -34.95
     longitude (deg): 117.85
     locality: Willyung Hill, c. 6 km N of Albany.
-    collector: Craven, L.A.
+    recorded by: Craven, L.A.
   site_at_-34.95_degS_and_117_degE:
     latitude (deg): -34.95
     longitude (deg): 117.0
     locality: 76 km from Albany along road to Walpole, Rocky Gully turnoff, between
       Kent River and Bow Bridge.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34.9567_degS_and_141.3744_degE:
     latitude (deg): -34.9567
     longitude (deg): 141.3744
     locality: 13 km W from Sunset Track and Underbool Track junction, on the Underbool
       Track, Murray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.9575_degS_and_141.2561_degE:
     latitude (deg): -34.9575
     longitude (deg): 141.2561
     locality: 25.9 km W of the Sunset Track and Underbool Track junction, on the Underbool
       Track.  Muray Sunset National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-34.9667_degS_and_116.8333_degE:
     latitude (deg): -34.9667
     longitude (deg): 116.8333
     locality: near Walpole, Valley of the Giants, entrance to Amenities Area.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-34.9667_degS_and_135.95_degE:
     latitude (deg): -34.9667
     longitude (deg): 135.95
     locality: Lincoln National Park; c. 42 km from Port Lincoln along Memory Cove
       track.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.9667_degS_and_149.2167_degE:
     latitude (deg): -34.9667
     longitude (deg): 149.2167
     locality: Gundaroo; Yass River Road.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-34.9731_degS_and_149.2192_degE:
     latitude (deg): -34.9731
     longitude (deg): 149.2192
     locality: W from corner of Back Creek Road and Yass River Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.9736_degS_and_150.4944_degE:
     latitude (deg): -34.9736
     longitude (deg): 150.4944
     locality: Braidwood Road, Nowra end, 8.4 km towards Nowra from the Turpentine
       Road turn-off, at the edge of the Parma Creek Nature Reserve.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-34.975_degS_and_148.6333_degE:
     latitude (deg): -34.975
     longitude (deg): 148.6333
     locality: 20.7 km from Hume Highway toward Burrinjuck.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-34.9758_degS_and_149.21_degE:
     latitude (deg): -34.9758
     longitude (deg): 149.21
     locality: 1227 Dicks Creek Road, Gundaroo. Behind dam wall.
-    collector: Higgisson, W.; Rath, H.; Lindner, J.
+    recorded by: Higgisson, W.; Rath, H.; Lindner, J.
   site_at_-34.9758_degS_and_149.2114_degE:
     latitude (deg): -34.9758
     longitude (deg): 149.2114
     locality: Property of S. McIntyre, Gang Gang; c. 500 m S on Dicks Creek Road,
       off Yass River Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.9761_degS_and_149.2106_degE:
     latitude (deg): -34.9761
     longitude (deg): 149.2106
     locality: 1227 Dicks Creek Road, Gundaroo.
-    collector: Higgisson, W.; Rath, H.; Lindner, J.
+    recorded by: Higgisson, W.; Rath, H.; Lindner, J.
   site_at_-34.9761_degS_and_149.2119_degE:
     latitude (deg): -34.9761
     longitude (deg): 149.2119
     locality: 1227 Dicks Creek Road, Gundaroo. Behind dam wall.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.9761_degS_and_149.2122_degE:
     latitude (deg): -34.9761
     longitude (deg): 149.2122
     locality: 1227 Dicks Creek Road; 100 m S E of house, on property boundary. Ca
       7.4 km ~NNW of Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-34.9767_degS_and_118.1753_degE:
     latitude (deg): -34.9767
     longitude (deg): 118.1753
     locality: Road to Little Beach, W end of 2 Peoples Bay.
-    collector: Chandler, G.T.
+    recorded by: Chandler, G.T.
   site_at_-34.9769_degS_and_149.2089_degE:
     latitude (deg): -34.9769
     longitude (deg): 149.2089
     locality: 1227 Dicks Creek Road, Gundaroo.
-    collector: Higgisson, W.; Rath, H.; Lindner, J.
+    recorded by: Higgisson, W.; Rath, H.; Lindner, J.
   site_at_-34.9833_degS_and_149.1833_degE:
     latitude (deg): -34.9833
     longitude (deg): 149.1833
     locality: Gundaroo; Dicks Creek Road.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-34.9847_degS_and_118.0267_degE:
     latitude (deg): -34.9847
     longitude (deg): 118.0267
     locality: 1.9 km W along Mt Richards Road from Nanarup Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-34.9994_degS_and_150.6047_degE:
     latitude (deg): -34.9994
     longitude (deg): 150.6047
     locality: Falls Creek, Jervis Bay Road, ca 2 km from intersection with Pricess
       Princes Highway, 200 m south of creek at S-bend in road.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-34_degS_and_140.8833_degE:
     latitude (deg): -34.0
     longitude (deg): 140.8833
     locality: River Murray, NW of Renmark, 1 km below Lock 6.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-34_degS_and_147.3_degE:
     latitude (deg): -34.0
     longitude (deg): 147.3
     locality: 5 km along road to Temora from junction with Mid-western Highway.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.0003_degS_and_150.6047_degE:
     latitude (deg): -35.0003
     longitude (deg): 150.6047
     locality: Falls Creek, Jervis Bay Road, c. 2 km from intersection with Princes
       Highway.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.0119_degS_and_149.1986_degE:
     latitude (deg): -35.0119
     longitude (deg): 149.1986
     locality: Gunnasgunya private property. End of Lees Road, Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0125_degS_and_149.1981_degE:
     latitude (deg): -35.0125
     longitude (deg): 149.1981
     locality: Gunnasgunya private property. End of Lees Road, Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0139_degS_and_149.1964_degE:
     latitude (deg): -35.0139
     longitude (deg): 149.1964
     locality: Gunnasgunya private property. End of Lees Road, Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0164_degS_and_149.2992_degE:
     latitude (deg): -35.0164
     longitude (deg): 149.2992
     locality: McLeods Creek Nature Reserve.
-    collector: Higgisson, W.; Rath, H.; Lindner, J.
+    recorded by: Higgisson, W.; Rath, H.; Lindner, J.
   site_at_-35.0167_degS_and_149.3028_degE:
     latitude (deg): -35.0167
     longitude (deg): 149.3028
     locality: McClouds Creek Reserve, Marked Tree Road, c. 5 km ~NE by road from Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0169_degS_and_149.3014_degE:
     latitude (deg): -35.0169
     longitude (deg): 149.3014
     locality: McLeods Creek Nature Reserve, E of Gundaroo; NW corner of uncleared
       area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0181_degS_and_149.1906_degE:
     latitude (deg): -35.0181
     longitude (deg): 149.1906
     locality: Gundaroo area Gunnasgunya, private property; NW corner.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0194_degS_and_149.2142_degE:
     latitude (deg): -35.0194
     longitude (deg): 149.2142
     locality: Gundaroo area 3 km S on Lees Road, off Back Creek Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0197_degS_and_149.2089_degE:
     latitude (deg): -35.0197
     longitude (deg): 149.2089
     locality: Gundaroo area 3 km S on Lees Road, off Back Creek Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.02_degS_and_149.1892_degE:
     latitude (deg): -35.02
     longitude (deg): 149.1892
     locality: Gundaroo area Gunnusgunya private property.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.0239_degS_and_149.2939_degE:
     latitude (deg): -35.0239
     longitude (deg): 149.2939
     locality: D.Taylor and A.H. property, Dairy Creek Road, Gundaroo and/or McClouds
       Creek Nature Reserve, Marked Tree Road ENE of Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0278_degS_and_149.2944_degE:
     latitude (deg): -35.0278
     longitude (deg): 149.2944
     locality: D.Taylor and A.H. property, Dairy Creek Road, Gundaroo.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-35.0311_degS_and_149.2944_degE:
     latitude (deg): -35.0311
     longitude (deg): 149.2944
     locality: Gundaroo, Lot 99 Dairy Creek Road. At junction of two gullys, NE section
       of lot.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-35.0314_degS_and_149.2967_degE:
     latitude (deg): -35.0314
     longitude (deg): 149.2967
     locality: Gundaroo; Dairy Creek Road, 1.6 km past the rubbish tip; road verge.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.0333_degS_and_139.1167_degE:
     latitude (deg): -35.0333
     longitude (deg): 139.1167
     locality: 9.8 km due N of Monarto South Railway Station, c. 0.3 km W of Monarto
       South-Palmer road.
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-35.0333_degS_and_149.3167_degE:
     latitude (deg): -35.0333
     longitude (deg): 149.3167
     locality: 3.5 km from Gundaroo on road towards Collector.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-35.0336_degS_and_149.2036_degE:
     latitude (deg): -35.0336
     longitude (deg): 149.2036
     locality: Ca 5 km W on Back Creek Road and Cummines Lane, from junction with Sutton
       Road, W of Gundaroo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0364_degS_and_150.6472_degE:
     latitude (deg): -35.0364
     longitude (deg): 150.6472
     locality: Tomerong Road, Huskisson.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.0453_degS_and_149.6714_degE:
     latitude (deg): -35.0453
     longitude (deg): 149.6714
     locality: Two exclosures on western edge of Lake Bathurst. Access via track across
       private property, 2.1 km N of Tarago on Braidwood road.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-35.05_degS_and_150.5_degE:
     latitude (deg): -35.05
     longitude (deg): 150.5
     locality: 9.5 km from Tomerong along Turpentine Road towards Sassafras.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-35.05_degS_and_150.6667_degE:
     latitude (deg): -35.05
     longitude (deg): 150.6667
     locality: Husskison side of Moonee Moonee Creek.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.0597_degS_and_149.6803_degE:
     latitude (deg): -35.0597
     longitude (deg): 149.6803
     locality: Grazing exclosure on margin of SW end of the main lake bed of Lake Bathurst.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-35.0667_degS_and_150.15_degE:
     latitude (deg): -35.0667
     longitude (deg): 150.15
     locality: Turnoff to The Jumps, Touga from Nerriga Road.
-    collector: McMillan, M.
+    recorded by: McMillan, M.
   site_at_-35.0667_degS_and_150.4833_degE:
     latitude (deg): -35.0667
     longitude (deg): 150.4833
     locality: Beside Flat Rock Creek on Turpentine Road, 10.1 km W of Tomerong.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.0667_degS_and_150.4917_degE:
     latitude (deg): -35.0667
     longitude (deg): 150.4917
     locality: Beside Flat Rock Creek on Turpentine Road, 10.1 km W of Tomerong.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.0667_degS_and_150.5833_degE:
     latitude (deg): -35.0667
     longitude (deg): 150.5833
     locality: Tomerong.
-    collector: Seed Store
+    recorded by: Seed Store
   site_at_-35.0714_degS_and_150.6478_degE:
     latitude (deg): -35.0714
     longitude (deg): 150.6478
     locality: Vincentia - Jervis Bay Road, c. 1 km north of Wool Road intersection,
       under power lines.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.0717_degS_and_150.6478_degE:
     latitude (deg): -35.0717
     longitude (deg): 150.6478
     locality: Vincentia, Jervis Bay Road, 1 km N of intersection with Wool Road.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.0817_degS_and_150.2244_degE:
     latitude (deg): -35.0817
     longitude (deg): 150.2244
     locality: 11.5 km W of Nerriga. Coordinates plot c. 15 km E of Nerriga, which
       is about 11.5 km W of Tianjara Falls.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.0828_degS_and_150.3928_degE:
     latitude (deg): -35.0828
     longitude (deg): 150.3928
     locality: Yerriyong State Forest; under power lines (tower 361) on the S side
       of the road c. 7.2 km E/NE of Tianjara Falls.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.0833_degS_and_150.1333_degE:
     latitude (deg): -35.0833
     longitude (deg): 150.1333
     locality: Bulee Gap, 7.1 km from Nerriga towards Nowra.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.0861_degS_and_149.3039_degE:
     latitude (deg): -35.0861
     longitude (deg): 149.3039
     locality: Ca 7.5 km SSE of Gundaroo; Shingle Hill Travelling Stock Reserve c.
       1 km ~N of intersection of Shingle Hill Way and Brooks Creek Lane.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0878_degS_and_149.3025_degE:
     latitude (deg): -35.0878
     longitude (deg): 149.3025
     locality: Ca 7.5 km SSE of Gundaroo; Shingle Hill Travelling Stock Reserve c.
       1 km ~N of intersection of Shingle Hill Way and Brooks Creek Lane.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.0886_degS_and_150.1292_degE:
     latitude (deg): -35.0886
     longitude (deg): 150.1292
     locality: Nerriga Road Bulee Gap.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.0892_degS_and_150.1383_degE:
     latitude (deg): -35.0892
     longitude (deg): 150.1383
     locality: Nerriga Road Bulee Gap.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.0894_degS_and_150.1378_degE:
     latitude (deg): -35.0894
     longitude (deg): 150.1378
     locality: Side of new road up the escarpment c. 6 km NE of Nerriga.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.0939_degS_and_150.3692_degE:
     latitude (deg): -35.0939
     longitude (deg): 150.3692
     locality: Tianjarra Falls, 7.5 km E along Turpentine Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.0953_degS_and_150.6922_degE:
     latitude (deg): -35.0953
     longitude (deg): 150.6922
     locality: Hyams Beach; Chinamans Beach c. 4 km N of Jervis Bay township.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1_degS_and_146.1_degE:
     latitude (deg): -35.1
     longitude (deg): 146.1
     locality: Rothdene road at junction with Griffith-Rankins Springs road, 21 km
       SW of Rankins Springs.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-35.1_degS_and_148.6667_degE:
     latitude (deg): -35.1
     longitude (deg): 148.6667
     locality: 1 km NW of Wee Jasper.
-    collector: Thompson, H.S.
+    recorded by: Thompson, H.S.
   site_at_-35.1_degS_and_150.3167_degE:
     latitude (deg): -35.1
     longitude (deg): 150.3167
     locality: Tianjara Falls.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-35.1111_degS_and_150.3064_degE:
     latitude (deg): -35.1111
     longitude (deg): 150.3064
     locality: Turpentine Road. Tianjara Falls 2.3 km towards Nerriga.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-35.1139_degS_and_150.3111_degE:
     latitude (deg): -35.1139
     longitude (deg): 150.3111
     locality: Turpentine Road. Tianjara Falls 2.2 km towards Nerriga.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-35.1167_degS_and_146.7833_degE:
     latitude (deg): -35.1167
     longitude (deg): 146.7833
     locality: Cultivated Galore Scenic Reserve Arboretum.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.1167_degS_and_150.7_degE:
     latitude (deg): -35.1167
     longitude (deg): 150.7
     locality: 3 km NNE of Cave Beach Road-Jervis Bay Road intersection.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.1167_degS_and_150.7667_degE:
     latitude (deg): -35.1167
     longitude (deg): 150.7667
     locality: Jervis Bay National Park, Murrays Beach.
-    collector: Rudd, R.J.
+    recorded by: Rudd, R.J.
   site_at_-35.1178_degS_and_150.2975_degE:
     latitude (deg): -35.1178
     longitude (deg): 150.2975
     locality: Morton National Park; 4-wheel-drive track turning off the Nerriga -
       Nowra road at the junction of the Boolijah Creek.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.1222_degS_and_150.0803_degE:
     latitude (deg): -35.1222
     longitude (deg): 150.0803
     locality: Nerriga cemetery.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.1333_degS_and_148.6667_degE:
     latitude (deg): -35.1333
     longitude (deg): 148.6667
     locality: 0.6 km WSW of Yass-Micalong Creek road junction, large limestone sinkhole
       (WJ9 painted on cliff face). (Map ref. 8627, 520099)
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.1333_degS_and_150.3333_degE:
     latitude (deg): -35.1333
     longitude (deg): 150.3333
     locality: Tianjara Falls, near carpark on approach to falls.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1333_degS_and_150.6667_degE:
     latitude (deg): -35.1333
     longitude (deg): 150.6667
     locality: Australian National Botanic Gardens Annexe, Lake McKenzie, N side just
       past lookout.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1333_degS_and_150.7167_degE:
     latitude (deg): -35.1333
     longitude (deg): 150.7167
     locality: Canberra University Field Station.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1342_degS_and_150.6994_degE:
     latitude (deg): -35.1342
     longitude (deg): 150.6994
     locality: Road into Cresswell. Navy Land.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1361_degS_and_150.6972_degE:
     latitude (deg): -35.1361
     longitude (deg): 150.6972
     locality: Jervis Bay, in C.B.G. Canberra Botanic.
-    collector: leg. ign.
+    recorded by: leg. ign.
   site_at_-35.1372_degS_and_150.7406_degE:
     latitude (deg): -35.1372
     longitude (deg): 150.7406
     locality: Booderee National Park, 6.1 km E of Entry Station.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.1406_degS_and_150.6736_degE:
     latitude (deg): -35.1406
     longitude (deg): 150.6736
     locality: Booderee National Park, Lake Windermere pump access road, 40 m NW from
       corner of Botanic Gardens fence line, under power lines.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.1414_degS_and_150.6825_degE:
     latitude (deg): -35.1414
     longitude (deg): 150.6825
     locality: Booderee National Park, Caves Beach Road, approx. 1 km from Botanic
       Gardens entrance towards Jervis Bay Road.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.1419_degS_and_150.6667_degE:
     latitude (deg): -35.1419
     longitude (deg): 150.6667
     locality: Australian National Botanic Gardens Annexe, rainforest trail.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1419_degS_and_150.6697_degE:
     latitude (deg): -35.1419
     longitude (deg): 150.6697
     locality: CULTIVATED  Australian National Botanic Gardens Annexe, rainforest.  Probably
       same providence as Australian National Botanic Gardens.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1439_degS_and_150.6733_degE:
     latitude (deg): -35.1439
     longitude (deg): 150.6733
     locality: Booderee Botanic Gardens, across road from potting shed.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.1453_degS_and_150.0683_degE:
     latitude (deg): -35.1453
     longitude (deg): 150.0683
     locality: Nerriga, 4 km S towards Braidwood.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.1478_degS_and_150.1075_degE:
     latitude (deg): -35.1478
     longitude (deg): 150.1075
@@ -7255,1297 +7255,1297 @@ sites:
       via Nerriga Road (c. 1.1 km), then Endrick River Road (c. 1.2 km), then 2.4
       km along a minor road running S and then E, and then 0.7 km along another minor
       road running S. Altitude c. 600 m.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.15_degS_and_150.05_degE:
     latitude (deg): -35.15
     longitude (deg): 150.05
     locality: Nerriga, 4 km SW towards Braidwood.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.15_degS_and_150.65_degE:
     latitude (deg): -35.15
     longitude (deg): 150.65
     locality: Booderee National Park, roundabout at Visitor Center, north west corner
       of roundabout.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.15_degS_and_150.6667_degE:
     latitude (deg): -35.15
     longitude (deg): 150.6667
     locality: Jervis Bay, National Botanic Gardens Annexe.
-    collector: Taylor, J.M.
+    recorded by: Taylor, J.M.
   site_at_-35.15_degS_and_150.7_degE:
     latitude (deg): -35.15
     longitude (deg): 150.7
     locality: 2.2 km S of Jervis Bay township, junction of Wreck Bay and Stony Creek
       roads.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-35.1572_degS_and_149.16_degE:
     latitude (deg): -35.1572
     longitude (deg): 149.16
     locality: Mulligans Flat Nature Reserve, in Sanctuary between gates 4 and 5 in
       Kangaroo exclusion zone.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1578_degS_and_149.0603_degE:
     latitude (deg): -35.1578
     longitude (deg): 149.0603
     locality: Stock Reserve on the northern ACT-NSW border on the Barton Highway;
       access from parking bay on NSW side; 50 m in from fence.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1606_degS_and_149.0606_degE:
     latitude (deg): -35.1606
     longitude (deg): 149.0606
     locality: Hall Travelling Stock Reserve on the west side of the Barton highway
       at the ACT/NSW border.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1647_degS_and_149.0644_degE:
     latitude (deg): -35.1647
     longitude (deg): 149.0644
     locality: Northern fenceline of northern paddock of Gibbes Street Hall horse paddock,
       120 m W of dam in NE corner of paddock. 35 deg 9 52.9 S, 149 deg 3 51.51 E.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.165_degS_and_149.0633_degE:
     latitude (deg): -35.165
     longitude (deg): 149.0633
     locality: Hall; c. 430 m NW of horse yards at corner of Gibbes and Hoskins Streets;
       NE corner of Gibbes Street horse paddocks.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.165_degS_and_149.0636_degE:
     latitude (deg): -35.165
     longitude (deg): 149.0636
     locality: Hall; c. 420 m NW of horse yards at corner of Gibbes and Hoskins Streets;
       NE corner of Gibbes Street horse paddocks.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1653_degS_and_150.4394_degE:
     latitude (deg): -35.1653
     longitude (deg): 150.4394
     locality: Twelve Mile Road, towards Boyd Lookout from Princes Highway c. 40 km
       S of Nowra; under power line.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1656_degS_and_149.1825_degE:
     latitude (deg): -35.1656
     longitude (deg): 149.1825
     locality: Mulligans Flat Nature Reserve; E end of sanctuary. 35 9 55.7 S 149 10
       57.4 E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.1656_degS_and_149.8967_degE:
     latitude (deg): -35.1656
     longitude (deg): 149.8967
     locality: Nadgigomar National Reserve, 650 m south on Mogo Road, from the northern
       edge of the reserve. Ca 250 m NW in a small ephemeral wetland.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-35.1656_degS_and_150.3783_degE:
     latitude (deg): -35.1656
     longitude (deg): 150.3783
     locality: Morton National Park near Granite Falls off Twelve Mile Road west of
       the Princes Highway, turn-off c. 40 km S of Nowra.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1661_degS_and_149.0628_degE:
     latitude (deg): -35.1661
     longitude (deg): 149.0628
     locality: Gibbes Street, Hall Horse Paddock. On marked Hall walk, c. 300 m NW
       of horseyards at the corner of Gibbes and Hoskins Streets.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1667_degS_and_149.0625_degE:
     latitude (deg): -35.1667
     longitude (deg): 149.0625
     locality: Hall; c. 320 m NW of horse yards at corner of Gibbes and Hoskins Streets;
       NE corner of Gibbes Street horse paddocks.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1667_degS_and_149.0636_degE:
     latitude (deg): -35.1667
     longitude (deg): 149.0636
     locality: Gibbes Street, Hall Horse Paddock. On marked Hall walk, c. 400 m NW
       of horseyards at the corner of Gibbes and Hoskins Streets.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1667_degS_and_149.0833_degE:
     latitude (deg): -35.1667
     longitude (deg): 149.0833
     locality: CSIRO Ginninderra Research Station, rocky knoll W of Homeleigh.
-    collector: Stewart, G.
+    recorded by: Stewart, G.
   site_at_-35.1667_degS_and_149.1492_degE:
     latitude (deg): -35.1667
     longitude (deg): 149.1492
     locality: Mulligans Flat Nature Reserve; on eastern side of access road 370 m
       along track from Amy Ackman Street entrance gate (80 m in from fence adjacent
       to the Doris Turner Street T junction in Forde (outside fence)).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1667_degS_and_149.1667_degE:
     latitude (deg): -35.1667
     longitude (deg): 149.1667
     locality: Micalong Reserve, up slope along road to Billy Grace Reserve (towards
       Wee Jasper).
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.1667_degS_and_150.6167_degE:
     latitude (deg): -35.1667
     longitude (deg): 150.6167
     locality: Jervis Bay National Park, Bherwerre Beach.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.1667_degS_and_150.7333_degE:
     latitude (deg): -35.1667
     longitude (deg): 150.7333
     locality: Jervis Bay Nature Reserve.
-    collector: McMillan, M.
+    recorded by: McMillan, M.
   site_at_-35.1669_degS_and_150.4106_degE:
     latitude (deg): -35.1669
     longitude (deg): 150.4106
     locality: Twelve Mile Road, on the way to Boyd Lookout c. 3 km west of the Princes
       Highway, turn-off c. 40 km S of Nowra.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1692_degS_and_149.1744_degE:
     latitude (deg): -35.1692
     longitude (deg): 149.1744
     locality: Mulligans Flat Nature Reserve, inside Mulligans Flat sanctuary.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.1706_degS_and_149.1811_degE:
     latitude (deg): -35.1706
     longitude (deg): 149.1811
     locality: Mulligans Flat Nature Reserve, SE corner of Mulligans Flat sanctuary.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.1708_degS_and_149.1811_degE:
     latitude (deg): -35.1708
     longitude (deg): 149.1811
     locality: Canberra Nature Park; Mulligans Flat, on access road 120 m short of
       the Bustard Gate in SE corner.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1711_degS_and_149.1833_degE:
     latitude (deg): -35.1711
     longitude (deg): 149.1833
     locality: Mulligans Flat Nature Reserve; 60 m S of gate in Vermin Proof Fence
       accessed by track from southern Goorooyaroo entrance on Horse Park Drive. 35
       deg 10 16.4 S, 149 deg 10 59.8 E.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1722_degS_and_149.0569_degE:
     latitude (deg): -35.1722
     longitude (deg): 149.0569
     locality: Hall Cemetery on Wallaroo Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1725_degS_and_150.7011_degE:
     latitude (deg): -35.1725
     longitude (deg): 150.7011
     locality: Booderee National Park, Blacks Waterhole, track on northern side.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.1731_degS_and_149.0572_degE:
     latitude (deg): -35.1731
     longitude (deg): 149.0572
     locality: Hall Cemetery.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.1736_degS_and_149.1844_degE:
     latitude (deg): -35.1736
     longitude (deg): 149.1844
     locality: Goorooyarroo Nature Reserve, 300 m from Mulligans woodland Sanctuary
       gate.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.1739_degS_and_150.0281_degE:
     latitude (deg): -35.1739
     longitude (deg): 150.0281
     locality: Corang River, near Oallen - Nerriga road crossing.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-35.1742_degS_and_149.0636_degE:
     latitude (deg): -35.1742
     longitude (deg): 149.0636
     locality: Hall area; on N side of Gladstone Street between Hall and Barton Highway,
       100 m E from Barton Highway beside access gate to powerlines.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.1744_degS_and_150.37_degE:
     latitude (deg): -35.1744
     longitude (deg): 150.37
     locality: Boyd Lookout near Twelve Mile Road c. 7.5 km west of the Princes Highway,
       turn-off c. 40 km S of Nowra.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.1819_degS_and_150.6686_degE:
     latitude (deg): -35.1819
     longitude (deg): 150.6686
     locality: Booderee National Park, Brooks Lookout,
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-35.1833_degS_and_150.25_degE:
     latitude (deg): -35.1833
     longitude (deg): 150.25
     locality: Morton National Park, Camping Rock Creek, at crossing of New Haven Gap
       - The Vines fire trail.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.19_degS_and_149.1803_degE:
     latitude (deg): -35.19
     longitude (deg): 149.1803
     locality: Goorooyarroo Nature Reserve.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.1914_degS_and_149.1817_degE:
     latitude (deg): -35.1914
     longitude (deg): 149.1817
     locality: Goorooyarroo Nature Reserve. 35 11 28.9 S 149 10 53.8 E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.2_degS_and_149.1_degE:
     latitude (deg): -35.2
     longitude (deg): 149.1
     locality: Gungahlin Hill Reserve, near entrance off Barton Highway.
-    collector: Wallace, B.J.
+    recorded by: Wallace, B.J.
   site_at_-35.2_degS_and_150.05_degE:
     latitude (deg): -35.2
     longitude (deg): 150.05
     locality: Corang River, Braidwood-Nerriga Rd. (near bridge).
-    collector: Wrigley, J.W.
+    recorded by: Wrigley, J.W.
   site_at_-35.2_degS_and_150.2333_degE:
     latitude (deg): -35.2
     longitude (deg): 150.2333
     locality: Camping Rock Creek.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.2008_degS_and_149.2244_degE:
     latitude (deg): -35.2008
     longitude (deg): 149.2244
     locality: Bidges Road, 750 m from Federal Highway service road on right W side,
       roadside.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2031_degS_and_149.1808_degE:
     latitude (deg): -35.2031
     longitude (deg): 149.1808
     locality: Goorooyarroo Nature Reserve; W side of Gecko Hills, 20 m below gate
       on Goorooyarroo track.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.2044_degS_and_149.1756_degE:
     latitude (deg): -35.2044
     longitude (deg): 149.1756
     locality: Goorooyarroo Nature Reserve; walking track on the N side of Burnt Stump
       Hill.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.2058_degS_and_149.1222_degE:
     latitude (deg): -35.2058
     longitude (deg): 149.1222
     locality: Gungaderra Nature Reserve; Gungahlin Hill, Barton Highway, 340 m NE
       of ACTEW Water Tank.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2058_degS_and_150.0514_degE:
     latitude (deg): -35.2058
     longitude (deg): 150.0514
     locality: Braidwood - Nerriga road, at crossing of Corang River near Kings Flat
       - Travelling Stock Reserve.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2083_degS_and_148.675_degE:
     latitude (deg): -35.2083
     longitude (deg): 148.675
     locality: 12.3 km from Yass Road, along Nottingham Road toward Tumut.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.2119_degS_and_149.1125_degE:
     latitude (deg): -35.2119
     longitude (deg): 149.1125
     locality: Canberra Nature Park, Gungahlin Hill; 1 km from Crace development; 100
       m off Barton Highway.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2133_degS_and_149.1161_degE:
     latitude (deg): -35.2133
     longitude (deg): 149.1161
     locality: Paddock on N side of Gungaderra Woodland Reserve, adjacent to 1RPH radio
       station on Barton Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2142_degS_and_150.05_degE:
     latitude (deg): -35.2142
     longitude (deg): 150.05
     locality: Corang River crossing Braidwood - Nerriga Road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.2167_degS_and_139.5833_degE:
     latitude (deg): -35.2167
     longitude (deg): 139.5833
     locality: Murray region. Karoonda to Tailem Bend Road, 10km from Tailem Bend.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.2167_degS_and_145.1333_degE:
     latitude (deg): -35.2167
     longitude (deg): 145.1333
     locality: 8 km from Conargo towards Hay on Willurah road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.2167_degS_and_149.0833_degE:
     latitude (deg): -35.2167
     longitude (deg): 149.0833
     locality: Belconnen Naval Station, NW corner. Grid ref. 6 896 61 006
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-35.2167_degS_and_149.125_degE:
     latitude (deg): -35.2167
     longitude (deg): 149.125
     locality: Canberra, Barton Highway, opposite entrance to CSIRO Wildlife Research.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.2167_degS_and_149.7333_degE:
     latitude (deg): -35.2167
     longitude (deg): 149.7333
     locality: C. 1 km NW of Sight Hill, c. 24 km NNW of Braidwood.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-35.2169_degS_and_149.2269_degE:
     latitude (deg): -35.2169
     longitude (deg): 149.2269
     locality: Private property, 241 Bidges Road, Sutton, 2620. Adjjacent to property
       of 239 Bidges Road - 50 m from fenceline. 35 deg 13 1.0 S, 149 deg 13 36.5 E
       (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2175_degS_and_149.1114_degE:
     latitude (deg): -35.2175
     longitude (deg): 149.1114
     locality: Stirling Park, 150 m S of Canberra Yacht Club, on bike trail.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2178_degS_and_149.2264_degE:
     latitude (deg): -35.2178
     longitude (deg): 149.2264
     locality: Private property, 241 Bidges Road, Sutton; 200 m from main gate along
       driveway.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2183_degS_and_149.2292_degE:
     latitude (deg): -35.2183
     longitude (deg): 149.2292
     locality: 241 Bidges Road (private property) Sutton, adjacent to Defence Land
       on ACT border.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2189_degS_and_149.0842_degE:
     latitude (deg): -35.2189
     longitude (deg): 149.0842
     locality: Belconnen Naval Station, towards NW corner.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.2192_degS_and_149.0839_degE:
     latitude (deg): -35.2192
     longitude (deg): 149.0839
     locality: Belconnen Naval Station, towards NW corner.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.2194_degS_and_149.2258_degE:
     latitude (deg): -35.2194
     longitude (deg): 149.2258
     locality: Private property, 241 Bidges Road, Sutton; ca halfway along entrance
       driveway. 35 deg 13 9.6 S, 149 deg 13 33.2 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2197_degS_and_149.2269_degE:
     latitude (deg): -35.2197
     longitude (deg): 149.2269
     locality: 241 Bidges Road, Sutton. Private Property. 200 m from main gate up driveway.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2197_degS_and_149.23_degE:
     latitude (deg): -35.2197
     longitude (deg): 149.23
     locality: 241 Bidges Road, Sutton. Private Property.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.22_degS_and_149.0836_degE:
     latitude (deg): -35.22
     longitude (deg): 149.0836
     locality: Belconnen Naval Station, towards NW corner.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.2211_degS_and_149.0828_degE:
     latitude (deg): -35.2211
     longitude (deg): 149.0828
     locality: Belconnen Naval Station adjacent to Lake Ginninderra.
-    collector: Sharp, S.
+    recorded by: Sharp, S.
   site_at_-35.2211_degS_and_149.2281_degE:
     latitude (deg): -35.2211
     longitude (deg): 149.2281
     locality: Private property, 241 Bidges Road, Sutton; 400 m from entrance gate,
       roadside - easterly. 35 deg 13 15.5 S, 149 deg 13 41.3 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2211_degS_and_149.2283_degE:
     latitude (deg): -35.2211
     longitude (deg): 149.2283
     locality: Private property, 241 Bidges Road, Sutton, 2620. Along driveway 0.8
       km from main gate. Waypoint 057. 35 deg 13 15.5 S, 149 deg 13 41.8 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2211_degS_and_149.2292_degE:
     latitude (deg): -35.2211
     longitude (deg): 149.2292
     locality: Private property, 241 Bidges Road, Sutton, 2620. Waypoint 043. 35 deg
       13 16.2 S, 149 deg 13 45.4 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2214_degS_and_149.2286_degE:
     latitude (deg): -35.2214
     longitude (deg): 149.2286
     locality: 241 Bidges Road, Sutton. Private Property.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2217_degS_and_149.1775_degE:
     latitude (deg): -35.2217
     longitude (deg): 149.1775
     locality: Canberra Nature Park Mount Majura Nature Reserve; just off Northbourne
       Avenue opposite Bendora Kennels.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.2217_degS_and_149.2303_degE:
     latitude (deg): -35.2217
     longitude (deg): 149.2303
     locality: 241 Bidges Road, Sutton. Private Property.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2217_degS_and_149.2317_degE:
     latitude (deg): -35.2217
     longitude (deg): 149.2317
     locality: Private property, 241 Bidges Road, Sutton.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2219_degS_and_149.1753_degE:
     latitude (deg): -35.2219
     longitude (deg): 149.1753
     locality: 1 km from the Antill St, Watson turn off along Federal Highway, at gate
       leading to Mount Majura.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2219_degS_and_149.1761_degE:
     latitude (deg): -35.2219
     longitude (deg): 149.1761
     locality: Canberra Nature Park; Mount Majura Reserve; Federal Highway entrance
       (Waypoint 34) - 150 m S - Gungahlin/Fyshwick exit sign Waypoint 033. 35 13 18.8
       S, 149 10 34.1 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2219_degS_and_149.2303_degE:
     latitude (deg): -35.2219
     longitude (deg): 149.2303
     locality: Private property, 241 Bidges Road, Sutton. 35 deg 13 18.8 S, 149 deg
       13 49 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2219_degS_and_149.2311_degE:
     latitude (deg): -35.2219
     longitude (deg): 149.2311
     locality: Private property, 241 Bidges Road, Sutton; adjacent to ACT border.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2228_degS_and_149.1744_degE:
     latitude (deg): -35.2228
     longitude (deg): 149.1744
     locality: Canberra Nature Park; Mount Majura. On Mount Majura horse trail access
       road at northern end 100 m from Federal Highway gate.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2231_degS_and_149.1778_degE:
     latitude (deg): -35.2231
     longitude (deg): 149.1778
     locality: Canberra Nature Park; Mount Majura Reserve. Waypoint 036, c. 300 m ~S
       of main entrance on Federal Highway, off the equestrian track; 100 m S of S.Fethers
       454 (Waypoint 035). 35 deg 13 23.4 S, 149 deg 10 39.7 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2247_degS_and_149.1792_degE:
     latitude (deg): -35.2247
     longitude (deg): 149.1792
     locality: Canberra Nature Park; Mount Majura Reserve; 461 m from start of track
       at Federal Highway entrance. Waypoint 048. 35 13 29.4 S, 149 10 45.0 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.225_degS_and_147.85_degE:
     latitude (deg): -35.225
     longitude (deg): 147.85
     locality: 5 km due S of Snowy Mountains Highway turnoff Hume Highway. Mt Yaven
       - property of Gary and Louise Orr.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-35.2258_degS_and_149.1803_degE:
     latitude (deg): -35.2258
     longitude (deg): 149.1803
     locality: Canberra Nature Park; Mount Majura access road at northern end, 500
       m ~S from Barton Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2297_degS_and_149.1781_degE:
     latitude (deg): -35.2297
     longitude (deg): 149.1781
     locality: Canberra Nature Park; Mount Majura Reserve. Ca 1 km directly S of main
       entrance on Federal Highway, near the equestrian track; 200 m along track from
       S.Fethers 456. 35 deg 13 46.5 S, 149 deg 10 41.3 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2333_degS_and_139.1167_degE:
     latitude (deg): -35.2333
     longitude (deg): 139.1167
     locality: Ferries McDonald Conservation Park; 11.4 km from Monarto South toward
       Langhorne Creek.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.2333_degS_and_148.9167_degE:
     latitude (deg): -35.2333
     longitude (deg): 148.9167
     locality: Near Brookvale entrance, on Mountain Creek Rd.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.2333_degS_and_150_degE:
     latitude (deg): -35.2333
     longitude (deg): 150.0
     locality: 41.6 km towards Nerriga from Braidwood turnoff, ford at Corange River.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.2336_degS_and_149.1806_degE:
     latitude (deg): -35.2336
     longitude (deg): 149.1806
     locality: Canberra Nature Park; Mount Majura. Access off Majura Road via road
       to Tracking Station. Ca 600 m past gate in saddle then walk 100 m NW towards
       rock outcrops.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2425_degS_and_149.1775_degE:
     latitude (deg): -35.2425
     longitude (deg): 149.1775
     locality: Canberra Nature Park; Mount Majura Nature Reserve, Mount Majura Summit
       Track Casuarina Trail, 2/3 of the way up, from powerline carpark on Antill Street.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2436_degS_and_149.1731_degE:
     latitude (deg): -35.2436
     longitude (deg): 149.1731
     locality: Canberra Nature Park; Mount Majura - Antill Street entrance, N of Hackett;
       0.41 km (straight line GPS) at 73 degrees from water tank c. 0.7 km SE of entrance;
       gully off access road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2461_degS_and_149.45_degE:
     latitude (deg): -35.2461
     longitude (deg): 149.45
     locality: CULTIVATED Bungendore; Elmslea private property, DP1048816, Lot 314.
-    collector: Rehwinkel, R.
+    recorded by: Rehwinkel, R.
   site_at_-35.2478_degS_and_149.4489_degE:
     latitude (deg): -35.2478
     longitude (deg): 149.4489
     locality: 23 McCusker Drive, Bungendore; Rainer Rehwinkels property.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.2494_degS_and_149.1125_degE:
     latitude (deg): -35.2494
     longitude (deg): 149.1125
     locality: OConnor Ridge, OConnor a suburb of Canberra.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.25_degS_and_149.1_degE:
     latitude (deg): -35.25
     longitude (deg): 149.1
     locality: Lyneham; reserve opposite Dryandra & Wattle Street intersection.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-35.2536_degS_and_149.11_degE:
     latitude (deg): -35.2536
     longitude (deg): 149.11
     locality: Canberra Nature Park OConnor Ridge.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.2544_degS_and_149.1106_degE:
     latitude (deg): -35.2544
     longitude (deg): 149.1106
     locality: Canberra Nature Park OConnor Ridge.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.2592_degS_and_149.0397_degE:
     latitude (deg): -35.2592
     longitude (deg): 149.0397
     locality: Canberra Nature Park The Pinnacle Reserve.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.2639_degS_and_149.0814_degE:
     latitude (deg): -35.2639
     longitude (deg): 149.0814
     locality: Canberra Nature Park; Aranda Bushland Reserve; c. 200 m E of Galali
       Place entrance along Aranda Horse Trail (Waypoint 032, 200 m ENE of Waypoint
       31, S.Fethers 451). 35 deg 15 50.2 S, 149 deg 4 53 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2644_degS_and_149.0275_degE:
     latitude (deg): -35.2644
     longitude (deg): 149.0275
     locality: Belconnen Reserve (former grazing land W of William Hovell Drive).
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.2644_degS_and_149.0811_degE:
     latitude (deg): -35.2644
     longitude (deg): 149.0811
     locality: Canberra Nature Park; Aranda Bushland Reserve; 150 m SE of Galali Place
       entrance (Waypoint 031). 35 deg 15 51.9 S, 149 deg 4 51.9 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2647_degS_and_149.0781_degE:
     latitude (deg): -35.2647
     longitude (deg): 149.0781
     locality: Canberra Nature Park, Arandra Bushland; 100 m from Aranda house track
       near Wargi Place.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2653_degS_and_149.025_degE:
     latitude (deg): -35.2653
     longitude (deg): 149.025
     locality: Canberra Nature Park; Kama Nature Reserve, dam on Dam Walk,
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2664_degS_and_149.1086_degE:
     latitude (deg): -35.2664
     longitude (deg): 149.1086
     locality: Canberra Nature Park, Black Mountain Reserve; on powerline track, 430
       m N of Black Mountain Power Transmission Station, Frith Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2667_degS_and_136.8833_degE:
     latitude (deg): -35.2667
     longitude (deg): 136.8833
     locality: Innes National Park; 6.3 km from Stenhouse Bay toward Pondalowie Bay.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.2667_degS_and_146.1333_degE:
     latitude (deg): -35.2667
     longitude (deg): 146.1333
     locality: 200 m W of NW entrance of Urana Nature Reserve.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.2667_degS_and_148.5917_degE:
     latitude (deg): -35.2667
     longitude (deg): 148.5917
     locality: 26 km from Yass Road, along Nottingham Road toward Tumut.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.2667_degS_and_149.0667_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.0667
     locality: On a slope near horse paddocks at Wybalena Grove, Cook, Canberra.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2667_degS_and_149.0917_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.0917
     locality: Canberra Nature Park Black Mountain Reserve.
-    collector: Hampshire, R.U.
+    recorded by: Hampshire, R.U.
   site_at_-35.2667_degS_and_149.1_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.1
     locality: Outside Australian National Botanic Gardens boundary fence between ANBG
       and CSIRO.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.2667_degS_and_149.1089_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.1089
     locality: Canberra Nature Park, Black Mountain Reserve; on powerline track, c.
       400 m N of Frith Road Power Transmission Station gate.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2667_degS_and_149.1167_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.1167
     locality: CULTIVATED  Australian National Botanic Gardens, Rainforest Gully.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.2667_degS_and_149.9167_degE:
     latitude (deg): -35.2667
     longitude (deg): 149.9167
     locality: 23 km from Braidwood towards Nerriga via Charleyong.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.2669_degS_and_149.095_degE:
     latitude (deg): -35.2669
     longitude (deg): 149.095
     locality: Black Mountain Nature Reserve, 730 m from Belconnen Way turn-off.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2678_degS_and_149.0797_degE:
     latitude (deg): -35.2678
     longitude (deg): 149.0797
     locality: Canberra Nature Park; Aranda Bushland; about the middle of the power
       line track (Waypoint 027.)
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2681_degS_and_149.105_degE:
     latitude (deg): -35.2681
     longitude (deg): 149.105
     locality: Canberra Nature Park; Black Mountain Reserve; Waypoint 013, 393 m NW
       of gate of ACTEW power station (Waypoint 11).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2683_degS_and_149.1086_degE:
     latitude (deg): -35.2683
     longitude (deg): 149.1086
     locality: Canberra Nature Park, Black Mountain Reserve; on powerline track, 226
       m N from Frith  Road Power Transmission Station gate (straight line GPS).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2683_degS_and_149.1097_degE:
     latitude (deg): -35.2683
     longitude (deg): 149.1097
     locality: Canberra Nature Park; Black Mountain, road verge on Frith Road, adjacent
       to stile allowing walker access.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2686_degS_and_149.0756_degE:
     latitude (deg): -35.2686
     longitude (deg): 149.0756
     locality: Canberra Nature Park, Aranda Bushland; 100 m N of main gate on Bindubi
       Street.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2686_degS_and_149.1083_degE:
     latitude (deg): -35.2686
     longitude (deg): 149.1083
     locality: Canberra Nature Park; Black Mountain Reserve; Waypoint 012, 204 m N
       of gate of ACTEW power station (Waypoint 011), just over hump.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2689_degS_and_149.0814_degE:
     latitude (deg): -35.2689
     longitude (deg): 149.0814
     locality: Canberra Nature Park; Aranda Bushland Reserve; 300 m up Powerline Track
       Waypoint 045 - at bend of track. 35 16 0.8 S, 149 4 53.2 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2694_degS_and_147.7278_degE:
     latitude (deg): -35.2694
     longitude (deg): 147.7278
     locality: Adjacent to Tarcutta cemetery, to the S.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.2694_degS_and_149.7017_degE:
     latitude (deg): -35.2694
     longitude (deg): 149.7017
     locality: Jamaleopa Road between Bungendore and Braidwood.
-    collector: Mallinson, D.J.
+    recorded by: Mallinson, D.J.
   site_at_-35.2697_degS_and_149.0833_degE:
     latitude (deg): -35.2697
     longitude (deg): 149.0833
     locality: Canberra Nature Park, Aranda Bushland; along main walking track; 707
       m (directly) E of main gate on Bindubi Street (straight line GPS).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2717_degS_and_149.0881_degE:
     latitude (deg): -35.2717
     longitude (deg): 149.0881
     locality: CULTIVATED Caswell Drive, on edge of road by Gungahlin Drive Sign post;
       on right 1 km S from Belconnen Way. 35 deg 16 17.6 S, 149 deg 5 16.6 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2719_degS_and_149.08_degE:
     latitude (deg): -35.2719
     longitude (deg): 149.08
     locality: Canberra Nature Park; Aranda Bushland Reserve; Frost Hollow to Forest
       Walk. Waypoint 047. 35 16 19.3 S, 149 4 48.0 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2719_degS_and_149.0978_degE:
     latitude (deg): -35.2719
     longitude (deg): 149.0978
     locality: Canberra Nature Park; circuit walk near top of Black Mountain.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2719_degS_and_149.0981_degE:
     latitude (deg): -35.2719
     longitude (deg): 149.0981
     locality: Canberra Nature Park; Black Mountain, three-quarters of the way up the
       north-western slope.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2725_degS_and_149.2997_degE:
     latitude (deg): -35.2725
     longitude (deg): 149.2997
     locality: Wamboin Reserve; behind 159/161 Poppet Road, Wamboin c. 1 km SE of Poppet
       Road. Waypoint 56.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2731_degS_and_149.1092_degE:
     latitude (deg): -35.2731
     longitude (deg): 149.1092
     locality: CULTIVATED Australian National Botanic Gardens, Canberra; section 189.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.2744_degS_and_149.0994_degE:
     latitude (deg): -35.2744
     longitude (deg): 149.0994
     locality: Canberra Nature Park; Black Mountain, three-quarters of the way up the
       north-eastern slope.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2753_degS_and_149.0797_degE:
     latitude (deg): -35.2753
     longitude (deg): 149.0797
     locality: Canberra Nature Park; Aranda Bushland; W of Snow Gum area close to William
       Hovell Drive. (Waypoint 029). 35 deg 16 30.6 S, 149 deg 4 47.0 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2753_degS_and_149.0886_degE:
     latitude (deg): -35.2753
     longitude (deg): 149.0886
     locality: Canberra Nature Park; Black Mountain, base of western slope, 20 m from
       car park off Gungahlin Drive / Caswell Drive.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2756_degS_and_147.0747_degE:
     latitude (deg): -35.2756
     longitude (deg): 147.0747
     locality: The Rock Nature Reserve, Yerong Trail, 3 km from carpark, near summit.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2756_degS_and_149.0992_degE:
     latitude (deg): -35.2756
     longitude (deg): 149.0992
     locality: Canberra Nature Park; Black Mountain, three-quarters of the way up the
       eastern slope.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2758_degS_and_149.0883_degE:
     latitude (deg): -35.2758
     longitude (deg): 149.0883
     locality: Canberra Nature Park; Black Mountain, western base.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2758_degS_and_149.0889_degE:
     latitude (deg): -35.2758
     longitude (deg): 149.0889
     locality: Canberra Nature Park; Black Mountain Reserve; Woodland Fire Trail Track,
       60.7 m W of style entrance off E side of Caswell Drive. (Waypoint 015.) 35 deg
       16 33 S, 149 deg 5 20.1 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2761_degS_and_149.6897_degE:
     latitude (deg): -35.2761
     longitude (deg): 149.6897
     locality: Kings Highway between Bungendore and Braidwood; roadside at Jamaleopa
       Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2767_degS_and_149.0964_degE:
     latitude (deg): -35.2767
     longitude (deg): 149.0964
     locality: Canberra Nature Park; Black Mountain, three-quarters of the way up the
       southern slope.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.2775_degS_and_149.105_degE:
     latitude (deg): -35.2775
     longitude (deg): 149.105
     locality: CULTIVATED Australian National Botanic Gardens, Section 185.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.28_degS_and_149.0883_degE:
     latitude (deg): -35.28
     longitude (deg): 149.0883
     locality: Canberra Nature Park; Black Mountain, SW corner; cleared grassy areas
       near William Hovell Drive - Parkes Way junction with cycle path; 30 m N of access
       track that runs E-W.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2806_degS_and_149.1_degE:
     latitude (deg): -35.2806
     longitude (deg): 149.1
     locality: Black Mountain, upper W side of creek flowing SW from near summit.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.2811_degS_and_150.1894_degE:
     latitude (deg): -35.2811
     longitude (deg): 150.1894
     locality: Budawang National Park, Monolith Valley, at base of valley along track
       in heathland.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.2833_degS_and_136.9333_degE:
     latitude (deg): -35.2833
     longitude (deg): 136.9333
     locality: Innes National Park 1.4 km from Stenhouse Bay toward Inneston.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.2833_degS_and_140.1167_degE:
     latitude (deg): -35.2833
     longitude (deg): 140.1167
     locality: Cultivated ANBG Section 100 ex CABG 618536
-    collector: Umback, J.
+    recorded by: Umback, J.
   site_at_-35.2833_degS_and_146.05_degE:
     latitude (deg): -35.2833
     longitude (deg): 146.05
     locality: 20 km W of Urana along Jerilderie road, 50 m S of road.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.2833_degS_and_149.1167_degE:
     latitude (deg): -35.2833
     longitude (deg): 149.1167
     locality: CULTIVATED Australian National Botanic Gardens, Canberra; Section 219.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2833_degS_and_150.1333_degE:
     latitude (deg): -35.2833
     longitude (deg): 150.1333
     locality: Morton National Park, c. 2.5 km ENE of Corang Peak at Yurnga Lookout.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.2833_degS_and_150.1911_degE:
     latitude (deg): -35.2833
     longitude (deg): 150.1911
     locality: NE end of Monolith Valley.
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-35.2836_degS_and_148.8117_degE:
     latitude (deg): -35.2836
     longitude (deg): 148.8117
     locality: Brindabella National Park, 1.8 km west of Mount Coree camp ground.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2836_degS_and_150.1031_degE:
     latitude (deg): -35.2836
     longitude (deg): 150.1031
     locality: Morton National Park; top of Corang Peak.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.2864_degS_and_150.1033_degE:
     latitude (deg): -35.2864
     longitude (deg): 150.1033
     locality: Morton National Park Corang Peak, 6 km E of Wog Wog campsite.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2867_degS_and_149.2111_degE:
     latitude (deg): -35.2867
     longitude (deg): 149.2111
     locality: MFFR - Department of Defence. Next to Fairbairn Airport. Path next to
       private land. EACT3.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.2889_degS_and_149.0839_degE:
     latitude (deg): -35.2889
     longitude (deg): 149.0839
     locality: Yarramundi Reach near the Aboriginal Art Gallery on Lady Denman Drive.
       Ca 150 m from Lake Burley Griffin.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.2889_degS_and_149.1164_degE:
     latitude (deg): -35.2889
     longitude (deg): 149.1164
     locality: Australian National University, 100 m to the S of Staff Centre.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.2897_degS_and_150.1964_degE:
     latitude (deg): -35.2897
     longitude (deg): 150.1964
     locality: Budawang National Park. On track leading up to The Castle, from the
       Long Gully Road campsite (Kalianna Ridge).
-    collector: Taylor, D.A.
+    recorded by: Taylor, D.A.
   site_at_-35.2914_degS_and_149.26_degE:
     latitude (deg): -35.2914
     longitude (deg): 149.26
     locality: Kowen Forest, up access road on E side of Sutton Road 4.8 km N from
       Fairbairn Avenue Pialligo Avenue, 200 m directly E of Sutton Road, above and
       N of creek gully.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2922_degS_and_149.2581_degE:
     latitude (deg): -35.2922
     longitude (deg): 149.2581
     locality: Kowen Forest, on E side of Sutton Road 4.8 km N from Fairbairn Avenue
       Pialligo Avenue, 90 m E of Sutton Road (over fence) on N side of creek gully.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.2958_degS_and_136.8839_degE:
     latitude (deg): -35.2958
     longitude (deg): 136.8839
     locality: Innes National Park; Cape Spencer.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.2972_degS_and_148.8072_degE:
     latitude (deg): -35.2972
     longitude (deg): 148.8072
     locality: Brindabella National Park, Mount Coree camp ground.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3_degS_and_145.8_degE:
     latitude (deg): -35.3
     longitude (deg): 145.8
     locality: c. 25 km direct NE of Jerilderie, 500 m along the road towards Urana
       from its intersection with the Newell Highway.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.3_degS_and_149.1_degE:
     latitude (deg): -35.3
     longitude (deg): 149.1
     locality: Australian National Botanic Gardens, Section 167.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.3_degS_and_149.1167_degE:
     latitude (deg): -35.3
     longitude (deg): 149.1167
     locality: Canberra, Lady Denman Drive, just N of and across the road from entrance
       to the riding school.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-35.3008_degS_and_149.1114_degE:
     latitude (deg): -35.3008
     longitude (deg): 149.1114
     locality: Canberra Stirling Park, northern side.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3025_degS_and_149.1131_degE:
     latitude (deg): -35.3025
     longitude (deg): 149.1131
     locality: Attunga Point, Alexandrina Drive Yarralumla.
-    collector: Sharp, S.
+    recorded by: Sharp, S.
   site_at_-35.3067_degS_and_149.1375_degE:
     latitude (deg): -35.3067
     longitude (deg): 149.1375
     locality: St Marks grassland, Barton, ACT.  Between Blackall St/Bowen Drive and
       Kings Avenue.
-    collector: Sharp, S.
+    recorded by: Sharp, S.
   site_at_-35.3083_degS_and_148.8333_degE:
     latitude (deg): -35.3083
     longitude (deg): 148.8333
     locality: Blue Range road.
-    collector: Fagg, M.
+    recorded by: Fagg, M.
   site_at_-35.3167_degS_and_149.2833_degE:
     latitude (deg): -35.3167
     longitude (deg): 149.2833
     locality: c. 9 km direct SW of Bungendore at Kowen Stock Reserve.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.3167_degS_and_149.4_degE:
     latitude (deg): -35.3167
     longitude (deg): 149.4
     locality: 2 km E of Doughboy Creek beside Kings Highway.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.3167_degS_and_149.9167_degE:
     latitude (deg): -35.3167
     longitude (deg): 149.9167
     locality: 17.6 km towards Nerriga from Braidwood turnoff, roadside.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.3181_degS_and_149.01_degE:
     latitude (deg): -35.3181
     longitude (deg): 149.01
     locality: 200 m north-east of Mount Stromlo Observatory Visitors Centre.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3197_degS_and_149.0075_degE:
     latitude (deg): -35.3197
     longitude (deg): 149.0075
     locality: Top of Mount Stromlo at observatory; 100 m NE of dome.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3233_degS_and_149.0114_degE:
     latitude (deg): -35.3233
     longitude (deg): 149.0114
     locality: Near summit of Mount Stromlo.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3239_degS_and_149.3622_degE:
     latitude (deg): -35.3239
     longitude (deg): 149.3622
     locality: Kowen Travelling Stock Reserve. Kings Highway, Queanbeyan to Bungendore
       Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3244_degS_and_149.3608_degE:
     latitude (deg): -35.3244
     longitude (deg): 149.3608
     locality: The Pound Travelling Stock Reserve, Kowen Forest.
-    collector: Hurle, P.D.
+    recorded by: Hurle, P.D.
   site_at_-35.325_degS_and_149.3622_degE:
     latitude (deg): -35.325
     longitude (deg): 149.3622
     locality: The Pound Kowen Forest Travelling Stock Reserve.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3261_degS_and_149.0128_degE:
     latitude (deg): -35.3261
     longitude (deg): 149.0128
     locality: Mount Stromlo Road, 2 km up from Cotter Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3264_degS_and_149.3619_degE:
     latitude (deg): -35.3264
     longitude (deg): 149.3619
     locality: The Pound Kowen Forest Travelling Stock Reserve. 35 19 35.2 S 149 21
       43.3 E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3264_degS_and_149.3639_degE:
     latitude (deg): -35.3264
     longitude (deg): 149.3639
     locality: Pounds TSR Travelling Stock Reserve, on the Kings Highway between Bungendore
       and Queanbeyan.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-35.3269_degS_and_149.3617_degE:
     latitude (deg): -35.3269
     longitude (deg): 149.3617
     locality: The Pound Kowen Forest Travelling Stock Reserve. 35 19 37 S 149 21 42
       E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3269_degS_and_149.3622_degE:
     latitude (deg): -35.3269
     longitude (deg): 149.3622
     locality: Kowen Travelling Stock Reserve; 250 m E of dam and carpark off old Kings
       Highway.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3272_degS_and_149.3608_degE:
     latitude (deg): -35.3272
     longitude (deg): 149.3608
     locality: Kowen Travelling Stock Reserve; 250 m E of car park and dam off old
       Kings Highway.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3272_degS_and_149.3636_degE:
     latitude (deg): -35.3272
     longitude (deg): 149.3636
     locality: The Pound Travelling Stock Reserve, Kowen Forest.
-    collector: Hurle, P.D.
+    recorded by: Hurle, P.D.
   site_at_-35.3283_degS_and_149.0022_degE:
     latitude (deg): -35.3283
     longitude (deg): 149.0022
     locality: Mount Stromlo.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3283_degS_and_149.0025_degE:
     latitude (deg): -35.3283
     longitude (deg): 149.0025
     locality: Mount Stromlo Observatory, c. 2 km up Mount Stromlo Road from junction
       with Cotter Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3333_degS_and_148.6833_degE:
     latitude (deg): -35.3333
     longitude (deg): 148.6833
     locality: 8.6 km from Goodradigbee River towards Tumut, on right side of road.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-35.3333_degS_and_149.2333_degE:
     latitude (deg): -35.3333
     longitude (deg): 149.2333
     locality: S bank of Molonglo Gorge, 1 km upstream from picnic area.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.3333_degS_and_149.25_degE:
     latitude (deg): -35.3333
     longitude (deg): 149.25
     locality: Molonglo Gorge.
-    collector: Seedstore
+    recorded by: Seedstore
   site_at_-35.3406_degS_and_148.9097_degE:
     latitude (deg): -35.3406
     longitude (deg): 148.9097
     locality: Vanitys Crossing Road, 1.5 km from turn-off from Pierces Creek - Paddys
       River Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3417_degS_and_149.25_degE:
     latitude (deg): -35.3417
     longitude (deg): 149.25
     locality: without locality
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.3422_degS_and_148.9111_degE:
     latitude (deg): -35.3422
     longitude (deg): 148.9111
     locality: 2 km along road adjacent to Pipeline Road - Pierces Creek - Sugar Loaf
       Hill - SE.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.345_degS_and_148.8925_degE:
     latitude (deg): -35.345
     longitude (deg): 148.8925
     locality: Vanitys Crossing Road, c. 4.3 km off Paddys River Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3478_degS_and_148.3944_degE:
     latitude (deg): -35.3478
     longitude (deg): 148.3944
     locality: Goobarragandra, 6.7 km E along Goobarragandra Rd from intersection with
       Kells Lane. South bank of Goobarragandra River across suspension foot bridge
       from Travelling Stock Reserve.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-35.3494_degS_and_148.8203_degE:
     latitude (deg): -35.3494
     longitude (deg): 148.8203
     locality: Powerline easement, Brindabella Road, 1 km west of Namadgi National
       Park sign.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3494_degS_and_148.9244_degE:
     latitude (deg): -35.3494
     longitude (deg): 148.9244
     locality: Pierces Creek Forest; Laurel Camp Road c. 650 m SE of Paddys River Road
       along road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.35_degS_and_145.5_degE:
     latitude (deg): -35.35
     longitude (deg): 145.5
     locality: 22 km W of Jerilderie along road to Conargo.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.35_degS_and_145.6_degE:
     latitude (deg): -35.35
     longitude (deg): 145.6
     locality: 11 km W of Jerilderie at Wangamong Creek crossing on the Jerilderie-Deniliquin
       Road.
-    collector: Hadlow, R.B.
+    recorded by: Hadlow, R.B.
   site_at_-35.35_degS_and_145.6667_degE:
     latitude (deg): -35.35
     longitude (deg): 145.6667
     locality: 1 km S of Jerilderie along road to Finley.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.35_degS_and_148.9333_degE:
     latitude (deg): -35.35
     longitude (deg): 148.9333
     locality: Pierces Creek Pine Forest, 1.5 km SE of Sugar Loaf Hill.
-    collector: Fielding, J.P.
+    recorded by: Fielding, J.P.
   site_at_-35.35_degS_and_148.9528_degE:
     latitude (deg): -35.35
     longitude (deg): 148.9528
     locality: Paddys River Mine, Cotter (near Old Cotter Caves).
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.35_degS_and_149.2167_degE:
     latitude (deg): -35.35
     longitude (deg): 149.2167
     locality: Outskirts of Queanbeyan, corner of Norse Road and Mountain Road.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.3558_degS_and_149.0925_degE:
     latitude (deg): -35.3558
     longitude (deg): 149.0925
     locality: Mawson Grassland, Parramatta Street, Mawson/Woden.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3653_degS_and_149.0686_degE:
     latitude (deg): -35.3653
     longitude (deg): 149.0686
     locality: Canberra Nature Park Mount Taylor Reserve; under power lines on W side
       of hill.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3658_degS_and_149.0706_degE:
     latitude (deg): -35.3658
     longitude (deg): 149.0706
     locality: Canberra Nature Park Mount Taylor Reserve; North Taylor FT entrance
       from north gate - Waldock Street.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3664_degS_and_149.0725_degE:
     latitude (deg): -35.3664
     longitude (deg): 149.0725
     locality: Canberra Nature Park; Mount Taylor Reserve; near Colquhoun FT intersection
       with North Taylor track.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3667_degS_and_148.7167_degE:
     latitude (deg): -35.3667
     longitude (deg): 148.7167
     locality: 5 km from Goodradigbee River towards Tumut on Tumut-Canberra road.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-35.3667_degS_and_148.7917_degE:
     latitude (deg): -35.3667
     longitude (deg): 148.7917
     locality: Brindabella Range, 1.5 km from Picadilly Circus toward Brindabella Valley
       and Goodradigbee River.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.3667_degS_and_149.0833_degE:
     latitude (deg): -35.3667
     longitude (deg): 149.0833
     locality: Middle W slope of Mt Taylor.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.3667_degS_and_149.1667_degE:
     latitude (deg): -35.3667
     longitude (deg): 149.1667
     locality: Woden, Model Aircraft paddock, Monaro Highway.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-35.3667_degS_and_149.2_degE:
     latitude (deg): -35.3667
     longitude (deg): 149.2
     locality: Queanbeyan Tip, adjacent to Queanbeyan Racecourse.
-    collector: Seedstore
+    recorded by: Seedstore
   site_at_-35.3667_degS_and_149.25_degE:
     latitude (deg): -35.3667
     longitude (deg): 149.25
     locality: Coats Estate, Temora Place.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.3667_degS_and_150.25_degE:
     latitude (deg): -35.3667
     longitude (deg): 150.25
     locality: Pigeon House Mountain; 100 m N of summit.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.3678_degS_and_149.0703_degE:
     latitude (deg): -35.3678
     longitude (deg): 149.0703
     locality: Canberra Nature Park, Mount Taylor Reserve.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3681_degS_and_149.0683_degE:
     latitude (deg): -35.3681
     longitude (deg): 149.0683
     locality: Canberra Nature Park Mount Taylor Reserve.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3703_degS_and_149.0675_degE:
     latitude (deg): -35.3703
     longitude (deg): 149.0675
     locality: Canberra Nature Park Mount Taylor Reserve.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3703_degS_and_149.0689_degE:
     latitude (deg): -35.3703
     longitude (deg): 149.0689
     locality: Mt Taylor, Woden.
-    collector: Sharp, S.
+    recorded by: Sharp, S.
   site_at_-35.3711_degS_and_150.4728_degE:
     latitude (deg): -35.3711
     longitude (deg): 150.4728
     locality: Coral Crescent, Ulladulla; 80 m NW from Augenaut Avenue, on E side of
       road.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.3728_degS_and_149.0661_degE:
     latitude (deg): -35.3728
     longitude (deg): 149.0661
     locality: Canberra Nature Park; Mount Taylor Reserve, 121 m WNW from main gate
       on Sulwood Drive.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.375_degS_and_145.7167_degE:
     latitude (deg): -35.375
     longitude (deg): 145.7167
     locality: c. 2.6 km along the Newell Highway from Jerilderie PO towards Finley,
       paddock on W side of road, c. 100 m in.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.3769_degS_and_149.1122_degE:
     latitude (deg): -35.3769
     longitude (deg): 149.1122
     locality: Canberra Nature Park, Farrer Ridge Nature Reserve near corner of Yamba
       Drive and Dookie Street; roadside cutting.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3769_degS_and_149.1672_degE:
     latitude (deg): -35.3769
     longitude (deg): 149.1672
     locality: Jerrabomberra Grassland Reserve on the Monaro Highway opposite the Alexander
       Maconochie Centre. On low rocky outcrop close to southern end of Jerrabomberra
       Grassland Reserve, 30 m from top of rise towards highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.3772_degS_and_149.0769_degE:
     latitude (deg): -35.3772
     longitude (deg): 149.0769
     locality: Canberra Nature Park; Mount Taylor Reserve; south slope, opposite park
       bench next to walking track.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.38_degS_and_149.0117_degE:
     latitude (deg): -35.38
     longitude (deg): 149.0117
     locality: Kambah Pool, 2.8 km downstream north of the carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3814_degS_and_149.1142_degE:
     latitude (deg): -35.3814
     longitude (deg): 149.1142
     locality: Canberra Nature Park; Farrer Ridge Reserve; 50 m S E of Hawkesbury Crescent
       near end of Lambrigg Street. (Waypoint 025.) 35 deg 22 52.5 S, 149 deg 6 51.1
       E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3822_degS_and_149.1022_degE:
     latitude (deg): -35.3822
     longitude (deg): 149.1022
     locality: Canberra Nature Park Farrer Ridge Nature Reserve, behind Hawkesbury
       Crescent.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3833_degS_and_146.3333_degE:
     latitude (deg): -35.3833
     longitude (deg): 146.3333
     locality: 41.3 km towards Urana on Rand-Urana road.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.3833_degS_and_148.7833_degE:
     latitude (deg): -35.3833
     longitude (deg): 148.7833
     locality: Brindabella Range, 2 km from Picadilly Circus towards Goodradigbee River.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.3833_degS_and_148.9667_degE:
     latitude (deg): -35.3833
     longitude (deg): 148.9667
     locality: Cotter Reserve, 400 m NNE of Murrays Corner River Crossing, over river
       and 100 m N up Forest Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.3833_degS_and_149.95_degE:
     latitude (deg): -35.3833
     longitude (deg): 149.95
     locality: Half Moon Flat Wildlife Refuge, 4.7 km NNE of Mongarlowe.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-35.3842_degS_and_149.1133_degE:
     latitude (deg): -35.3842
     longitude (deg): 149.1133
     locality: Canberra Nature Park; Farrer Ridge Reserve; 100 m ~S of SE bend of Hawkesbury
       Crescent, 10 m from walking track; Waypoint 023. 35 deg 23 3 S, 149 deg 6 47.9
       E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3856_degS_and_149.1103_degE:
     latitude (deg): -35.3856
     longitude (deg): 149.1103
     locality: Canberra Nature Park; Farrer Ridge Reserve, 200 m S from Hawkesbury
       Crescent, 100 m S from fire trail, c. 500 m W of Erindale Drive. Waypoint 040.
       35 deg 23 7.5 S, 149 deg 0.6 37.0 E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3858_degS_and_149.1056_degE:
     latitude (deg): -35.3858
     longitude (deg): 149.1056
     locality: Canberra Nature Park; Farrer Ridge Reserve; Waypoint 021, 155 m NW S
       from Notice Board Muresk Street (Waypoint 020). 35 deg 23 8.8 S, 149 deg 6 19.5
       E (WGS84).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3858_degS_and_149.1528_degE:
     latitude (deg): -35.3858
     longitude (deg): 149.1528
     locality: Canberra Nature Park; Wanniassa Hills Nature Reserve, entrance from
       Long Gully Road. Under powerlines. 35 23 9.3 S, 149 7 9.9 E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.3867_degS_and_149.1058_degE:
     latitude (deg): -35.3867
     longitude (deg): 149.1058
@@ -8553,4659 +8553,4660 @@ sites:
       Waypoint 021, which is 155 m NW S from Notice Board Muresk Street (Waypoint
       020). 35 deg 23 12.4 S, 149 deg 6 20.5 E (WGS84). Point plots c. 260 m ~S from
       the end of Muresk Street.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.3903_degS_and_149.1064_degE:
     latitude (deg): -35.3903
     longitude (deg): 149.1064
     locality: Canberra Nature Park, Farrer Ridge Reserve. Dam 100 m S of Erindale
       Drive gate.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3919_degS_and_149.015_degE:
     latitude (deg): -35.3919
     longitude (deg): 149.015
     locality: Kambah Pool Reserve walking track, c. 600 m from carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3942_degS_and_149.0986_degE:
     latitude (deg): -35.3942
     longitude (deg): 149.0986
     locality: Kambah Pool Reserve walking track, c. 400 m from carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.3961_degS_and_149.1244_degE:
     latitude (deg): -35.3961
     longitude (deg): 149.1244
     locality: Canberra Nature Park; Wanniassa Hills Nature Reserve. 35 23 45.7 S,
       149 7 27.8 E.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.4_degS_and_148.8167_degE:
     latitude (deg): -35.4
     longitude (deg): 148.8167
     locality: Warks Rd, Brindabella Range.
-    collector: McMillan, M.
+    recorded by: McMillan, M.
   site_at_-35.4_degS_and_149.1667_degE:
     latitude (deg): -35.4
     longitude (deg): 149.1667
     locality: Mt Taylor, W side, midslope NNE of carpark on Bolden Place, Kambah.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.4167_degS_and_148.7833_degE:
     latitude (deg): -35.4167
     longitude (deg): 148.7833
     locality: Brindabella Range, 6.1 km from Picadilly Circus towards Mount Franklin.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.4167_degS_and_149.8667_degE:
     latitude (deg): -35.4167
     longitude (deg): 149.8667
     locality: 8 km towards Nerriga from Braidwood turnoff.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.4167_degS_and_150.0333_degE:
     latitude (deg): -35.4167
     longitude (deg): 150.0333
     locality: Mt. Currockbilly, Budawang Range, 21 km ENE of Braidwood.
-    collector: Sikkes, A.; Telford, I.
+    recorded by: Sikkes, A.; Telford, I.
   site_at_-35.4306_degS_and_148.3808_degE:
     latitude (deg): -35.4306
     longitude (deg): 148.3808
     locality: Kosciuszko National Park; on E side of Betts Creek on S side of Kosciuszko
       Road; 610 m S of Betts Creek bridge, and 360 m E of Betts Creek bend.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.4333_degS_and_148.8833_degE:
     latitude (deg): -35.4333
     longitude (deg): 148.8833
     locality: c. 300 m N of Tidbinbilla Peak, along walking trail to radio transmitter.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.4417_degS_and_148.7667_degE:
     latitude (deg): -35.4417
     longitude (deg): 148.7667
     locality: 7.4 km from Brindabella Valley road turnoff toward Kiandra.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.4481_degS_and_149.1042_degE:
     latitude (deg): -35.4481
     longitude (deg): 149.1042
     locality: Canberra Nature Park; Tuggeranong Hill Reserve; 0.30 km from gate -
       entrance off Fidge Street, Calwell.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.4486_degS_and_149.1028_degE:
     latitude (deg): -35.4486
     longitude (deg): 149.1028
     locality: Canberra Nature Park; Mount Tuggeranong, western edge of ridge.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.4489_degS_and_149.1017_degE:
     latitude (deg): -35.4489
     longitude (deg): 149.1017
     locality: Canberra Nature Park, Tuggeranong Hill, south side.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.45_degS_and_148.9_degE:
     latitude (deg): -35.45
     longitude (deg): 148.9
     locality: Tidbinbilla Nature Reserve; Mountain Creek Trail.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-35.45_degS_and_149.1_degE:
     latitude (deg): -35.45
     longitude (deg): 149.1
     locality: Pine Island Road, roadside c. 100 m from Tharwa Road turnoff.
-    collector: Ward, J.E.
+    recorded by: Ward, J.E.
   site_at_-35.45_degS_and_149.1167_degE:
     latitude (deg): -35.45
     longitude (deg): 149.1167
     locality: 80 m W of Monaro Highway, 200 m S of Tuggeranong Hill Information Map.
-    collector: Mallinson, D.
+    recorded by: Mallinson, D.
   site_at_-35.4583_degS_and_148.7167_degE:
     latitude (deg): -35.4583
     longitude (deg): 148.7167
     locality: 8.0 km from Brindabella Valley Road turnoff, toward Kiandra.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.4597_degS_and_140.9661_degE:
     latitude (deg): -35.4597
     longitude (deg): 140.9661
     locality: 25 km S of the Mallee Highway and Border Track Junction, on the Border
       Track.  Big Desert Wilderness.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.4711_degS_and_150.3519_degE:
     latitude (deg): -35.4711
     longitude (deg): 150.3519
     locality: Meroo Point Road, 300 m from Princes Highway.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.4769_degS_and_150.3942_degE:
     latitude (deg): -35.4769
     longitude (deg): 150.3942
     locality: Meroo Head; coastal heathland above cliff.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.49_degS_and_147.6269_degE:
     latitude (deg): -35.49
     longitude (deg): 147.6269
     locality: Tarcutta, 4 km along Tumbarumba Road from Hume Highway.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.4911_degS_and_149.2658_degE:
     latitude (deg): -35.4911
     longitude (deg): 149.2658
     locality: Tin Dam, southern end of Googong Dam. Point plots between Tin Dam and
       Googong dam, c. 300-400 m from each.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.4992_degS_and_149.1547_degE:
     latitude (deg): -35.4992
     longitude (deg): 149.1547
     locality: 500 m NE of junction of Monaro Highway and Old Cooma Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5_degS_and_148.9167_degE:
     latitude (deg): -35.5
     longitude (deg): 148.9167
     locality: Gibraltar Falls.
-    collector: Ollerenshaw, N.
+    recorded by: Ollerenshaw, N.
   site_at_-35.5_degS_and_149.7_degE:
     latitude (deg): -35.5
     longitude (deg): 149.7
     locality: 12 km SW of Braidwood, roadside verge.
-    collector: Winsbury, M.J.
+    recorded by: Winsbury, M.J.
   site_at_-35.5008_degS_and_149.1517_degE:
     latitude (deg): -35.5008
     longitude (deg): 149.1517
     locality: Royalla rail easement, 70 m S from Cooma Road (to Googong) rail crossing.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5064_degS_and_148.9353_degE:
     latitude (deg): -35.5064
     longitude (deg): 148.9353
     locality: Namadgi National Park; Punchbowl Swamp, northern end.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5069_degS_and_148.935_degE:
     latitude (deg): -35.5069
     longitude (deg): 148.935
     locality: Namadgi National Park; Punchbowl Swamp, centre.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5183_degS_and_148.7703_degE:
     latitude (deg): -35.5183
     longitude (deg): 148.7703
     locality: Namadgi National Park; West Ginini Flat.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5189_degS_and_148.7714_degE:
     latitude (deg): -35.5189
     longitude (deg): 148.7714
     locality: Namadgi National Park; Ginini West.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5194_degS_and_148.9133_degE:
     latitude (deg): -35.5194
     longitude (deg): 148.9133
     locality: Namadgi National Park; Corin Dam Road, 100 m S of Square Rock car park
       on Square Rock Track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.52_degS_and_148.9111_degE:
     latitude (deg): -35.52
     longitude (deg): 148.9111
     locality: Namadgi National Park; just S of Corin Dam Road on Square Rock Track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5203_degS_and_148.9114_degE:
     latitude (deg): -35.5203
     longitude (deg): 148.9114
     locality: Namadgi National Park; just S of Corin Dam Road on Square Rock Track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5208_degS_and_148.7814_degE:
     latitude (deg): -35.5208
     longitude (deg): 148.7814
     locality: Namadgi National Park Ginini Flats, c. 500 m ~N of Mt Ginini carpark
       on Mt Franklin Road. Above sphagnum peat bog in sod tussock grassland bordering
       bog.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5208_degS_and_148.7825_degE:
     latitude (deg): -35.5208
     longitude (deg): 148.7825
     locality: Namadgi National Park; Ginini Bog, 700 m NNE of Ginini carpark on Mount
       Franklin Road on SSW-sloping open grassland.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5211_degS_and_148.7808_degE:
     latitude (deg): -35.5211
     longitude (deg): 148.7808
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5211_degS_and_148.9089_degE:
     latitude (deg): -35.5211
     longitude (deg): 148.9089
     locality: Namadgi National Park; Corin Dam Road, 500 m ~SW of Square Rock car
       park on Square Rock Track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5214_degS_and_148.7822_degE:
     latitude (deg): -35.5214
     longitude (deg): 148.7822
     locality: Namadgi National Park; Ginini Flats, eastern side.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.5214_degS_and_148.7825_degE:
     latitude (deg): -35.5214
     longitude (deg): 148.7825
     locality: Namadgi National Park; Ginini Flats, eastern side.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.5219_degS_and_148.7719_degE:
     latitude (deg): -35.5219
     longitude (deg): 148.7719
     locality: Ginini West sphagnum peat bog southern part, 0.5 km W from the Mt Ginini
       carpark on the Mt Franklin Road towards Bulls Head, and c. 0.4 km N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5219_degS_and_148.7725_degE:
     latitude (deg): -35.5219
     longitude (deg): 148.7725
     locality: Ginini West sphagnum peat bog southern part, 0.5 km W from the Mt Ginini
       carpark on the Mt Franklin Road towards Bulls Head, and c. 0.4 km N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5219_degS_and_148.7808_degE:
     latitude (deg): -35.5219
     longitude (deg): 148.7808
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5219_degS_and_148.7814_degE:
     latitude (deg): -35.5219
     longitude (deg): 148.7814
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5219_degS_and_148.7822_degE:
     latitude (deg): -35.5219
     longitude (deg): 148.7822
     locality: Namadgi National Park; Ginini Bog, 600 m NNE of Ginini carpark on Mount
       Franklin Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5222_degS_and_148.7725_degE:
     latitude (deg): -35.5222
     longitude (deg): 148.7725
     locality: Ginini West sphagnum peat bog southern part, 0.5 km W from the Mt Ginini
       carpark on the Mt Franklin Road towards Bulls Head, and c. 0.4 km N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5222_degS_and_148.7822_degE:
     latitude (deg): -35.5222
     longitude (deg): 148.7822
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5225_degS_and_148.7817_degE:
     latitude (deg): -35.5225
     longitude (deg): 148.7817
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5225_degS_and_148.7822_degE:
     latitude (deg): -35.5225
     longitude (deg): 148.7822
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5228_degS_and_148.7817_degE:
     latitude (deg): -35.5228
     longitude (deg): 148.7817
     locality: Namadgi National Park; Ginini Flats, central area of the bog.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.5228_degS_and_148.7819_degE:
     latitude (deg): -35.5228
     longitude (deg): 148.7819
     locality: Namadgi National Park Ginini Flats, c. 500 m ~N of Mt Ginini carpark
       on Mt Franklin Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5228_degS_and_148.7822_degE:
     latitude (deg): -35.5228
     longitude (deg): 148.7822
     locality: Namadgi National Park Ginini Flats, c. 500 m ~N of Mt Ginini carpark
       on Mt Franklin Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5231_degS_and_148.7819_degE:
     latitude (deg): -35.5231
     longitude (deg): 148.7819
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5231_degS_and_148.7822_degE:
     latitude (deg): -35.5231
     longitude (deg): 148.7822
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5233_degS_and_148.7825_degE:
     latitude (deg): -35.5233
     longitude (deg): 148.7825
     locality: Namadgi National Park; Ginini Flats, southern end.
-    collector: Higgisson, W.
+    recorded by: Higgisson, W.
   site_at_-35.5236_degS_and_148.7814_degE:
     latitude (deg): -35.5236
     longitude (deg): 148.7814
     locality: Namadgi National Park; Ginini Bog, 390 m NNE of Ginini carpark on Mount
       Franklin Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5236_degS_and_148.7819_degE:
     latitude (deg): -35.5236
     longitude (deg): 148.7819
     locality: Namadgi National Park; Ginini Flats, NE of locked gate and carpark near
       Mount Ginini on  Mount Franklin Road; access via old ski run E, NE, then walking
       N through woodland.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5242_degS_and_148.905_degE:
     latitude (deg): -35.5242
     longitude (deg): 148.905
     locality: Namadgi National Park; Square Rock track, 1 km from car park, to the
       left of duck boards.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.525_degS_and_148.7583_degE:
     latitude (deg): -35.525
     longitude (deg): 148.7583
     locality: Namadgi National Park, Mt Ginini, summit.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.525_degS_and_148.775_degE:
     latitude (deg): -35.525
     longitude (deg): 148.775
     locality: Namadgi National Park. Mt Ginini gate.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.525_degS_and_148.7811_degE:
     latitude (deg): -35.525
     longitude (deg): 148.7811
     locality: Namadgi National Park; between Ginini Flat and Ginini carpark on Mount
       Franklin Road, 100 m uphill from Ginini Flat, 250 m NE of carpark.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.525_degS_and_148.7878_degE:
     latitude (deg): -35.525
     longitude (deg): 148.7878
     locality: Namadgi National Park; Cheyenne Flat c. 1.5 km ~ENE of Mt Ginini.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5258_degS_and_148.7881_degE:
     latitude (deg): -35.5258
     longitude (deg): 148.7881
     locality: Namadgi National Park; Cheyenne Flat c. 1.5 km ~ENE of Mt Ginini.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5278_degS_and_148.7858_degE:
     latitude (deg): -35.5278
     longitude (deg): 148.7858
     locality: Namadgi National Park; Cheyenne Flat c. 1.5 km ~ENE of Mt Ginini.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5281_degS_and_148.7858_degE:
     latitude (deg): -35.5281
     longitude (deg): 148.7858
     locality: Namadgi National Park; Cheyenne Flats E c. 600 m from Ginini carpark
       and locked gate.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5319_degS_and_148.7858_degE:
     latitude (deg): -35.5319
     longitude (deg): 148.7858
     locality: Namadgi National Park; Cheyenne Flat c. 1.3 km ~ESE of Mt Ginini.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5333_degS_and_148.7667_degE:
     latitude (deg): -35.5333
     longitude (deg): 148.7667
     locality: Brindabella Range Mt Ginini.
-    collector: Woollcott, T.E.
+    recorded by: Woollcott, T.E.
   site_at_-35.5333_degS_and_148.7833_degE:
     latitude (deg): -35.5333
     longitude (deg): 148.7833
     locality: Brindabella Range, Mt Ginini, 1 km NE of summit.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-35.5344_degS_and_148.7783_degE:
     latitude (deg): -35.5344
     longitude (deg): 148.7783
     locality: Head waters of Snowy Flat Creek, Snowy Flats, Namadgi National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.5347_degS_and_148.8969_degE:
     latitude (deg): -35.5347
     longitude (deg): 148.8969
     locality: Namadgi National Park; Square Rock Track, 2+ km from car park on Corin
       Dam Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5356_degS_and_148.9081_degE:
     latitude (deg): -35.5356
     longitude (deg): 148.9081
     locality: Namadgi National Park Smokers Flat, Smokers Trail, E of Corin Road.
       Continue through locked gate at Smokers Trail car park, c. 3 km to trail connecting
       Smokers Trail and Square Rock Walk; peat bogs on N side of trail.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5358_degS_and_148.905_degE:
     latitude (deg): -35.5358
     longitude (deg): 148.905
     locality: Namadgi National Park Smokers Flat, western side.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5358_degS_and_148.9078_degE:
     latitude (deg): -35.5358
     longitude (deg): 148.9078
     locality: Namadgi National Park Smokers Flat, Smokers Trail, E of Corin Road.
       Continue through locked gate at Smokers Trail car park, c. 3 km to trail connecting
       Smokers Trail and Square Rock Walk; peat bogs on N side of trail.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5361_degS_and_148.9044_degE:
     latitude (deg): -35.5361
     longitude (deg): 148.9044
     locality: Namadgi National Park; Smokers Flat.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5364_degS_and_148.9058_degE:
     latitude (deg): -35.5364
     longitude (deg): 148.9058
     locality: Namadgi National Park; Smokers Flat.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5364_degS_and_148.9064_degE:
     latitude (deg): -35.5364
     longitude (deg): 148.9064
     locality: Namadgi National Park Smokers Flat, Smokers Trail, E of Corin Road.
       Continue through locked gate at Smokers Trail car park, c. 3 km to trail connecting
       Smokers Trail and Square Rock Walk; peat bogs on N side of trail.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5369_degS_and_148.9278_degE:
     latitude (deg): -35.5369
     longitude (deg): 148.9278
     locality: Namadgi National Park; Smokers Trail, c. 1 km S of car park (locked
       gate).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5397_degS_and_141.8181_degE:
     latitude (deg): -35.5397
     longitude (deg): 141.8181
     locality: Wyperfeld National Park, Nine Mile Square Track, Ironstone Hill, c.
       42 km NNW of Rainbow.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.5403_degS_and_148.9019_degE:
     latitude (deg): -35.5403
     longitude (deg): 148.9019
     locality: Namadgi National Park; Smokers Trail.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5478_degS_and_149.2286_degE:
     latitude (deg): -35.5478
     longitude (deg): 149.2286
     locality: Burra Road E side, opposite Burra sports ground, c. 100 m uphill from
       front gate.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.5478_degS_and_149.9553_degE:
     latitude (deg): -35.5478
     longitude (deg): 149.9553
     locality: Clyde Mountain, Pooh Bear Corner.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.5481_degS_and_149.2286_degE:
     latitude (deg): -35.5481
     longitude (deg): 149.2286
     locality: Burra Reserve, opposite Burra Tennis Court c. 200 m SW from entrance
       gate.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5486_degS_and_149.2292_degE:
     latitude (deg): -35.5486
     longitude (deg): 149.2292
     locality: Burra; 100 m E of gate to Burra Reserve.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.55_degS_and_148.6167_degE:
     latitude (deg): -35.55
     longitude (deg): 148.6167
     locality: Kosciusko National Park  Fiery Range Long Plain Road near Little Peppercorn
       Hut.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-35.55_degS_and_148.8_degE:
     latitude (deg): -35.55
     longitude (deg): 148.8
     locality: Brindabella Range Warks Road.
-    collector: Woollcott, T.E.
+    recorded by: Woollcott, T.E.
   site_at_-35.5544_degS_and_148.7828_degE:
     latitude (deg): -35.5544
     longitude (deg): 148.7828
     locality: Namadgi National Park Stockyard Spur bog; NE side of intersection between
       Mount Franklin Road and Stockyard Spur track.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5547_degS_and_148.7828_degE:
     latitude (deg): -35.5547
     longitude (deg): 148.7828
     locality: Namadgi National Park Stockyard Spur bog; NE side of intersection between
       Mount Franklin Road and Stockyard Spur track.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5583_degS_and_149.1_degE:
     latitude (deg): -35.5583
     longitude (deg): 149.1
     locality: Murrumbidgee River Gigerline NR 1.25 km SSE of Gigerline trig. Grid
       ref 6 902 60 651.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-35.5589_degS_and_148.9906_degE:
     latitude (deg): -35.5589
     longitude (deg): 148.9906
     locality: Booroomba Rocks, Namadgi National Park.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-35.5597_degS_and_148.7783_degE:
     latitude (deg): -35.5597
     longitude (deg): 148.7783
     locality: Head waters of Snowy Flat Creek, Snowy Flats. Namadgi National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.5647_degS_and_148.7833_degE:
     latitude (deg): -35.5647
     longitude (deg): 148.7833
     locality: Namadgi National Park; Snowy Flat Bog on the N side of Mount Franklin
       Road 1.5 km SE of Pryors Hut (1.7 km by road), 620 m N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5667_degS_and_148.775_degE:
     latitude (deg): -35.5667
     longitude (deg): 148.775
     locality: 500 m SW of the border gate on Leura Gap Road, Namadgi National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.5667_degS_and_148.9833_degE:
     latitude (deg): -35.5667
     longitude (deg): 148.9833
     locality: Booroomba Rocks, along Apollo Road, via Naas.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-35.5667_degS_and_149.8_degE:
     latitude (deg): -35.5667
     longitude (deg): 149.8
     locality: 9 km N of Araluen; roadside verge.
-    collector: Winsbury, M.J.
+    recorded by: Winsbury, M.J.
   site_at_-35.5672_degS_and_148.7836_degE:
     latitude (deg): -35.5672
     longitude (deg): 148.7836
     locality: Namadgi National Park Snowy Flats, c. 400-450 m below Mount Franklin
       Road, 15 km N from Cotter Hut T-junction on Mount Franklin Road; along creekline,
       c. 1 km ~NE of Mount Gingera summit.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5672_degS_and_148.7839_degE:
     latitude (deg): -35.5672
     longitude (deg): 148.7839
     locality: Namadgi National Park Snowy Flat, southern end; Mount Franklin Road,
       c. 5 km S of locked gate near Mount Ginini.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5675_degS_and_148.7839_degE:
     latitude (deg): -35.5675
     longitude (deg): 148.7839
     locality: Namadgi National Park Snowy Flat, southern end; Mount Franklin Road,
       c. 5 km S of locked gate near Mount Ginini.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5681_degS_and_148.7842_degE:
     latitude (deg): -35.5681
     longitude (deg): 148.7842
     locality: Namadgi National Park; S of locked Ginini gate, c. 5 km along Mount
       Franklin Road; Snowy Flat, southern end of bog c. 350 m N of Mount Franklin
       Road.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5681_degS_and_148.7844_degE:
     latitude (deg): -35.5681
     longitude (deg): 148.7844
     locality: Namadgi National Park Snowy Flat, southern end; Mount Franklin Road,
       c. 5 km S of locked gate near Mount Ginini.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.5686_degS_and_148.785_degE:
     latitude (deg): -35.5686
     longitude (deg): 148.785
     locality: Namadgi National Park; Snowy Flat Bog on the N side of Mount Franklin
       Road, 1.5 km SE of Pryors Hut (1.7 km by road), 130 m N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5689_degS_and_148.7844_degE:
     latitude (deg): -35.5689
     longitude (deg): 148.7844
     locality: Namadgi National Park Snowy Flats, 100 m below Mount Franklin Road,
       15 km N from Cotter Hut T-junction on Mount Franklin Road, c. 1 km NE of Mount
       Gingera summit.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5692_degS_and_148.7847_degE:
     latitude (deg): -35.5692
     longitude (deg): 148.7847
     locality: Namadgi National Park; Snowy Flat Bog on the N side of Mount Franklin
       Road 1.5 km SE of Pryors Hut (1.7 km by road), 60 m N of road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.5694_degS_and_150.3761_degE:
     latitude (deg): -35.5694
     longitude (deg): 150.3761
     locality: Kioloa area; headland at Snapper Point, c. 1 km from Pretty Beach picnic
       area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5703_degS_and_148.9858_degE:
     latitude (deg): -35.5703
     longitude (deg): 148.9858
     locality: Namadgi National Park; Booroomba Rocks track. Waypoint 55; just off
       track in granite outcrop; 1.75 km from car park at Honeysuckle Creek camp ground.
       35 34 13.3 S 148 59 9.3 E.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.5708_degS_and_150.3753_degE:
     latitude (deg): -35.5708
     longitude (deg): 150.3753
     locality: Kioloa area; Snapper Point walking track, c. 800 m from Pretty Beach
       picnic area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5719_degS_and_148.7831_degE:
     latitude (deg): -35.5719
     longitude (deg): 148.7831
     locality: Mt Gingera summit turnoff. Mt Franklin Road, Namadgi National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.5808_degS_and_148.9542_degE:
     latitude (deg): -35.5808
     longitude (deg): 148.9542
     locality: Namadgi National Park; Yankee Hut Fire Trail, 2 km NW of Frank and Jacks
       Hut.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5817_degS_and_148.9717_degE:
     latitude (deg): -35.5817
     longitude (deg): 148.9717
     locality: Namadgi National Park; Booroomba Rocks - Honeysuckle Creek track. Waypoint
       54; 259 m from Honeysuckle Creek camp ground.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.5822_degS_and_149.1392_degE:
     latitude (deg): -35.5822
     longitude (deg): 149.1392
     locality: Williamsdale.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.5872_degS_and_149.1372_degE:
     latitude (deg): -35.5872
     longitude (deg): 149.1372
     locality: CULTIVATED ACTEW Offset Site, Williamsdale, Monaro Highway.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5886_degS_and_149.1392_degE:
     latitude (deg): -35.5886
     longitude (deg): 149.1392
     locality: Williamsdale Offset Site, Monaro Highway, 2 km S of Williamsdale.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5889_degS_and_149.1392_degE:
     latitude (deg): -35.5889
     longitude (deg): 149.1392
     locality: CULTIVATED ACTEW Offset Site, Williamsdale, Monaro Highway.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5917_degS_and_149.8_degE:
     latitude (deg): -35.5917
     longitude (deg): 149.8
     locality: Bells Mount, 7 km N of Araluen on Braidwood Rd, headwaters of Dirty
       Butter Creek.
-    collector: Crawford, I.
+    recorded by: Crawford, I.
   site_at_-35.5936_degS_and_148.7864_degE:
     latitude (deg): -35.5936
     longitude (deg): 148.7864
     locality: Namadgi National Park, Mount Franklin Road, c. 1.75 km direct SSE of
       Mount Gingera.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.5953_degS_and_142.1089_degE:
     latitude (deg): -35.5953
     longitude (deg): 142.1089
     locality: Wyperfeld National Park, walking track to Eastern Lookout summit, c.
       4.5 km ESE of Flagstaff Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.5956_degS_and_142.1103_degE:
     latitude (deg): -35.5956
     longitude (deg): 142.1103
     locality: Wyperfeld National Park, walking track to Eastern Lookout summit, c.
       4.5 km ESE of Flagstaff Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.5983_degS_and_141.4358_degE:
     latitude (deg): -35.5983
     longitude (deg): 141.4358
     locality: 11.4 km from the junction of  the Nhill-Murrayville rd and the Milmed
       track heading east towards Milmed Rock. Wyperfield NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.5983_degS_and_141.4494_degE:
     latitude (deg): -35.5983
     longitude (deg): 141.4494
     locality: 26.5 km from the junction of  the Nhill-Murrayville rd and the Milmed
       track heading east towards Milmed Rock. Wyperfield NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.5989_degS_and_149.7953_degE:
     latitude (deg): -35.5989
     longitude (deg): 149.7953
     locality: 6639 Araluen Road, Araluen; enclosure on western scarp of property,
       100 m W of property entrance.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.5992_degS_and_149.7967_degE:
     latitude (deg): -35.5992
     longitude (deg): 149.7967
     locality: 6639 Araluen Road, Araluen; enclosure on western scarp of property,
       100 m W of caravans.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.6_degS_and_149.9_degE:
     latitude (deg): -35.6
     longitude (deg): 149.9
     locality: 8.5 km from Kings Highway via Monga Sawmill, 500 m E of Mongarlowe River.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.6_degS_and_149.9167_degE:
     latitude (deg): -35.6
     longitude (deg): 149.9167
     locality: 8.5 km from Kings Highway via Monga Sawmill. 750 m E of Mongarlowe River.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.6094_degS_and_142.0978_degE:
     latitude (deg): -35.6094
     longitude (deg): 142.0978
     locality: Wyperfeld National Park, Eastern Lookout Nature Drive, c. 4.5 km SE
       of Flagstaff Hill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.6167_degS_and_148.775_degE:
     latitude (deg): -35.6167
     longitude (deg): 148.775
     locality: Brindabella Range, 10.5 km from Bulls Head twd Mt Franklin.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.6242_degS_and_149.8914_degE:
     latitude (deg): -35.6242
     longitude (deg): 149.8914
     locality: 6 km S of Monga.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.6433_degS_and_141.3081_degE:
     latitude (deg): -35.6433
     longitude (deg): 141.3081
     locality: 57.3 km north of Yanac. Along the Nhill-Murrayville road at The Springs
       camping area. Big Desert Wilderness side.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.6536_degS_and_141.7122_degE:
     latitude (deg): -35.6536
     longitude (deg): 141.7122
     locality: 42 km from the junction of  the Nhill-Murrayville rd and the Milmed
       track heading east towards Albacutya. Wyperfield NP.National Park
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.6608_degS_and_148.7881_degE:
     latitude (deg): -35.6608
     longitude (deg): 148.7881
     locality: Namadgi National Park, c. 150 m direct NW of the summit of Bimberi Peak.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.6614_degS_and_148.9492_degE:
     latitude (deg): -35.6614
     longitude (deg): 148.9492
     locality: Namadgi National Park; 2 km from Nursery Swamp track head and carpark.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.6667_degS_and_149.25_degE:
     latitude (deg): -35.6667
     longitude (deg): 149.25
     locality: Tinderry Nature Reserve.
-    collector: McDougall, K.
+    recorded by: McDougall, K.
   site_at_-35.6678_degS_and_148.7964_degE:
     latitude (deg): -35.6678
     longitude (deg): 148.7964
     locality: Namadgi National Park, c. 750 m direct SE of the summit of Bimberi Peak.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.6714_degS_and_148.9561_degE:
     latitude (deg): -35.6714
     longitude (deg): 148.9561
     locality: Namadgi National Park; Nursery Swamp track at head of Nursery Swamp
       drainage line near timber seat.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-35.6733_degS_and_148.9606_degE:
     latitude (deg): -35.6733
     longitude (deg): 148.9606
     locality: Namadgi National Park; c. 400 m NW along Nursery Swamp track from Nursery
       Swamp sign / lookout; both sides of track.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-35.6753_degS_and_148.8011_degE:
     latitude (deg): -35.6753
     longitude (deg): 148.8011
     locality: Little Bimberi bog c. 850 m NNE of Murrays Gap sign post at Murrays
       Gap on Murrays Gap fire trail through Cotter Hut yard.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.6758_degS_and_148.8008_degE:
     latitude (deg): -35.6758
     longitude (deg): 148.8008
     locality: Little Bimberi bog c. 850 m NNE of Murrays Gap sign post at Murrays
       Gap on Murrays Gap fire trail through Cotter Hut yard.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.6758_degS_and_148.8011_degE:
     latitude (deg): -35.6758
     longitude (deg): 148.8011
     locality: Little Bimberi bog c. 850 m NNE of Murrays Gap sign post at Murrays
       Gap on Murrays Gap fire trail through Cotter Hut yard.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-35.6764_degS_and_148.8_degE:
     latitude (deg): -35.6764
     longitude (deg): 148.8
     locality: Namadgi National Park Little Bimberi Bog; c. 500 m N of Murrays Gap
       Fire Trail, on E side of ACT/NSW border.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.6769_degS_and_148.7978_degE:
     latitude (deg): -35.6769
     longitude (deg): 148.7978
     locality: Supplied as 35 40 37.9  S, 148 47 52.7  E
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.6831_degS_and_148.8103_degE:
     latitude (deg): -35.6831
     longitude (deg): 148.8103
     locality: Supplied as 35 40 59.1  S, 148 48 37.0  E
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.6833_degS_and_148.8_degE:
     latitude (deg): -35.6833
     longitude (deg): 148.8
     locality: Murrays Gap, between Mt Murray and Mt Bimberi.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.6833_degS_and_150.1_degE:
     latitude (deg): -35.6833
     longitude (deg): 150.1
     locality: Road to Runnyford.
-    collector: Phillips, M.E.
+    recorded by: Phillips, M.E.
   site_at_-35.6839_degS_and_148.8339_degE:
     latitude (deg): -35.6839
     longitude (deg): 148.8339
     locality: Namadgi National Park, Yaouk Trail, c. 3.5 km direct S of Cotter Hut.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.6881_degS_and_148.8331_degE:
     latitude (deg): -35.6881
     longitude (deg): 148.8331
     locality: Namadgi National Park, Yaouk Trail, c. 4 km direct S of Cotter Hut.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.7_degS_and_148.5667_degE:
     latitude (deg): -35.7
     longitude (deg): 148.5667
     locality: Koscuisko National Park, Long Plain, Port Phillip fire trail, 5 km ESE
       of Yarrangobilly Mtn.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-35.7108_degS_and_141.71_degE:
     latitude (deg): -35.7108
     longitude (deg): 141.71
     locality: At round swamp. 48.9 kms from the junction of the Nhill-Murrayville
       Rd and the Milmed Track. Heading East towards Albacutya. Wyperfield NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.7164_degS_and_141.7194_degE:
     latitude (deg): -35.7164
     longitude (deg): 141.7194
     locality: 50.6 kms from the junction of the Nhill-Murrayville Road and the Milmed
       Track. Heading East along the Milmed track towards Albacutya. Wyperfield National
       Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.7167_degS_and_148.5_degE:
     latitude (deg): -35.7167
     longitude (deg): 148.5
     locality: Kosciuszko National Park, Yarrangobilly Caves, near Glory Arch.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-35.7167_degS_and_149.1906_degE:
     latitude (deg): -35.7167
     longitude (deg): 149.1906
     locality: Michelago; roadside 2 km E on Tinderry Road; on roadside cutting left
       hand (N) side.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7317_degS_and_149.2694_degE:
     latitude (deg): -35.7317
     longitude (deg): 149.2694
     locality: Tinderry Nature Reserve; 13 km from Michelago on Captains Flat Road,
       1 km N from road on Tinderry Range.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7333_degS_and_144.1833_degE:
     latitude (deg): -35.7333
     longitude (deg): 144.1833
     locality: Cohuna, Gunbower Island near Reedy Lagoon.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-35.7333_degS_and_148.8667_degE:
     latitude (deg): -35.7333
     longitude (deg): 148.8667
     locality: Namadgi National Park, Scabby Range, c. 2.5 km SSW of Mt Kelly.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.7333_degS_and_148.9833_degE:
     latitude (deg): -35.7333
     longitude (deg): 148.9833
     locality: 1 km SE of Gudgenby Homestead on Tharwa to Shannons Flat road (straight
       line measurement).
-    collector: Hadlow, B.
+    recorded by: Hadlow, B.
   site_at_-35.7353_degS_and_149.2714_degE:
     latitude (deg): -35.7353
     longitude (deg): 149.2714
     locality: Tinderry Nature Reserve; 13 km from Michelago on Captains Flat Road,
       1 km N from road on Tinderry Range.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7378_degS_and_149.2686_degE:
     latitude (deg): -35.7378
     longitude (deg): 149.2686
     locality: Tinderry Nature Reserve, Tinderry Mountains, c. 4 km direct S of Tinderry
       Peak.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.7386_degS_and_149.2689_degE:
     latitude (deg): -35.7386
     longitude (deg): 149.2689
     locality: Tinderry Nature Reserve southern end, 300 m N of Tinderry Road just
       W of summit of range.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7394_degS_and_149.2644_degE:
     latitude (deg): -35.7394
     longitude (deg): 149.2644
     locality: Tinderry Nature Reserve; 150 m W from quarry carpark, Captains Flat
       Road, 9.75 km E of Michelago.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7394_degS_and_149.2647_degE:
     latitude (deg): -35.7394
     longitude (deg): 149.2647
     locality: Tinderry Nature Reserve; 150 m W from quarry carpark, Captains Flat
       Road, 9.75 km E of Michelago.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7419_degS_and_149.2656_degE:
     latitude (deg): -35.7419
     longitude (deg): 149.2656
     locality: Tinderry Nature Reserve; ca 2 km S of Kalabash Road on Captains Flat
       road. Coordinates given plot c. 0.9 km W of the Calabash Road turnoff on Tinderry
       Road (which heads towards Captains Flat) at correct altitude and habitat.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.7458_degS_and_148.9728_degE:
     latitude (deg): -35.7458
     longitude (deg): 148.9728
     locality: Namadgi National Park Yankee Hat Trail to bridge then walk c. 500 m
       NNE (left) to small peat swamp Gudgenby.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.75_degS_and_149.2833_degE:
     latitude (deg): -35.75
     longitude (deg): 149.2833
     locality: Tinderry Mountains, 10 km E of Michelago.
-    collector: Clements, M.A.
+    recorded by: Clements, M.A.
   site_at_-35.75_degS_and_149.3_degE:
     latitude (deg): -35.75
     longitude (deg): 149.3
     locality: Tinderry Mountains, 12.5 km NE of Michelago towards Jingera.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-35.7544_degS_and_148.8583_degE:
     latitude (deg): -35.7544
     longitude (deg): 148.8583
     locality: Mt. Scabby, Yaouk, ACT. Upper Cotter source swamp exit bar.
-    collector: Dawson, I.
+    recorded by: Dawson, I.
   site_at_-35.7642_degS_and_148.8672_degE:
     latitude (deg): -35.7642
     longitude (deg): 148.8672
     locality: Mt. Scabby, Yaouk. Swamp on NE flank of Mt. Scabby.
-    collector: Dawson, I.
+    recorded by: Dawson, I.
   site_at_-35.7644_degS_and_148.8736_degE:
     latitude (deg): -35.7644
     longitude (deg): 148.8736
     locality: Mt. Scabby, Yaouk, NSW. Swamp on SE slope.
-    collector: Dawson, I.
+    recorded by: Dawson, I.
   site_at_-35.7667_degS_and_148.8883_degE:
     latitude (deg): -35.7667
     longitude (deg): 148.8883
     locality: Sams Creek, Yaouk.
-    collector: Dawson, I.
+    recorded by: Dawson, I.
   site_at_-35.7919_degS_and_137.8603_degE:
     latitude (deg): -35.7919
     longitude (deg): 137.8603
     locality: Alongside road, 11 km from turnoff to Antechamber Bay (in Penneshaw)
       towards American River.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-35.8083_degS_and_138.0394_degE:
     latitude (deg): -35.8083
     longitude (deg): 138.0394
     locality: Roadside, 13 km from Penneshaw along Penneshaw - Cape Willoughby Rd.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-35.8167_degS_and_148.9167_degE:
     latitude (deg): -35.8167
     longitude (deg): 148.9167
     locality: Sentry Box Hill, near summit.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-35.8167_degS_and_150.2167_degE:
     latitude (deg): -35.8167
     longitude (deg): 150.2167
     locality: 10 km S of Batemans Bay, near Rosedale.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-35.8217_degS_and_149.2714_degE:
     latitude (deg): -35.8217
     longitude (deg): 149.2714
     locality: Tinderry Nature Reserve; 1.5 km NW of quarry carpark, top of first ridge
       line.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.8261_degS_and_141.3889_degE:
     latitude (deg): -35.8261
     longitude (deg): 141.3889
     locality: 34.3 km north of Yanac. Along the Nhill-Murrayville rd heading toward
       Murrayville. Big Desert Wilderness side.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.8264_degS_and_148.4928_degE:
     latitude (deg): -35.8264
     longitude (deg): 148.4928
     locality: Kosciuszko National Park; roadside at Old Kiandra Goldfields, 3 km N
       of turn-off to Cabramurra and Khancoban.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.8333_degS_and_150.25_degE:
     latitude (deg): -35.8333
     longitude (deg): 150.25
     locality: Surf Beach, N end of beach.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.8392_degS_and_137.7244_degE:
     latitude (deg): -35.8392
     longitude (deg): 137.7244
     locality: Region 12-Kangaroo Island. 25km W of Penneshaw on road from Parndana.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-35.8558_degS_and_148.8569_degE:
     latitude (deg): -35.8558
     longitude (deg): 148.8569
     locality: Yaouk Bill Range, c. 0.5 km direct NE of Yaouk Peak.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-35.8667_degS_and_141.2881_degE:
     latitude (deg): -35.8667
     longitude (deg): 141.2881
     locality: On the sourhtern fire trail. Big Desert Wilderness.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.8692_degS_and_141.1656_degE:
     latitude (deg): -35.8692
     longitude (deg): 141.1656
     locality: 21.5 km from the  junction of Nhill-Murrayville road and the Red Bluff
       road. Along the road bluff road heading west toward the SA/Vic. border. Big
       Desert Wilderness Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.8744_degS_and_148.9792_degE:
     latitude (deg): -35.8744
     longitude (deg): 148.9792
     locality: Namadgi National Park; settlers track, Brayshaws Hut area c. 2 km N
       of Boboyan Road crossing of southern ACT border.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.8747_degS_and_148.9789_degE:
     latitude (deg): -35.8747
     longitude (deg): 148.9789
     locality: Namadgi National Park; Settlers Track off Boboyan Road, c. 700 m W of
       car park, Brayshaws Hut area.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.8747_degS_and_148.9831_degE:
     latitude (deg): -35.8747
     longitude (deg): 148.9831
     locality: Namadgi National Park; Settlers Track off Boboyan Road, c. 200 m W of
       Brayshaws Hut car park.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.875_degS_and_148.9622_degE:
     latitude (deg): -35.875
     longitude (deg): 148.9622
     locality: Namadgi National Park; 1.6 km ~NW of Westermans Hut on Settlers Track,
       off Boboyan Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.875_degS_and_148.9853_degE:
     latitude (deg): -35.875
     longitude (deg): 148.9853
     locality: Namadgi National Park; Settlers Track off Boboyan Road, 50 m W of car
       park, Brayshaws Hut.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.8764_degS_and_148.9622_degE:
     latitude (deg): -35.8764
     longitude (deg): 148.9622
     locality: Namadgi National Park; Westermans Hut Track c. 2.3 km N of Boboyan Road
       crossing of southern ACT border.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-35.8786_degS_and_148.5036_degE:
     latitude (deg): -35.8786
     longitude (deg): 148.5036
     locality: Kosciuszko National Park, IBRA region AA; 79.1 km W NW from the Snowy
       Mountains Highway and Kosciuszko Road junction; 548 m (straight line GPS) N
       of the Kiandra cemetery.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.88_degS_and_148.5017_degE:
     latitude (deg): -35.88
     longitude (deg): 148.5017
     locality: Kosciuszko National Park, IBRA region AA; 79.1 km W NW from the Snowy
       Mountains Highway and Kosciuszko Road junction; 369 m (straight line GPS) N
       of the Kiandra cemetery.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.8869_degS_and_148.9719_degE:
     latitude (deg): -35.8869
     longitude (deg): 148.9719
     locality: Namadgi National Park; Westermans Hut on Settlers Track, off Boboyan
       Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.8869_degS_and_149.1247_degE:
     latitude (deg): -35.8869
     longitude (deg): 149.1247
     locality: Scottsdale Reserve (Bush Heritage Reserve, 5 km N of Bredbo); top of
       hill 300 m S from Murrumbidgee River.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.8919_degS_and_148.4472_degE:
     latitude (deg): -35.8919
     longitude (deg): 148.4472
     locality: 3 Mile Dam, Gold seekers track, c.118 m from The Link Road. Kosciuszko
       National Park.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.8947_degS_and_149.1253_degE:
     latitude (deg): -35.8947
     longitude (deg): 149.1253
     locality: Scottsdale Bush Heritage property, N of Bredbo; on easterly track from
       dam on ridge to river.
-    collector: Purdie, R.W.
+    recorded by: Purdie, R.W.
   site_at_-35.8972_degS_and_138.05_degE:
     latitude (deg): -35.8972
     longitude (deg): 138.05
     locality: Cape Hart.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-35.9_degS_and_148.95_degE:
     latitude (deg): -35.9
     longitude (deg): 148.95
     locality: Rosevue, 50.7 km S of Tharwa bridge (Murrumbidgee River crossing). 1.9
       km S of NSW/ACT border on Boboyan.
-    collector: Thompson, H.S.
+    recorded by: Thompson, H.S.
   site_at_-35.9058_degS_and_149.1397_degE:
     latitude (deg): -35.9058
     longitude (deg): 149.1397
     locality: Scottsdale Reserve (Bush Heritage Reserve, 5 km N of Bredbo); 1 km NW
       from shearers shed next to road.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.9067_degS_and_149.1203_degE:
     latitude (deg): -35.9067
     longitude (deg): 149.1203
     locality: Scottsdale Reserve (Bush Heritage Reserve, 5 km N of Bredbo); along
       ridge line, 2 km SW from small fenced dam.
-    collector: Schweickle, L.
+    recorded by: Schweickle, L.
   site_at_-35.9275_degS_and_148.3997_degE:
     latitude (deg): -35.9275
     longitude (deg): 148.3997
     locality: Dry dam on left of Kings Cross Road from Cabrarurra to Selwyn. Kosciuszko
       National Park.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-35.9289_degS_and_149.2314_degE:
     latitude (deg): -35.9289
     longitude (deg): 149.2314
     locality: Jerangle Road, c. 9 km out of Bredbo ~ENE.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.95_degS_and_149.0167_degE:
     latitude (deg): -35.95
     longitude (deg): 149.0167
     locality: Near Murrumbateman township in paddock
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.9667_degS_and_149.5_degE:
     latitude (deg): -35.9667
     longitude (deg): 149.5
     locality: Tallaganda State Forest, Lowden Park, 15 m E of Dam toward carpark,
       70 paces up Hopkins Pond Walking Trail near water wheel.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-35.9681_degS_and_149.1433_degE:
     latitude (deg): -35.9681
     longitude (deg): 149.1433
     locality: Bredbo, Monaro highway, Travelling Stock Reserve; 1.5 km S of town;
       roadside cutting.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-35.9692_degS_and_149.1422_degE:
     latitude (deg): -35.9692
     longitude (deg): 149.1422
     locality: Heading up the hill out of Bredbo towards Cooma; on road cutting, E
       side of road.
-    collector: Anlezark, M.J.
+    recorded by: Anlezark, M.J.
   site_at_-35.97_degS_and_149.1417_degE:
     latitude (deg): -35.97
     longitude (deg): 149.1417
     locality: Monaro Grasslands, 1 km S of Bredbo along the Monaro Highway.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-35.9803_degS_and_149.6917_degE:
     latitude (deg): -35.9803
     longitude (deg): 149.6917
     locality: 1.5 km E from the Dampier trig fire trail and the Minuma Range fire
       trail junction. On the Dampier Trig Fire Trail. Deua National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35.9917_degS_and_149.5667_degE:
     latitude (deg): -35.9917
     longitude (deg): 149.5667
     locality: Deua National Park, 0.5 km from Pikes Saddle along Big Badja Fire Trail.
-    collector: Thompson, H.
+    recorded by: Thompson, H.
   site_at_-35.9942_degS_and_141.4025_degE:
     latitude (deg): -35.9942
     longitude (deg): 141.4025
     locality: 14.7 km north of Yanac. Along the Nhill-Murrayville road heading toward
       Murrayville. Big Desert Wilderness side.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-35_degS_and_148.6_degE:
     latitude (deg): -35.0
     longitude (deg): 148.6
     locality: 0.4 km ESE of Burrinjuck village, edge of Lake Burrinjuck. (Map ref
       463255, Brindabella 1100,000)
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-36.0089_degS_and_148.7744_degE:
     latitude (deg): -36.0089
     longitude (deg): 148.7744
     locality: S of Adaminaby. Bushrangers Hill Road, 1 km S of junction with Snowy
       Mountains Highway; front gate of Happy Valley property.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.0167_degS_and_141.4_degE:
     latitude (deg): -36.0167
     longitude (deg): 141.4
     locality: Big Desert; 94 km from Murrayville toward Yanac.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-36.0167_degS_and_149.65_degE:
     latitude (deg): -36.0167
     longitude (deg): 149.65
     locality: Southern Tablelands escarpment. E of Big Badja Hill. Ridge N of Mother
       Woila, 3.7 km 205 degrees from Dampier trig.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-36.0333_degS_and_147.75_degE:
     latitude (deg): -36.0333
     longitude (deg): 147.75
     locality: Burrowa-Pine Mountain National Park, Pine Mountain, c. 4 km W of summit.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.0333_degS_and_147.7833_degE:
     latitude (deg): -36.0333
     longitude (deg): 147.7833
     locality: Burrowa-Pine Mountain National Park, Pine Mountain, c. 2 km W of summit.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.0333_degS_and_147.8_degE:
     latitude (deg): -36.0333
     longitude (deg): 147.8
     locality: Burrowa-Pine Mountain National Park, Pine Mountain, c. 1 km NW of summit.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.0333_degS_and_147.8167_degE:
     latitude (deg): -36.0333
     longitude (deg): 147.8167
     locality: Burrowa - Pine Mountain National Park, Pine Mountain, c. 500 m W of
       summit.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.0406_degS_and_150.0639_degE:
     latitude (deg): -36.0406
     longitude (deg): 150.0639
     locality: Moruya State Forest, 500 m from Western Boundary Road.
-    collector: Howe, A.
+    recorded by: Howe, A.
   site_at_-36.0414_degS_and_150.0633_degE:
     latitude (deg): -36.0414
     longitude (deg): 150.0633
     locality: 6 km N of Bodalla; power line easement c. 600 m SW of Western Boundary
       Road where it enters Moruya State Forest; western side of power line easement,
       40 m S of power pole, opposite extensive Commersonia thicket.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.0417_degS_and_150.0639_degE:
     latitude (deg): -36.0417
     longitude (deg): 150.0639
     locality: 6 km N of Bodalla; power line easement c. 600 m SW of Western Boundary
       Road where it enters Moruya State Forest; eastern side of power line easement,
       23 m SW and downhill from power pole.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.0422_degS_and_150.0642_degE:
     latitude (deg): -36.0422
     longitude (deg): 150.0642
     locality: 6 km N of Bodalla; power line easement c. 600 m SW of Western Boundary
       Road where it enters Moruya State Forest; on S slope 50 m into forest from easement,
       eastern side of track 6 m N of boundary fence.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.1325_degS_and_148.44_degE:
     latitude (deg): -36.1325
     longitude (deg): 148.44
     locality: Doubtful Creek headwaters ca 1.9 km NNW of Cesjacks Hut, Jagungal Wilderness
       Area. Kosciuszko National Park.
-    collector: Wright, G.T.
+    recorded by: Wright, G.T.
   site_at_-36.1492_degS_and_148.4444_degE:
     latitude (deg): -36.1492
     longitude (deg): 148.4444
     locality: Kosciuszko National Park. Doubtful Creek, c. 5.1 km due E of Mount Jagungal
       summit.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-36.1711_degS_and_148.41_degE:
     latitude (deg): -36.1711
     longitude (deg): 148.41
     locality: Geehi River, c. 3.2 km due SE of Mount Jagungal summit.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-36.19_degS_and_148.4153_degE:
     latitude (deg): -36.19
     longitude (deg): 148.4153
     locality: Jagungal Wilderness area, tributary flowing into Geehi River. Ca 2 km
       west of North Bulls Peak, Kosciuszko National Park.
-    collector: Wright, G.T.
+    recorded by: Wright, G.T.
   site_at_-36.1911_degS_and_148.3878_degE:
     latitude (deg): -36.1911
     longitude (deg): 148.3878
     locality: Kosciuszko National Park. Geehi Creek c. 4.7 km due S of Mount Jaggungal.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-36.2_degS_and_149.7333_degE:
     latitude (deg): -36.2
     longitude (deg): 149.7333
     locality: Tuross River, above Woila Creek junction.
-    collector: Walton, S.
+    recorded by: Walton, S.
   site_at_-36.2061_degS_and_148.3997_degE:
     latitude (deg): -36.2061
     longitude (deg): 148.3997
     locality: Kosciuszko National Park. Big bend on Valentine Creek, 1.8 km due N
       of Mawson Hut.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-36.2125_degS_and_148.4222_degE:
     latitude (deg): -36.2125
     longitude (deg): 148.4222
     locality: Jagungal Wilderness area, upper reaches of tributary to Valentine Creek.
       Ca 900 m south-east of Cup & Saucer. Kosciuszko National Park.
-    collector: Wright, G.T.
+    recorded by: Wright, G.T.
   site_at_-36.2342_degS_and_149.3964_degE:
     latitude (deg): -36.2342
     longitude (deg): 149.3964
     locality: Kybeyan Nature Reserve, East Kybeyan River Fire Trail, 100 m S of ford,
       in granite outcrop.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.2381_degS_and_149.0847_degE:
     latitude (deg): -36.2381
     longitude (deg): 149.0847
     locality: Ca 3.5 km W of Cooma; Dry Plains Road, 300 m N of junction with Snowy
       Mountains Highway; roadside verge.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.2386_degS_and_149.1397_degE:
     latitude (deg): -36.2386
     longitude (deg): 149.1397
     locality: Old Cooma Common, 1 m E of radio towers.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.2389_degS_and_149.4078_degE:
     latitude (deg): -36.2389
     longitude (deg): 149.4078
     locality: Kybeyan Nature Reserve; 4 km S on Kybean East Fire Trail, from junction
       with Kybean West Fire Trail, at second creek ford; E along creekline.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.2503_degS_and_148.4181_degE:
     latitude (deg): -36.2503
     longitude (deg): 148.4181
     locality: Kosciuszko National Park. Headwaters of Valentine Creek, c. 3.4 km due
       SSE of Mawsons Hut.
-    collector: Albrecht, D.E.
+    recorded by: Albrecht, D.E.
   site_at_-36.2531_degS_and_149.4075_degE:
     latitude (deg): -36.2531
     longitude (deg): 149.4075
     locality: Kybeyan Nature Reserve; 5 km S on Kybean East Fire Trail, from junction
       with Kybean West Fire Trail, at third creek ford; 100 m SE from ford between
       the Trail and creekline.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.2667_degS_and_146.7167_degE:
     latitude (deg): -36.2667
     longitude (deg): 146.7167
     locality: 1.5 km N of Wooragee.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.2667_degS_and_149.5333_degE:
     latitude (deg): -36.2667
     longitude (deg): 149.5333
     locality: Conways Gap, NE of Kybean Kybeyan.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-36.275_degS_and_148.3833_degE:
     latitude (deg): -36.275
     longitude (deg): 148.3833
     locality: Kosciuszko National Park; 150 m W of Schlink Hilton (towards river)
       on Schlink Pass Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.2869_degS_and_148.4114_degE:
     latitude (deg): -36.2869
     longitude (deg): 148.4114
     locality: Kosciuszko National Park; E of Gungartan (a peak) towards Finns Swamp
       on the Finns River, 2.23 km E of kink in Schlink Pass Road, which is 1.17 km
       S of Schlink Hilton.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.2939_degS_and_150.0611_degE:
     latitude (deg): -36.2939
     longitude (deg): 150.0611
     locality: Dr Allan England property, 3 km N of Central Tilba.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.3_degS_and_149.5333_degE:
     latitude (deg): -36.3
     longitude (deg): 149.5333
     locality: 3 km from Tuross River Crossing towards Conways Gap.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-36.3114_degS_and_150.0678_degE:
     latitude (deg): -36.3114
     longitude (deg): 150.0678
     locality: Central Tilba; 450 m W from Central Tilba water tower.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.3161_degS_and_150.0706_degE:
     latitude (deg): -36.3161
     longitude (deg): 150.0706
     locality: Central Tilba Public School; 50 m to SE on granite rock outcrop.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.3175_degS_and_150.0581_degE:
     latitude (deg): -36.3175
     longitude (deg): 150.0581
     locality: 1 km NW from Tilba Tilba start of Tilba Tilba walking Track.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.3333_degS_and_144.6833_degE:
     latitude (deg): -36.3333
     longitude (deg): 144.6833
     locality: Rochester Race Course (7825 Echuca BV 941747).
-    collector: Scarlett, N.H.
+    recorded by: Scarlett, N.H.
   site_at_-36.3333_degS_and_149.5167_degE:
     latitude (deg): -36.3333
     longitude (deg): 149.5167
     locality: 10 km NE of Kybean along Kybean-Countegany road, through gate 500 m
       on right.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.3411_degS_and_148.5078_degE:
     latitude (deg): -36.3411
     longitude (deg): 148.5078
     locality: Kosciuszko National Park 2.20 km north from Rennix Walk signpost Kosciuszko
       Road (straight line GPS). Along main track at knoll - hill top. Ca 9.3 km ~NE
       of Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3425_degS_and_149.6_degE:
     latitude (deg): -36.3425
     longitude (deg): 149.6
     locality: Wadbilliga National Park, 1 km S of Trig.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-36.3433_degS_and_148.5108_degE:
     latitude (deg): -36.3433
     longitude (deg): 148.5108
     locality: Kosciuszko National Park 1.93 km north-north-east from Rennix Walk signpost
       Kosciuszko Road (straight line GPS). Along pathway. Ca 9.3 km ENE of Smiggin
       Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3489_degS_and_149.6111_degE:
     latitude (deg): -36.3489
     longitude (deg): 149.6111
     locality: Wadbilliga National Park, Brogo Wilderness area, c. 15 km direct ENE
       of Kybean beside the Razor Back Fire Trail.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.35_degS_and_148.4_degE:
     latitude (deg): -36.35
     longitude (deg): 148.4
     locality: Kosciuszko National Park, 400 m from Guthega power station up Schlink
       Pass road.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-36.35_degS_and_149.5833_degE:
     latitude (deg): -36.35
     longitude (deg): 149.5833
     locality: Southern tablelands escarpment. Wadbilliga trig fire trail, 9.3 km E
       of Tuross River crossing.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-36.3514_degS_and_148.5075_degE:
     latitude (deg): -36.3514
     longitude (deg): 148.5075
     locality: Kosciuszko National Park 1.0 km north from Rennix Walk signpost Kosciuszko
       Road (straight line GPS). On track. Ca 8 km ~ENE of Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3517_degS_and_149.5711_degE:
     latitude (deg): -36.3517
     longitude (deg): 149.5711
     locality: Wadbilliga National Park, Brogo Wilderness area, c. 15 km direct ENE
       of Kybean beside the Razor Back Fire Trail.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.3547_degS_and_148.5064_degE:
     latitude (deg): -36.3547
     longitude (deg): 148.5064
     locality: Kosciuszko National Park 734 m north from Rennix Walk signpost Kosciuszko
       Road (straight line GPS). Ca 8 km ~ENE of Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3564_degS_and_148.3536_degE:
     latitude (deg): -36.3564
     longitude (deg): 148.3536
     locality: Kosciuszko National Park, IBRA region AA; Tate Ridge East, 4.2 km NW
       of Guthega.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3569_degS_and_149.6183_degE:
     latitude (deg): -36.3569
     longitude (deg): 149.6183
     locality: Wadbilliga National Park, Brogo Wilderness area, c. 15 km direct ENE
       of Kybean beside the Razor Back Fire Trail.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.3581_degS_and_148.3542_degE:
     latitude (deg): -36.3581
     longitude (deg): 148.3542
     locality: Kosciuszko National Park, IBRA region AA; Tate Ridge East, 4 km NW from
       Guthega (straight line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3583_degS_and_148.5061_degE:
     latitude (deg): -36.3583
     longitude (deg): 148.5061
     locality: Kosciuszko National Park 234 m north from Rennix Walk signpost Kosciuszko
       Road (straight line GPS). Waypoint 26. Ca 8 km ~ENE of Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3589_degS_and_148.4878_degE:
     latitude (deg): -36.3589
     longitude (deg): 148.4878
     locality: Kosciuszko National Park c. 400 m E of Sponars Chalet on E side of pond
       on N side of Kosciuszko Road.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.3606_degS_and_148.3564_degE:
     latitude (deg): -36.3606
     longitude (deg): 148.3564
     locality: Kosciuszko National Park, IBRA region AA; Tate Ridge East, c. 3.7 km
       NW of Guthega.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.3606_degS_and_148.5047_degE:
     latitude (deg): -36.3606
     longitude (deg): 148.5047
     locality: Kosciuszko National Park; Rennix Gap; 300 m N of Kosciuszko Road.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.3622_degS_and_148.3561_degE:
     latitude (deg): -36.3622
     longitude (deg): 148.3561
     locality: Kosciuszko National Park, IBRA region AA; Tate Ridge East, 3.6 km NW
       of Guthega; just below Gills Nobs (North Nob).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3625_degS_and_148.5061_degE:
     latitude (deg): -36.3625
     longitude (deg): 148.5061
     locality: Kosciuszko National Park; Rennis Gap, S of Kosciuszko Road c. 1 km E
       of Guthega Road.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.3658_degS_and_148.3719_degE:
     latitude (deg): -36.3658
     longitude (deg): 148.3719
     locality: Kosciuszko National Park; 1.484 km N of Guthega Pondage Dam on top of
       ridge line E of Guthega River.
-    collector: McAuliffe, J.; Percival, J.; Flowers, G.
+    recorded by: McAuliffe, J.; Percival, J.; Flowers, G.
   site_at_-36.3669_degS_and_148.3714_degE:
     latitude (deg): -36.3669
     longitude (deg): 148.3714
     locality: Kosciuszko National Park; 1.34 km N from Guthega Pondage Dam.
-    collector: McAuliffe, J.; Flowers, G.
+    recorded by: McAuliffe, J.; Flowers, G.
   site_at_-36.3681_degS_and_148.4122_degE:
     latitude (deg): -36.3681
     longitude (deg): 148.4122
     locality: Kosciuszko National Park; Pengilleys Bog, c. 2 km ~NNW from Smiggin
       Holes on Link Road.
-    collector: Buykx, A.J.
+    recorded by: Buykx, A.J.
   site_at_-36.3683_degS_and_148.375_degE:
     latitude (deg): -36.3683
     longitude (deg): 148.375
     locality: Kosciuszko National Park; 1.27 m N from Guthega Pondage Dam.
-    collector: Percival, J.; Flowers, G.; McAuliffe, J.
+    recorded by: Percival, J.; Flowers, G.; McAuliffe, J.
   site_at_-36.37_degS_and_148.4764_degE:
     latitude (deg): -36.37
     longitude (deg): 148.4764
     locality: Kosciuszko National Park; ford along Rainbow Lake track, 0.5 km from
       road. Ca 5 km ~NE of Smiggin Holes.
-    collector: Sweet, H.; Hoyle, G.
+    recorded by: Sweet, H.; Hoyle, G.
   site_at_-36.3703_degS_and_148.4717_degE:
     latitude (deg): -36.3703
     longitude (deg): 148.4717
     locality: Kosciuszko National Park; 60 m N of the Kosciuszko Road opposite snow
       chain bay 300 m up road from Rainbow Lake walking track.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.3703_degS_and_148.4761_degE:
     latitude (deg): -36.3703
     longitude (deg): 148.4761
     locality: Kosciuszko National Park, IBRA region AA; along the Rainbow Lake walking
       track from Kosciuszko Road, c. 150 m from the carpark.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3706_degS_and_148.4761_degE:
     latitude (deg): -36.3706
     longitude (deg): 148.4761
     locality: Kosciuszko National Park Rainow Lake Walk, 164 m E from Rainbow Lake
       signpost (straight line GPS) which is on Kosciuszko Road, c. 5 km ENE of Smiggin
       Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3728_degS_and_148.4822_degE:
     latitude (deg): -36.3728
     longitude (deg): 148.4822
     locality: Kosciuszko National Park; by Rainbow Lake Track, c. 1 km from Kosciuszko
       Road.
-    collector: Nicotra, A.; Good, R.
+    recorded by: Nicotra, A.; Good, R.
   site_at_-36.3744_degS_and_148.3731_degE:
     latitude (deg): -36.3744
     longitude (deg): 148.3731
     locality: Kosciuszko National Park; 564 m N from Guthega Pondage Dam.
-    collector: Percival, J.; Flowers, G.; McAuliffe, J.
+    recorded by: Percival, J.; Flowers, G.; McAuliffe, J.
   site_at_-36.375_degS_and_143.5833_degE:
     latitude (deg): -36.375
     longitude (deg): 143.5833
     locality: 1.2 km W of the t/o to Whychitella on the Calder Highway, just W of
       Wedderburn
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-36.3756_degS_and_148.3736_degE:
     latitude (deg): -36.3756
     longitude (deg): 148.3736
     locality: Kosciuszko National Park; 474 m downstream ~NE from Guthega Pondage
       Dam.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.3756_degS_and_148.4839_degE:
     latitude (deg): -36.3756
     longitude (deg): 148.4839
     locality: Kosciuszko National Park, IBRA region AA; Rainbow Lake, c. 20-50 m above
       lake edge; NE corner.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3767_degS_and_148.3736_degE:
     latitude (deg): -36.3767
     longitude (deg): 148.3736
     locality: Kosciuszko National Park, IBRA region AA; c. 380 m NE of Guthega Pondage
       Dam; high on the southern banks of the Snowy River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3794_degS_and_148.3564_degE:
     latitude (deg): -36.3794
     longitude (deg): 148.3564
     locality: Kosciuszko National Park, IBRA region AA; Tate Ridge East, c. 2.4 km
       W of Guthega (straight line GPS). 4 km NE of Mt Twynam (GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3797_degS_and_148.3969_degE:
     latitude (deg): -36.3797
     longitude (deg): 148.3969
     locality: Kosciuszko National Park; Summit Quad Chairlift, Blue Cow.
-    collector: McAuliffe, J.; Percival, J.; Nicotra, A.; Flowers, G.
+    recorded by: McAuliffe, J.; Percival, J.; Nicotra, A.; Flowers, G.
   site_at_-36.3797_degS_and_148.4142_degE:
     latitude (deg): -36.3797
     longitude (deg): 148.4142
     locality: Kosciuszko National Park; Pengilleys Bog, 2 km up Link Road from Smiggin
       Holes.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.38_degS_and_148.4153_degE:
     latitude (deg): -36.38
     longitude (deg): 148.4153
     locality: Kosciuszko National Park Pengillys Bog, c. 200 m down slope off Smiggin
       Holes - Guthega Link Road
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.3806_degS_and_148.3964_degE:
     latitude (deg): -36.3806
     longitude (deg): 148.3964
     locality: Kosciuszko National Park, IBRA region AA; Mt Blue Cow, 30 m SW of the
       third pole of The Quad Summit chair lift.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3811_degS_and_148.3969_degE:
     latitude (deg): -36.3811
     longitude (deg): 148.3969
     locality: Kosciuszko National Park, IBRA region AA; Mt Blue Cow, 20 m SW of The
       Quad Summit chair lift, second pole from the base.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3811_degS_and_148.3975_degE:
     latitude (deg): -36.3811
     longitude (deg): 148.3975
     locality: Kosciuszko National Park, IBRA region AA; Mt Blue Cow, along the ski
       slope 20 m NE of Summit chair lift.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3833_degS_and_148.3667_degE:
     latitude (deg): -36.3833
     longitude (deg): 148.3667
     locality: Kosciuszko National Park. Guthega River at footbridge.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-36.3844_degS_and_148.4594_degE:
     latitude (deg): -36.3844
     longitude (deg): 148.4594
     locality: Kosciuszko National Park, IBRA region AA; 458 m (straight line GPS)
       S from the Kosciuszko Road / Wragges Creek ford, on the N-facing slope heading
       towards Thompsons Plain.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3861_degS_and_148.4653_degE:
     latitude (deg): -36.3861
     longitude (deg): 148.4653
     locality: Kosciuszko National Park; Thompsons Plain, 890 m SE from Wragges Creek
       parking bay on Kosciuszko Road, on southern side of road and western side of
       Wragges Creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.3861_degS_and_148.4656_degE:
     latitude (deg): -36.3861
     longitude (deg): 148.4656
     locality: Kosciuszko National Park; Thompsons Plain, 900 m SE from Wragges Creek
       parking bay on Kosciuszko Road, on southern side of road and western side of
       Wragges Creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.3867_degS_and_148.4586_degE:
     latitude (deg): -36.3867
     longitude (deg): 148.4586
     locality: Kosciuszko National Park; 1.22 km S of Wragges Creek Ford on Kosciuszko
       Road, on way to Thompsons Plain.
-    collector: McAuliffe, J.; Percival, J.; Flowers, G.; Nicotra, A.; McIntosh, E.
+    recorded by: McAuliffe, J.; Percival, J.; Flowers, G.; Nicotra, A.; McIntosh,
+      E.
   site_at_-36.3875_degS_and_148.4617_degE:
     latitude (deg): -36.3875
     longitude (deg): 148.4617
     locality: Kosciuszko National Park 834 m south-east from Wragges Creek carpark
       towards Thompson Plain (Waypoint 008 - straight line GPS). Ca 3 km ~ east of
       Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3889_degS_and_148.4672_degE:
     latitude (deg): -36.3889
     longitude (deg): 148.4672
     locality: Kosciuszko National Park, IBRA region AA; Wrags Creek at Thompsons Plain.
       1.2 km S from Kosciuszko Road and Wragges Creek ford (straight line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3892_degS_and_148.4428_degE:
     latitude (deg): -36.3892
     longitude (deg): 148.4428
     locality: Kosciuszko National Park; adjacent to Pipers Creek c. 100 m N from Kosciuszko
       Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.3908_degS_and_148.4539_degE:
     latitude (deg): -36.3908
     longitude (deg): 148.4539
     locality: Kosciuszko National Park, IBRA region AA; Wragges Creek tributary on
       Thompsons Plain; 1.6 km due S from the Wragges Creek ford on Mount Kosciuszko
       Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3911_degS_and_148.465_degE:
     latitude (deg): -36.3911
     longitude (deg): 148.465
     locality: Kosciuszko National Park (Waypoint 009) 1.33 km south-east to Wragges
       Creek carpark, Thompson Plain (Waypoint 008 - straight line GPS). Ca 3.3 km
       ~ east of Smiggin Holes.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.3914_degS_and_148.4567_degE:
     latitude (deg): -36.3914
     longitude (deg): 148.4567
     locality: Kosciuszko National Park, IBRA region AA; Wragges Creek area, 1.2 km
       S from Kosciuszko Road and Wragges Creek ford (straight line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3917_degS_and_148.3197_degE:
     latitude (deg): -36.3917
     longitude (deg): 148.3197
     locality: Kosciuszko National Park, IBRA region AA; on the lower N slopes of Mt
       Twynam; 474 m NE from the summit of Mt Twynam (straight line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3922_degS_and_148.4536_degE:
     latitude (deg): -36.3922
     longitude (deg): 148.4536
     locality: Kosciuszko National Park; 1.37 km from Wragges Ford on Kosciuszko Road.
-    collector: McAuliffe, J.; Percival, J.; Nicotra, A.
+    recorded by: McAuliffe, J.; Percival, J.; Nicotra, A.
   site_at_-36.3922_degS_and_148.4614_degE:
     latitude (deg): -36.3922
     longitude (deg): 148.4614
     locality: Kosciuszko National Park, IBRA region AA; at the base of a rocky outcrop
       bordering the southern edge of Thompsons Plain, 1.3 km from Kosciuszko Road
       and Wragges Creek ford (straight line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.3931_degS_and_148.4561_degE:
     latitude (deg): -36.3931
     longitude (deg): 148.4561
     locality: Kosciuszko National Park; 1.45 km S of Wrags Ford off Kosciuszko Road.
-    collector: Flowers, G.H.; McIntosh, E.
+    recorded by: Flowers, G.H.; McIntosh, E.
   site_at_-36.3944_degS_and_148.3203_degE:
     latitude (deg): -36.3944
     longitude (deg): 148.3203
     locality: Kosciuszko National Park, IBRA region AA; in creekline N of the saddle
       between Mt Twynam and Little Twynam.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4_degS_and_146.2333_degE:
     latitude (deg): -36.4
     longitude (deg): 146.2333
     locality: E. foot of the Warby Range 3.2 km W. of the Hume Hwy. on the Taminick
       Gap road, then 80 m N. of road. On property of C.D. Nason.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-36.4022_degS_and_148.3169_degE:
     latitude (deg): -36.4022
     longitude (deg): 148.3169
     locality: Kosciuszko National Park, IBRA region AA; northern slopes of Blue Lake
       cirque.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4036_degS_and_148.3014_degE:
     latitude (deg): -36.4036
     longitude (deg): 148.3014
     locality: Kosciuszko National Park, IBRA region AA; on southern ridge leading
       to Mt Twynam due W of Blue Lake, 6.65 km N from Rawson Pass (straight line GPS
       measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4039_degS_and_148.3056_degE:
     latitude (deg): -36.4039
     longitude (deg): 148.3056
     locality: Kosciuszko National Park; on steep slope of Mount Twynam leading towards
       Blue Lake viewing area.
-    collector: Sweet, H.; Percival, J.; Nicotra, A.
+    recorded by: Sweet, H.; Percival, J.; Nicotra, A.
   site_at_-36.4042_degS_and_148.2997_degE:
     latitude (deg): -36.4042
     longitude (deg): 148.2997
     locality: Kosciuszko National Park, IBRA region AA; on secondary walking track,
       N of Mt Twynam, 6.05 km N of Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4044_degS_and_148.3058_degE:
     latitude (deg): -36.4044
     longitude (deg): 148.3058
     locality: Kosciuszko National Park; in gully on eastern slopes of Mount Twynam
       leading toward Blue Lake viewing area.
-    collector: Sweet, H.; Percival, J.; Nicotra, A.
+    recorded by: Sweet, H.; Percival, J.; Nicotra, A.
   site_at_-36.4053_degS_and_148.3058_degE:
     latitude (deg): -36.4053
     longitude (deg): 148.3058
     locality: Kosciuszko National Park; c. 350 m N of Blue Lake and Main Range track
       junction.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4056_degS_and_148.3058_degE:
     latitude (deg): -36.4056
     longitude (deg): 148.3058
     locality: Kosciuszko National Park; c. 250 m W from the junction of the Blue Lake
       and Main Range walking tracks.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4067_degS_and_148.2967_degE:
     latitude (deg): -36.4067
     longitude (deg): 148.2967
     locality: Kosciuszko National Park, IBRA region AA; at the junction of the Main
       Range walking track and the turnoff to Mount Twynam.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4069_degS_and_148.2822_degE:
     latitude (deg): -36.4069
     longitude (deg): 148.2822
     locality: Kosciuszko National Park, IBRA region AA; 1.4 km NW (straight line GPS)
       from Mt Lee. 688 m NW from JMc839; 991 m NW from JMc 816.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4069_degS_and_148.2964_degE:
     latitude (deg): -36.4069
     longitude (deg): 148.2964
     locality: Kosciuszko National Park, IBRA region AA; Main Range walking track,
       on the saddle due N of Carruthers Peak.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4069_degS_and_148.3039_degE:
     latitude (deg): -36.4069
     longitude (deg): 148.3039
     locality: Kosciuszko National Park; c. 200 m westwards from Blue Lake lookout
       along Main Range walking track towards Mt Carruthers; 10 m N from track.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4069_degS_and_148.305_degE:
     latitude (deg): -36.4069
     longitude (deg): 148.305
     locality: Kosciuszko National Park; c. 100 m from Blue Lake lookout westwards
       along Main Range walking track towards Mt Carruthers; 20 m off track in rocky
       depression.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4069_degS_and_148.3075_degE:
     latitude (deg): -36.4069
     longitude (deg): 148.3075
     locality: Kosciuszko National Park; above Blue Lake, 200 m below main junction
       of main walking track.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4072_degS_and_148.3011_degE:
     latitude (deg): -36.4072
     longitude (deg): 148.3011
     locality: Kosciuszko National Park; Main Range walking track - 600 m from Blue
       Lake junction towards Mt Carruthers.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4078_degS_and_148.3067_degE:
     latitude (deg): -36.4078
     longitude (deg): 148.3067
     locality: Kosciuszko National Park, IBRA region AA; at the Blue Lake Lookout on
       the Main Range Walking Track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4081_degS_and_148.3056_degE:
     latitude (deg): -36.4081
     longitude (deg): 148.3056
     locality: Kosciuszko National Park, IBRA region AA; c. 50 m S of the Blue Lake
       Lookout on the Main Range Walking Track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4081_degS_and_148.3167_degE:
     latitude (deg): -36.4081
     longitude (deg): 148.3167
     locality: 100 m SE of Blue Lake, Kosciuszko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4083_degS_and_148.3031_degE:
     latitude (deg): -36.4083
     longitude (deg): 148.3031
     locality: Kosciuszko National Park, IBRA region AA; above Carruthers Creek between
       the creek and the Main Range walking track, c. 50 m below walking track.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4086_degS_and_148.2856_degE:
     latitude (deg): -36.4086
     longitude (deg): 148.2856
     locality: Kosciuszko National Park (Waypoint 011) 1.87 km west of Blue Lake Lookout
       (straight line GPS). Carruthers Peak - west - Grandstand area.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4089_degS_and_148.3058_degE:
     latitude (deg): -36.4089
     longitude (deg): 148.3058
     locality: Kosciuszko National Park, IBRA region AA; in a bog along the Main Range
       Walking Track c. 100 m S of the Blue Lake Walking Track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4089_degS_and_148.3083_degE:
     latitude (deg): -36.4089
     longitude (deg): 148.3083
     locality: Kosciuszko National Park; 500 m NW of Blue Lake and main range walking
       tracks junction.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4092_degS_and_148.3036_degE:
     latitude (deg): -36.4092
     longitude (deg): 148.3036
     locality: Kosciuszko National Park, IBRA region AA; at the head of Soil Con Creek
       c. 150 m W from where the Main Range walking track crosses Soil Con Creek.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4092_degS_and_148.3039_degE:
     latitude (deg): -36.4092
     longitude (deg): 148.3039
     locality: Kosciuszko National Park, IBRA region AA; on the southern slopes of
       Carruthers Creek c. 50 m W from where the Main Range track crosses Carruthers
       Creek.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4094_degS_and_148.2931_degE:
     latitude (deg): -36.4094
     longitude (deg): 148.2931
     locality: Kosciuszko National Park, IBRA region AA; along Main Range walking track,
       5.74 km N from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4097_degS_and_148.3056_degE:
     latitude (deg): -36.4097
     longitude (deg): 148.3056
     locality: Kosciuszko National Park; on track from Charlottes Pass to Blue Lake,
       on right hand side in drainage line on last hillside before reaching Blue Lake
       / Main Range track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.41_degS_and_148.2831_degE:
     latitude (deg): -36.41
     longitude (deg): 148.2831
     locality: Kosciuszko National Park, IBRA region AA; 1 km NW from Mt Lee (straight
       line GPS); 400 m W from JMc839.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.41_degS_and_148.3044_degE:
     latitude (deg): -36.41
     longitude (deg): 148.3044
     locality: Kosciuszko National Park, IBRA region AA; on the southern slopes of
       Carruthers Creek c. 50 m W from where the Main Range track crosses Carruthers
       Creek.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4106_degS_and_148.3056_degE:
     latitude (deg): -36.4106
     longitude (deg): 148.3056
     locality: Kosciuszko National Park, IBRA region AA; near Main Range walking track,
       c. 400 m ~ S of junction with track to Blue Lake, c. 1 km SE of Blue Lake.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4106_degS_and_148.3058_degE:
     latitude (deg): -36.4106
     longitude (deg): 148.3058
     locality: Kosciuszko National Park; 300 m S of the junction of Blue Lake walking
       track and Main Range walking track, 15 m NE of Blue Lake walking track beside
       creek.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4108_degS_and_148.3131_degE:
     latitude (deg): -36.4108
     longitude (deg): 148.3131
     locality: Kosciuszko National Park. S of Blue Lake in drainage area down to lake,
       half way between Blue Lake Lookout on walking track from Charlottes Pass and
       lake edge.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4108_degS_and_148.3686_degE:
     latitude (deg): -36.4108
     longitude (deg): 148.3686
     locality: Kosciuszko National Park, IBRA region AA; E of The Paralyser on southern
       slopes below saddle.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4111_degS_and_148.3083_degE:
     latitude (deg): -36.4111
     longitude (deg): 148.3083
     locality: Kosciuszko National Park; down from Blue Lake path to stream; over stream;
       rocky slope.
-    collector: McAuliffe, J.; Hoyle, G.
+    recorded by: McAuliffe, J.; Hoyle, G.
   site_at_-36.4114_degS_and_148.2875_degE:
     latitude (deg): -36.4114
     longitude (deg): 148.2875
     locality: Kosciuszko National Park, IBRA region AA; Main Range walkng track, between
       Mt Lee and Carruthers Peak.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4114_degS_and_148.3067_degE:
     latitude (deg): -36.4114
     longitude (deg): 148.3067
     locality: Kosciuszko National Park; on track from Charlottes Pass to Blue Lake,
       on the southern slope of creek before Blue Lake.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4119_degS_and_148.3075_degE:
     latitude (deg): -36.4119
     longitude (deg): 148.3075
     locality: Kosciuszko National Park, IBRA region AA; S from the Blue Lake lookout
       on the Main Range Walking Track; in gully that flows N into Soil Conservation
       Creek.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4122_degS_and_148.3072_degE:
     latitude (deg): -36.4122
     longitude (deg): 148.3072
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track between Charlottes Pass and Blue Lake.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4125_degS_and_148.3069_degE:
     latitude (deg): -36.4125
     longitude (deg): 148.3069
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track from Charlottes Pass to Blue Lake. 2.9 km W of Charlottes Pass (straight
       line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4133_degS_and_148.2839_degE:
     latitude (deg): -36.4133
     longitude (deg): 148.2839
     locality: Kosciuszko National Park, IBRA region AA; 636 m NW of Mt Lee (straight
       line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4133_degS_and_148.2856_degE:
     latitude (deg): -36.4133
     longitude (deg): 148.2856
     locality: Kosciuszko National Park, IBRA region AA; 633 m N of Mt Lee (straight
       line GPS) on the western side of the Main Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4136_degS_and_148.41_degE:
     latitude (deg): -36.4136
     longitude (deg): 148.41
     locality: Kosciuszko Natinal Park; Porcupine walking track 220 m SW of Perisher
       water supply on the SW side of Perisher.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4139_degS_and_148.4103_degE:
     latitude (deg): -36.4139
     longitude (deg): 148.4103
     locality: Kosciuszko National Park; upstream from Perisher water supply dam on
       W bank of creek, 70 m upstream from weir impoundment on creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4142_degS_and_148.41_degE:
     latitude (deg): -36.4142
     longitude (deg): 148.41
     locality: Kosciuszko National Park; 300 m upstream from Perisher water supply
       dam on W bank of creek, 140 m above weir on creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4142_degS_and_148.4106_degE:
     latitude (deg): -36.4142
     longitude (deg): 148.4106
     locality: Kosciuszko National Park; upstream from Perisher water supply dam on
       E bank of creek, 70 m upstream from weir impoundment on creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4144_degS_and_148.3519_degE:
     latitude (deg): -36.4144
     longitude (deg): 148.3519
     locality: Kosciuszko National Park Waypoint 015 (straight line GPS) Edge of Spencers
       Creek, 1.82 km north-north-west of Spencers Creek car park which is on Kosciuszko
       Road.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4144_degS_and_148.4106_degE:
     latitude (deg): -36.4144
     longitude (deg): 148.4106
     locality: Kosciuszko National Park; upstream from Perisher water supply dam on
       E bank of creek, 100 m upstream from weir impoundment.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4153_degS_and_148.2864_degE:
     latitude (deg): -36.4153
     longitude (deg): 148.2864
     locality: Kosciuszko National Park, IBRA region AA; Main Range walking track,
       saddle between Mt Lee and Carruthers Peak.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4153_degS_and_148.2883_degE:
     latitude (deg): -36.4153
     longitude (deg): 148.2883
     locality: Kosciuszko National Park, IBRA region AA; on the eastern slope of Mt
       Lee, 4.99 km N from Rawson Pass (straight line GPS measurement). E of the Main
       Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4158_degS_and_148.2636_degE:
     latitude (deg): -36.4158
     longitude (deg): 148.2636
     locality: Kosciuszko National Park, IBRA region AA; summit of Alice Rawson Peak.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4158_degS_and_148.2872_degE:
     latitude (deg): -36.4158
     longitude (deg): 148.2872
     locality: Kosciuszko National Park, IBRA region AA; on the eastern slope of Mt
       Lee, 4.9 km N from Rawson Pass (straight line GPS measurement). E of the Main
       Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4161_degS_and_148.2664_degE:
     latitude (deg): -36.4161
     longitude (deg): 148.2664
     locality: Kosciuszko National Park, IBRA region AA; Townsend Spur. In the first
       gully N of Racecourse Gully; 1.1 km NE of Mt Townsend summit (straight line
       GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4161_degS_and_148.3111_degE:
     latitude (deg): -36.4161
     longitude (deg): 148.3111
     locality: Kosciuszko National Park; N side of Path main walking track NE from
       Charlottes Pass, overlooking Hedley Tarn.
-    collector: McAuliffe, J.; Hoyle, G.
+    recorded by: McAuliffe, J.; Hoyle, G.
   site_at_-36.4161_degS_and_148.3756_degE:
     latitude (deg): -36.4161
     longitude (deg): 148.3756
     locality: Kosciuszko National Park; 1010 m up valley directly N of Betts Creek
       bridge on Snowy Mountains Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4164_degS_and_148.3761_degE:
     latitude (deg): -36.4164
     longitude (deg): 148.3761
     locality: Kosciuszko National Park; 1000 m up valley directly N of Betts Creek
       bridge on Snowy Mountains Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4169_degS_and_148.3897_degE:
     latitude (deg): -36.4169
     longitude (deg): 148.3897
     locality: Kosciuszko National Park; headwaters of Guthrie Creek, 20 m S of Kosciuszko
       Road; 200 m WSW of Wheatley link / Kosciuszko Road link carpark.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4172_degS_and_148.3097_degE:
     latitude (deg): -36.4172
     longitude (deg): 148.3097
     locality: 600m SW of Hedley Tarn, Kosciusko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4175_degS_and_148.3911_degE:
     latitude (deg): -36.4175
     longitude (deg): 148.3911
     locality: Kosciuszko National Park; headwaters of Guthrie Creek, 170 m S of Kosciuszko
       Road; S over ridge from Wheatley link / Kosciuszko Road link carpark; 140 m
       S from carpark.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4178_degS_and_148.2639_degE:
     latitude (deg): -36.4178
     longitude (deg): 148.2639
     locality: Kosciuszko National Park, IBRA region AA; on Townsend Spur, just below
       the ridge top on E side; 718 m NE of Mt Townsend.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4178_degS_and_148.3758_degE:
     latitude (deg): -36.4178
     longitude (deg): 148.3758
     locality: Kosciuszko National Park; 830 m up valley directly N of Betts Creek
       bridge on Snowy Mountains Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4178_degS_and_148.3903_degE:
     latitude (deg): -36.4178
     longitude (deg): 148.3903
     locality: Kosciuszko National Park; headwaters of Guthrie Creek, c. 230 m S of
       Kosciuszko Road; S over ridge from Wheatley link / Kosciuszko Road link carpark
       and downhill to SW; c. 180 m SW from carpark.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4181_degS_and_148.3897_degE:
     latitude (deg): -36.4181
     longitude (deg): 148.3897
     locality: Kosciuszko National Park; headwaters of Guthrie Creek, c. 230 m SE of
       Wheatley link / Kosciuszko Road link carpark S of Kosciuszko Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4189_degS_and_148.2856_degE:
     latitude (deg): -36.4189
     longitude (deg): 148.2856
     locality: Kosciuszko National Park, IBRA region AA; Main Range at the summit of
       Mt Lee.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4189_degS_and_148.3881_degE:
     latitude (deg): -36.4189
     longitude (deg): 148.3881
     locality: Kosciuszko National Park; 400 m downstream on Guthrie Creek from Perisher
       Gap.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4194_degS_and_148.3172_degE:
     latitude (deg): -36.4194
     longitude (deg): 148.3172
     locality: Kosciuszko National Park; between Hedley Tarn and Heartbreak Hill on
       cairned walking track. On eastern side of ridge to east of Blue Lake track c.
       1 km from Snowy River crossing.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4197_degS_and_148.3469_degE:
     latitude (deg): -36.4197
     longitude (deg): 148.3469
     locality: Kosciuszko National Park, IBRA region AA; just below Guthrie Ridge,
       E side, at the base of large rock outcrop.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4203_degS_and_148.3244_degE:
     latitude (deg): -36.4203
     longitude (deg): 148.3244
     locality: Kosciuszko National Park, IBRA region AA; Blue Lake creek 1.1 km N from
       where the Main Range track crosses the Snowy River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4203_degS_and_148.3511_degE:
     latitude (deg): -36.4203
     longitude (deg): 148.3511
     locality: Kosciuszko National Park, IBRA region AA; on western banks of Spencers
       Creek, downstream 1.23 km (straight line GPS measurement) from Spencers Creek
       bridge on Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4203_degS_and_148.3514_degE:
     latitude (deg): -36.4203
     longitude (deg): 148.3514
     locality: Kosciuszko National Park, IBRA region AA; in gully on W bank of Spencers
       Creek, 1.23 km (GPS) N of Spencers Creek bridge on Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4206_degS_and_148.2636_degE:
     latitude (deg): -36.4206
     longitude (deg): 148.2636
     locality: Kosciuszko National Park, IBRA region AA; on the eastern slopes of Mt
       Townsend, 505 m (straight line GPS measurement) from the summit of Mt Townsend,
       in the southern arm of Racecourse Gully.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4211_degS_and_148.3136_degE:
     latitude (deg): -36.4211
     longitude (deg): 148.3136
     locality: Kosciuszko National Park; Blue Lake Track.
-    collector: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.; Briceno, V.
+    recorded by: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.; Briceno, V.
   site_at_-36.4214_degS_and_148.2825_degE:
     latitude (deg): -36.4214
     longitude (deg): 148.2825
     locality: SE side of Mt Lee. 50 m from peak, Kosciuszko National Park.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4217_degS_and_148.3133_degE:
     latitude (deg): -36.4217
     longitude (deg): 148.3133
     locality: Kosciuszko National Park; just left off Blue Lake path, c. 3 km from
       Snowy River.
-    collector: Hoyle, G.; McAuliffe, J.
+    recorded by: Hoyle, G.; McAuliffe, J.
   site_at_-36.4217_degS_and_148.3772_degE:
     latitude (deg): -36.4217
     longitude (deg): 148.3772
     locality: Kosciuszko National Park; on bed of Guthrie Creek, 390 m N of Betts
       Creek bridge on Snowy Mountains Highway.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4219_degS_and_148.2597_degE:
     latitude (deg): -36.4219
     longitude (deg): 148.2597
     locality: Kosciuszko National Park, IBRA region AA; 140 m N from the summit of
       Mt Townsend (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4228_degS_and_148.315_degE:
     latitude (deg): -36.4228
     longitude (deg): 148.315
     locality: Kosciuszko National Park, IBRA region AA; on Main Range Walking Track
       between Charlottes Pass and Blue Lake, 1.57 (GPS) W of Charlottes Pass car park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4233_degS_and_148.3694_degE:
     latitude (deg): -36.4233
     longitude (deg): 148.3694
     locality: Kosciuszko National Park 157 m up slope from Betts Creek c. 3.7 km ENE
       of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4236_degS_and_148.315_degE:
     latitude (deg): -36.4236
     longitude (deg): 148.315
     locality: Kosciuszko National Park; in drain beside Blue Lake walking track, c.
       2 km from Charlotte Pass lookout.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4239_degS_and_148.2803_degE:
     latitude (deg): -36.4239
     longitude (deg): 148.2803
     locality: Kosciuszko National Park, IBRA region AA; along Main Range walking track
       4.1 km NE of Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4239_degS_and_148.2806_degE:
     latitude (deg): -36.4239
     longitude (deg): 148.2806
     locality: Kosciuszko National Park; Main Range Track.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4239_degS_and_148.3181_degE:
     latitude (deg): -36.4239
     longitude (deg): 148.3181
     locality: Kosciuszko National Park, on walking track from Charlottes Pass to Blue
       Lake, about 600m NW of stream crossing at base of hill below Charlottes Pass.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4242_degS_and_148.3514_degE:
     latitude (deg): -36.4242
     longitude (deg): 148.3514
     locality: Kosciuszko National Park, IBRA region AA; in a gully on the W side of
       Spencers Creek, 930 m (GPS) ~NW from Spencers Creek bridge on Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4244_degS_and_148.3767_degE:
     latitude (deg): -36.4244
     longitude (deg): 148.3767
     locality: Kosciuszko National Park; on N side of Snowy Mountains Highway 60 m
       N of Betts Creek bridge.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.425_degS_and_148.3153_degE:
     latitude (deg): -36.425
     longitude (deg): 148.3153
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range Walking
       Track between Charlotte Pass and Blue Lake, 1.44 km (GPS) NW of Charlotte Pass
       car park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.425_degS_and_148.3164_degE:
     latitude (deg): -36.425
     longitude (deg): 148.3164
     locality: Kosciuszko National Park; Blue Lake Track.
-    collector: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.
+    recorded by: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.
   site_at_-36.4253_degS_and_148.3525_degE:
     latitude (deg): -36.4253
     longitude (deg): 148.3525
     locality: Kosciuszko National Park; Spencers Creek.
-    collector: Hoyle, G.; Sweet, H.
+    recorded by: Hoyle, G.; Sweet, H.
   site_at_-36.4253_degS_and_148.355_degE:
     latitude (deg): -36.4253
     longitude (deg): 148.355
     locality: Kosciuszko National Park; Spencers Creek, N bank.
-    collector: Nicotra, A.; Good, R.; McAuliffe, J.
+    recorded by: Nicotra, A.; Good, R.; McAuliffe, J.
   site_at_-36.4256_degS_and_148.3256_degE:
     latitude (deg): -36.4256
     longitude (deg): 148.3256
     locality: Kosciuszko National Park, 300m down hill from start of walking track
       from Charlottes Pass to Blue Lake.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4256_degS_and_148.3461_degE:
     latitude (deg): -36.4256
     longitude (deg): 148.3461
     locality: Kosciuszko National Park, IBRA region AA; Spencers Creek at Johnnies
       Plain.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4256_degS_and_148.355_degE:
     latitude (deg): -36.4256
     longitude (deg): 148.355
     locality: Kosciuszko National Park Johnnies Plain. N side of Spencers Creek bridge,
       N side of Spencers Creek, 800 m along creek from bridge.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4256_degS_and_148.3694_degE:
     latitude (deg): -36.4256
     longitude (deg): 148.3694
     locality: Kosciuszko National Park Kosciuszko Road between Perisher and Charlottes
       Pass - 1 km from Spencers Creek bridge towards Perisher.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4258_degS_and_148.315_degE:
     latitude (deg): -36.4258
     longitude (deg): 148.315
     locality: Kosciuszko National Park; beside Blue Lake walking track, c. 1.5 km
       from Charlotte Pass lookout.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4261_degS_and_148.3778_degE:
     latitude (deg): -36.4261
     longitude (deg): 148.3778
     locality: Kosciuszko National Park Betts Creek 50 m from bridge upstream on eastern
       bank.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4264_degS_and_148.315_degE:
     latitude (deg): -36.4264
     longitude (deg): 148.315
     locality: Kosciuszko National Park; Blue Lake Track.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4267_degS_and_148.3344_degE:
     latitude (deg): -36.4267
     longitude (deg): 148.3344
     locality: Kosciuszko National Park; under the ski tow bar at Mount Guthrie, near
       Charlottes Pass.
-    collector: Rath, H.
+    recorded by: Rath, H.
   site_at_-36.4267_degS_and_148.3542_degE:
     latitude (deg): -36.4267
     longitude (deg): 148.3542
     locality: Kosciuszko National Park Johnnies Plain. N side of Spencers Creek bridge,
       S of Spencers Creek, 400 m along creek from the bridge.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4269_degS_and_148.2783_degE:
     latitude (deg): -36.4269
     longitude (deg): 148.2783
     locality: Kosciuszko National Park; Lake Albina.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4269_degS_and_148.3547_degE:
     latitude (deg): -36.4269
     longitude (deg): 148.3547
     locality: Kosciuszko National Park; Spencers Creek.
-    collector: Sweet, H.; Hoyle, G.
+    recorded by: Sweet, H.; Hoyle, G.
   site_at_-36.4269_degS_and_148.3583_degE:
     latitude (deg): -36.4269
     longitude (deg): 148.3583
     locality: Kosciuszko National Park 500 m north from Spencers Creek on Kosciuszko
       Road c. 3 km ~ E of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4269_degS_and_148.3678_degE:
     latitude (deg): -36.4269
     longitude (deg): 148.3678
     locality: Kosciuszko National Park, IBRA region AA; in fens in and along Spencers
       Creek. 790 m NE from the Spencers Creek bridge on Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4269_degS_and_148.3781_degE:
     latitude (deg): -36.4269
     longitude (deg): 148.3781
     locality: Kosciuszko National Park Betts Creek 200 m from bridge upstream on eastern
       bank.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4272_degS_and_148.3017_degE:
     latitude (deg): -36.4272
     longitude (deg): 148.3017
     locality: Kosciuszko National Park, on walking track from Charlottes Pass to Blue
       Lake, about 1km NW of stream crossing at base of hill below Charlottes Pass.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4272_degS_and_148.3164_degE:
     latitude (deg): -36.4272
     longitude (deg): 148.3164
     locality: Kosciuszko National Park Main Range Walking Track, c. 150 m up hillside
       NE from river flats between Snowy River and Merritts Creek, just off track.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4272_degS_and_148.355_degE:
     latitude (deg): -36.4272
     longitude (deg): 148.355
     locality: Kosciuszko National Park; Spencers Creek; river bank below road.
-    collector: Sweet, H.; Hoyle, G.
+    recorded by: Sweet, H.; Hoyle, G.
   site_at_-36.4272_degS_and_148.3669_degE:
     latitude (deg): -36.4272
     longitude (deg): 148.3669
     locality: Kosciuszko National Park; 700 m E from the Spencers creek bridge on
       the Kosciuszko Road on the N side of the road; wet areas.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4275_degS_and_148.3483_degE:
     latitude (deg): -36.4275
     longitude (deg): 148.3483
     locality: Kosciuszko National Park; above Johnnys Plain.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.4275_degS_and_148.3569_degE:
     latitude (deg): -36.4275
     longitude (deg): 148.3569
     locality: Kosciuszko National Park Johnnies Plain. N side of Spencers Creek bridge,
       N side of Spencers Creek, 400 m along creek from bridge.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4275_degS_and_148.3572_degE:
     latitude (deg): -36.4275
     longitude (deg): 148.3572
     locality: Kosciuszko National Park, IBRA region AA; on the northern bank of Spencers
       Creek.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4275_degS_and_148.3775_degE:
     latitude (deg): -36.4275
     longitude (deg): 148.3775
     locality: Kosciuszko National Park; on E side of Betts Creek on S side of Kosciuszko
       Road; 280 m upstream and 170 m E of creek bed.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4278_degS_and_148.2778_degE:
     latitude (deg): -36.4278
     longitude (deg): 148.2778
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track, 3.73 km NW from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4278_degS_and_148.3156_degE:
     latitude (deg): -36.4278
     longitude (deg): 148.3156
     locality: Kosciuszko National Park; Blue Lake Track.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4278_degS_and_148.3558_degE:
     latitude (deg): -36.4278
     longitude (deg): 148.3558
     locality: Kosciuszko National Park 1.5 km west of Picnic Area Spencers Creek,
       next to Spencers Creek c. 3 km ~ E of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4278_degS_and_148.3575_degE:
     latitude (deg): -36.4278
     longitude (deg): 148.3575
     locality: Kosciuszko National Park Edge of bank of Spencers Creek (Waypoint 013)
       - 322 m west of Spencers Creek car park/bridge.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4281_degS_and_148.3158_degE:
     latitude (deg): -36.4281
     longitude (deg): 148.3158
     locality: Kosciuszko National Park; Blue Lake Track.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4281_degS_and_148.3178_degE:
     latitude (deg): -36.4281
     longitude (deg): 148.3178
     locality: Kosciuszko National Park, on walking track from Charlottes Pass to Blue
       Lake, about 650 m NW of stream crossing at base of hill below Charlottes Pass.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4283_degS_and_148.2772_degE:
     latitude (deg): -36.4283
     longitude (deg): 148.2772
     locality: Kosciuszko National Park; Lake Albina.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4283_degS_and_148.3564_degE:
     latitude (deg): -36.4283
     longitude (deg): 148.3564
     locality: Kosciuszko National Park, IBRA region AA; 296 m W from Spencers Creek
       ford on Kosciuszko Road (straight line GPS).
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4286_degS_and_148.32_degE:
     latitude (deg): -36.4286
     longitude (deg): 148.32
     locality: Kosciuszko National Park; on track from Charlottes Pass to Blue Lake,
       c. 300 m above first stream as heading towards Blue Lake.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4289_degS_and_148.2769_degE:
     latitude (deg): -36.4289
     longitude (deg): 148.2769
     locality: Kosciuszko National Park; Lake Albina.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4292_degS_and_148.3158_degE:
     latitude (deg): -36.4292
     longitude (deg): 148.3158
     locality: 350 m NW of Snowy River Crossing, on Blue Lake walking track, Kosciuszko
       National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4292_degS_and_148.3214_degE:
     latitude (deg): -36.4292
     longitude (deg): 148.3214
     locality: Kosciuszko National Park; c. 2 km ~W on Main Range Track from Charlotte
       Pass, (anti-clockwise direction), just beyond Snowy River crossing (stepping
       stones).
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4292_degS_and_148.345_degE:
     latitude (deg): -36.4292
     longitude (deg): 148.345
     locality: Kosciuszko National Park, IBRA region AA; on the southern lower slope
       of Mt Guthrie, heading directly towards Johnnies Plain. 1.5 km NE from Charlottes
       Pass (direct line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4292_degS_and_148.3597_degE:
     latitude (deg): -36.4292
     longitude (deg): 148.3597
     locality: Kosciuszko National Park; Spencers Creek. By bridge and gravel slip
       road. Valley floor 30 m from creek edge.
-    collector: Bahar, N.A.; McIntosh, E.
+    recorded by: Bahar, N.A.; McIntosh, E.
   site_at_-36.4294_degS_and_148.3203_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3203
     locality: Kosciuszko National Park; bottom of Heartbreak Hill W of Charlottes
       Pass, beyond second river crossing, rocky gully 50 m off path Main Range Track.
-    collector: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
+    recorded by: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
   site_at_-36.4294_degS_and_148.3206_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3206
     locality: Kosciuszko National Park; Blue Lake track.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.4294_degS_and_148.3467_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3467
     locality: Kosciuszko National Park, IBRA region AA; between Spencers Creek and
       Kosciuszko Road, S of road 1590 m ~ENE of Charlotte Pass car park (GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4294_degS_and_148.3586_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3586
     locality: Kosciuszko National Park; S side of Spencers Creek bridge; roadside
       and water side.
-    collector: Hoyle, G.
+    recorded by: Hoyle, G.
   site_at_-36.4294_degS_and_148.3589_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3589
     locality: Kosciuszko National Park; Spencers Creek, w side of bridge, very close
       to bridge.
-    collector: McAuliffe, J.; Hoyle, G.
+    recorded by: McAuliffe, J.; Hoyle, G.
   site_at_-36.4294_degS_and_148.3594_degE:
     latitude (deg): -36.4294
     longitude (deg): 148.3594
     locality: Kosciuszko National Park; Johnnies Plain, 50 m S of Spencers Creek bridge
       on Kosciuszko Road; W side of river.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4297_degS_and_148.3164_degE:
     latitude (deg): -36.4297
     longitude (deg): 148.3164
     locality: Kosciusko National Park, 300 m NW of Snowy River Crossing, on Blue Lake
       walking track.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4297_degS_and_148.3194_degE:
     latitude (deg): -36.4297
     longitude (deg): 148.3194
     locality: Kosciuszko National Park, IBRA region AA; along Club Lake Creek, c.
       500 m W of its junction with the Snowy River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4297_degS_and_148.3208_degE:
     latitude (deg): -36.4297
     longitude (deg): 148.3208
     locality: Kosciuszko National Park; c. 50 m W of stream crossing by Charlottes
       Pass - Blue Lake track at the base of Heart-break Hill.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4297_degS_and_148.3214_degE:
     latitude (deg): -36.4297
     longitude (deg): 148.3214
     locality: Kosciuszko National Park; Snowy River junction c. 1 km below and ~W
       of Charlotte Pass; alongside paved path and river bank, slope to N.
-    collector: Buykx, A.J.
+    recorded by: Buykx, A.J.
   site_at_-36.4297_degS_and_148.345_degE:
     latitude (deg): -36.4297
     longitude (deg): 148.345
     locality: Kosciuszko National Park; Johnnys Plain.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.43_degS_and_148.3217_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3217
     locality: Kosciuszko National Park, IBRA region AA; W side of the Snowy River
       at the base of Heartbreak Hill.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.43_degS_and_148.3447_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3447
     locality: Kosciuszko National Park; Johnnys Plain.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.43_degS_and_148.3456_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3456
     locality: Kosciuszko National Park, IBRA region AA; on the southern lower slope
       of Mt Guthrie, heading directly towards Johnnies Plain. 1.5 km NE from Charlottes
       Pass (direct line GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.43_degS_and_148.3586_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3586
     locality: Kosciuszko National Park; Spencers Creek.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.43_degS_and_148.3589_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3589
     locality: Kosciuszko National Park Spencers Creek, SW of bridge, 75 m from road
       on W side of creek.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.43_degS_and_148.3592_degE:
     latitude (deg): -36.43
     longitude (deg): 148.3592
     locality: Kosciuszko National Park; Spencers Creek, W side of bridge; depression
       by water, close to road.
-    collector: Hoyle, G.; McAuliffe, J.
+    recorded by: Hoyle, G.; McAuliffe, J.
   site_at_-36.4303_degS_and_148.3206_degE:
     latitude (deg): -36.4303
     longitude (deg): 148.3206
     locality: Kosciuszko National Park bottom of Heartbreak Hill, Main Range Walking
       Track, c. 30 m off track on river flats between Snowy River and Merritts Creek.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4303_degS_and_148.3214_degE:
     latitude (deg): -36.4303
     longitude (deg): 148.3214
     locality: Kosciuszko National Park, IBRA region AA; at the base of heartbreak
       hill along the walking track heading to Blue Lake. On the banks of the Snowy
       River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4303_degS_and_148.3244_degE:
     latitude (deg): -36.4303
     longitude (deg): 148.3244
     locality: Kosciuszko National Park; bank of Snowy River; just across river, bottom
       of Heartbreak Hill near Charlottes Pass.
-    collector: Good, R.; Hoyle, G.; Nicotra, A.; McIntosh, E.
+    recorded by: Good, R.; Hoyle, G.; Nicotra, A.; McIntosh, E.
   site_at_-36.4303_degS_and_148.3572_degE:
     latitude (deg): -36.4303
     longitude (deg): 148.3572
     locality: Kosciuszko National Park; Spencers Creek, S side of bridge, Sphagnum
       bog.
-    collector: Hoyle, G.; Clarke, M.
+    recorded by: Hoyle, G.; Clarke, M.
   site_at_-36.4303_degS_and_148.3583_degE:
     latitude (deg): -36.4303
     longitude (deg): 148.3583
     locality: Kosciuszko National Park 215 m north-west from Spencers Creek carpark
       (waypoint 006 - straight line GPS).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4306_degS_and_148.2736_degE:
     latitude (deg): -36.4306
     longitude (deg): 148.2736
     locality: Kosciuszko National Park, IBRA region AA; W side of Main Range walking
       track in gully that flows N into Lake Albina, 3.6 km NW of Rawson Pass (straight
       line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4306_degS_and_148.3458_degE:
     latitude (deg): -36.4306
     longitude (deg): 148.3458
     locality: Kosciuszko National Park; Charlottes Pass valley, 2 km from Charlottes
       Pass; heavily eroded area with granitic sand.
-    collector: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
+    recorded by: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
   site_at_-36.4308_degS_and_148.2736_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.2736
     locality: Kosciuszko National Park, IBRA region AA; 2.7 km N from Rawson Pass
       (GPS) on the western slopes of Mt Northcote; first creek below the Main Range
       walking track that flows directly into Lake Albina.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4308_degS_and_148.3219_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.3219
     locality: Kosciuszko National Park bottom of Heartbreak Hill 10 m before Snowy
       River on Main Range track.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4308_degS_and_148.3444_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.3444
     locality: Kosciuszko National Park; Guthries Bog; c. 200 m S of Kosciuszko Road,
       c. 500 m E of turn-off to Charlotte Pass lodges.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4308_degS_and_148.3461_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.3461
     locality: Kosciuszko National Park, IBRA region AA; Johnnies Plain, c. 100 m S
       from Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4308_degS_and_148.3778_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.3778
     locality: Kosciuszko National Park; on E side of Betts Creek on S side of Kosciuszko
       Road; 650 m S of Betts Creek bridge.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4308_degS_and_148.3825_degE:
     latitude (deg): -36.4308
     longitude (deg): 148.3825
     locality: Kosciuszko National Park; on E side of Betts Creek on S side of Kosciuszko
       Road; on saddle on N side of first tributary of Betts Creek (flows in from E).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4311_degS_and_148.3464_degE:
     latitude (deg): -36.4311
     longitude (deg): 148.3464
     locality: Kosciuszko National Park, IBRA region AA; Johnnies Plain, c. 100 m S
       from Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4311_degS_and_148.3583_degE:
     latitude (deg): -36.4311
     longitude (deg): 148.3583
     locality: Kosciuszko National Park 100 m N of Spencers Creek bridge on edge of
       Spencers Creek c. 3 km ~ E of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4314_degS_and_148.3247_degE:
     latitude (deg): -36.4314
     longitude (deg): 148.3247
     locality: Kosciuszko National Park; c. 100 m W of Charlottes Pass start of walking
       track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4314_degS_and_148.3461_degE:
     latitude (deg): -36.4314
     longitude (deg): 148.3461
     locality: Kosciuszko National Park; Johnnys Plain.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.4317_degS_and_148.3583_degE:
     latitude (deg): -36.4317
     longitude (deg): 148.3583
     locality: Kosciuszko National Park Spencers Creek, SSW of bridge, 600 m from road
       on W side of creek.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4317_degS_and_148.3586_degE:
     latitude (deg): -36.4317
     longitude (deg): 148.3586
     locality: Kosciuszko National Park Spencers Creek, SSW of bridge, c. 600 m from
       road on W side of creek.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4319_degS_and_148.3456_degE:
     latitude (deg): -36.4319
     longitude (deg): 148.3456
     locality: Kosciuszko National Park; just off road to Charlottes Pass; 2 km NNE
       ENE prior to Charlottes Pass; streamside.
-    collector: McAuliffe, J.; Hoyle, G.; McIntosh, E.
+    recorded by: McAuliffe, J.; Hoyle, G.; McIntosh, E.
   site_at_-36.4319_degS_and_148.3569_degE:
     latitude (deg): -36.4319
     longitude (deg): 148.3569
     locality: Kosciuszko National Park (Waypoint 007) north-east from SF291 to Spencers
       Creek carpark - straight line GPS. from GPS reading ca 370 m ~south-west of
       Kosciuszko Road bridge over Spencers Creek.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4322_degS_and_148.3164_degE:
     latitude (deg): -36.4322
     longitude (deg): 148.3164
     locality: Kosciuszko National Park, IBRA region AA; 550 m SW of where the Main
       Range walking track crosses the Snowy River.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4322_degS_and_148.3283_degE:
     latitude (deg): -36.4322
     longitude (deg): 148.3283
     locality: Kosciuszko National Park within 50 m radius of toilet block at Charlottes
       Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4333_degS_and_141.75_degE:
     latitude (deg): -36.4333
     longitude (deg): 141.75
     locality: Little Desert National Park; camping ground.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-36.4333_degS_and_144.5_degE:
     latitude (deg): -36.4333
     longitude (deg): 144.5
     locality: Hunter, 11 km NW of Elmore, SE of grain silo.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-36.4333_degS_and_148.2664_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.2664
     locality: Kosciuszko National Park, IBRA region AA; western side of Muellers Peak
       along track to Mt Townsend.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4333_degS_and_148.2833_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.2833
     locality: Kosciusko National Park; Rawsons Creek, 2 km NE of Mt Kosciuszko.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-36.4333_degS_and_148.3_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.3
     locality: Kosciuszko National Park below Seamans Hut toward Snowy River Bridge.
-    collector: Barnsley, B.
+    recorded by: Barnsley, B.
   site_at_-36.4333_degS_and_148.3106_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.3106
     locality: Kosciuszko National Park, IBRA region AA; 1.07 km SW from where the
       Main Range walking track to Blue Lake crosses the Snowy River; c. 70 m W of
       river.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4333_degS_and_148.3133_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.3133
     locality: Kosciuszko National Park, IBRA region AA; 839 m SW of where Main Range
       walking track to Blue Lake crosses Snowy River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4333_degS_and_148.3333_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.3333
     locality: Kosciusko National Park, 0.5 km from Charlotte Pass gate along track
       to Mt Kosciusko summit.
-    collector: Taylor, J.M.
+    recorded by: Taylor, J.M.
   site_at_-36.4333_degS_and_148.3494_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.3494
     locality: Kosciuszko National Park, IBRA region AA; Johnnies Plain, c. 250 m S
       from Kosciuszko Road.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4333_degS_and_148.4333_degE:
     latitude (deg): -36.4333
     longitude (deg): 148.4333
     locality: 6 km WSW along Tin Mine Track, 2.5 km NW on four-wheel drive track.
-    collector: Winsbury, M.J.
+    recorded by: Winsbury, M.J.
   site_at_-36.4336_degS_and_148.2756_degE:
     latitude (deg): -36.4336
     longitude (deg): 148.2756
     locality: Kosciuszko National Park; Mount Clarke.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4336_degS_and_148.3556_degE:
     latitude (deg): -36.4336
     longitude (deg): 148.3556
     locality: Kosciuszko National Park 627 m north from Spencers Creek carpark - straight
       line GPS. (Waypoint 008). 2 m from Spencer Creek in between rocks.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4339_degS_and_148.2742_degE:
     latitude (deg): -36.4339
     longitude (deg): 148.2742
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track, 3.29 km NW from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4339_degS_and_148.29_degE:
     latitude (deg): -36.4339
     longitude (deg): 148.29
     locality: Kosciuszko National Park; Mount Clarke.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4339_degS_and_148.3067_degE:
     latitude (deg): -36.4339
     longitude (deg): 148.3067
     locality: Kosciuszko National Park, IBRA region AA; 1.4 km SW from where the Main
       Range walking track to Blue Lake crosses the Snowy River.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4342_degS_and_148.3342_degE:
     latitude (deg): -36.4342
     longitude (deg): 148.3342
     locality: Kosciuszko National Park; Guthries Bog, 250 m NE of Charlotte Pass Village
       lodges.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4342_degS_and_148.3561_degE:
     latitude (deg): -36.4342
     longitude (deg): 148.3561
     locality: Kosciuszko National Park; on banks of Spencers Creek 641 m (GPS) SW
       from Spencers Creek bridge on Kosciuszko Road. 36 26 3 S 148 21 22 E.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4347_degS_and_148.3225_degE:
     latitude (deg): -36.4347
     longitude (deg): 148.3225
     locality: Kosciuszko National Park, along the Charlottes Pass to Rawsons Pass
       road about 400 m from the Charlottes Pass gate, at the edge of the N side of
       the road.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.435_degS_and_148.2672_degE:
     latitude (deg): -36.435
     longitude (deg): 148.2672
     locality: Kosciuszko National Park, IBRA region AA; on the western slopes of the
       main range, c. 80 m below Muellers Pass. 2.4 km N from Mt Kosciuszko and 1.6
       km S from Mt Townsend (straight line GPS measurements).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4361_degS_and_148.2722_degE:
     latitude (deg): -36.4361
     longitude (deg): 148.2722
     locality: Kosciuszko National Park; Main Range Track.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4364_degS_and_148.2744_degE:
     latitude (deg): -36.4364
     longitude (deg): 148.2744
     locality: Kosciuszko National Park c. 150 m SE of Albina Pass / Main Range walking
       track, above Snowy River (north arm).
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4369_degS_and_148.2744_degE:
     latitude (deg): -36.4369
     longitude (deg): 148.2744
     locality: Kosciuszko National Park c. 250 m SE of Albina Pass / Main Range walking
       track, above Snowy River (north arm).
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4372_degS_and_148.2719_degE:
     latitude (deg): -36.4372
     longitude (deg): 148.2719
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track, 3.11 km NW from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4372_degS_and_148.3289_degE:
     latitude (deg): -36.4372
     longitude (deg): 148.3289
     locality: Kosciuszko National Park, IBRA region AA; Charlottes Pass Ski Village;
       c. 20 m below the water reservoir above the Charlottes Pass village.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4378_degS_and_148.2761_degE:
     latitude (deg): -36.4378
     longitude (deg): 148.2761
     locality: Kosciuszko National Park c. 350 m SE of Albina Pass / Main Range walking
       track, above Snowy River (north arm).
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4383_degS_and_148.3247_degE:
     latitude (deg): -36.4383
     longitude (deg): 148.3247
     locality: Kosciuszko National Park, IBRA region AA; on top of N ridge to Mount
       Stilwell from c. 100 m S of top chair lift to Charlottes Pass car park (GPS).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4386_degS_and_148.2708_degE:
     latitude (deg): -36.4386
     longitude (deg): 148.2708
     locality: Kosciuszko National Park; 2.1 km N of Mt Kosciuszko summit, on Main
       Range track.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4386_degS_and_148.3119_degE:
     latitude (deg): -36.4386
     longitude (deg): 148.3119
     locality: Kosciuszko National Park, IBRA region AA; 1.3 km SW from where the Main
       Range walking track to Blue Lake crosses the Snowy River.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4386_degS_and_148.325_degE:
     latitude (deg): -36.4386
     longitude (deg): 148.325
     locality: Kosciuszko National Park; Mount Stilwell slope. 36 deg 26 19.17 S, 148
       deg 19 29.8 E.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4389_degS_and_148.325_degE:
     latitude (deg): -36.4389
     longitude (deg): 148.325
     locality: Kosciuszko National Park; above Charlottes Pass.
-    collector: Hoyle, G.
+    recorded by: Hoyle, G.
   site_at_-36.4392_degS_and_148.3186_degE:
     latitude (deg): -36.4392
     longitude (deg): 148.3186
     locality: Kosciuszko National Park, IBRA region AA; on the Kosciuszko Summit Road,
       1.26 km SW from Charlottes Pass car park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4392_degS_and_148.3244_degE:
     latitude (deg): -36.4392
     longitude (deg): 148.3244
     locality: Kosciuszko National Park; Mount Stilwell slope. 36 deg 26 20.7 S, 148
       deg 19 27.7 E.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4394_degS_and_148.2703_degE:
     latitude (deg): -36.4394
     longitude (deg): 148.2703
     locality: Kosciuszko National Park; 2 km N of Mt Kosciuszko summit, on Main Range
       track.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4397_degS_and_148.2706_degE:
     latitude (deg): -36.4397
     longitude (deg): 148.2706
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track, 3 km NW from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4397_degS_and_148.3253_degE:
     latitude (deg): -36.4397
     longitude (deg): 148.3253
     locality: Kosciuszko National Park; jjust above Charlottes Pass, along Stillwell
       track.
-    collector: Sweet, H.; Hoyle, G.
+    recorded by: Sweet, H.; Hoyle, G.
   site_at_-36.4408_degS_and_148.3256_degE:
     latitude (deg): -36.4408
     longitude (deg): 148.3256
     locality: Kosciuszko National Park, IBRA region AA; on the eastern slopes of Mount
       Stillwell, in creekline above treeline.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4425_degS_and_148.27_degE:
     latitude (deg): -36.4425
     longitude (deg): 148.27
     locality: Kosciuszko National Park Main Range Track, c. 1 km ~N from track turn-off
       from Kosciuszko Summit Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4425_degS_and_148.4472_degE:
     latitude (deg): -36.4425
     longitude (deg): 148.4472
     locality: Little Thredbo River, Lake Crackenback, 200 m from Bullocks Way, near
       Bullocks Flat.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4428_degS_and_148.2833_degE:
     latitude (deg): -36.4428
     longitude (deg): 148.2833
     locality: Kosciuszko National Park; 830 m N of Seamans Hut on Charlotte Pass -
       Rawsons Pass track, on vallley floor of north Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4428_degS_and_148.2836_degE:
     latitude (deg): -36.4428
     longitude (deg): 148.2836
     locality: Kosciuszko National Park; 840 m N of Seamans Hut on Charlotte Pass -
       Rawsons Pass track, on vallley floor of north Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4431_degS_and_148.27_degE:
     latitude (deg): -36.4431
     longitude (deg): 148.27
     locality: Kosciuszko National Park; Lake Albina Track 2 km from Rawsons Pass.
-    collector: Nicotra, A.; McAuliffe, J.
+    recorded by: Nicotra, A.; McAuliffe, J.
   site_at_-36.4431_degS_and_148.2714_degE:
     latitude (deg): -36.4431
     longitude (deg): 148.2714
     locality: Kosciuszko National Park; snowpatch slope c. 2 km N from Rawsons Pass.
-    collector: McAuliffe, J.; Nicotra, A.
+    recorded by: McAuliffe, J.; Nicotra, A.
   site_at_-36.4433_degS_and_148.3317_degE:
     latitude (deg): -36.4433
     longitude (deg): 148.3317
     locality: Kosciuszko National Park; 50 m E of track to Mount Stillwell, 10 minutes
       from Charlottes Pass carpark.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4436_degS_and_148.2708_degE:
     latitude (deg): -36.4436
     longitude (deg): 148.2708
     locality: Kosciuszko National Park; 1.5 km N of Mt Kosciuszko summit on Main Range
       track.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4439_degS_and_148.2317_degE:
     latitude (deg): -36.4439
     longitude (deg): 148.2317
     locality: Kosciuszko National Park; above Charlottes Pass.
-    collector: Hoyle, G.
+    recorded by: Hoyle, G.
   site_at_-36.4439_degS_and_148.2708_degE:
     latitude (deg): -36.4439
     longitude (deg): 148.2708
     locality: Kosciuszko National Park, IBRA region AA; 1.3 km due N from Rawson Pass
       (GPS); slightly down the eastern slope from the Main Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4442_degS_and_148.2828_degE:
     latitude (deg): -36.4442
     longitude (deg): 148.2828
     locality: Kosciuszko National Park north of Seamans Hut (Waypoint 007); 670 m
       north-north-west from Seamans Hut carpark - straight line GPS; 30 m uphill from
       creek, eastern facing rocky slope.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4444_degS_and_148.3136_degE:
     latitude (deg): -36.4444
     longitude (deg): 148.3136
     locality: 1.5 km S of Charlottes Pass carpark on Kosciuszko summit walking track.
       Kosciuszko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4444_degS_and_148.325_degE:
     latitude (deg): -36.4444
     longitude (deg): 148.325
     locality: Kosciuszko National Park; Mount Stilwell peak. 36 deg 26 40.2 S, 148
       deg 19 29.9 E.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4447_degS_and_148.2825_degE:
     latitude (deg): -36.4447
     longitude (deg): 148.2825
     locality: Kosciuszko National Park; 610 m N of Seamans Hut on Charlotte Pass -
       Rawsons Pass track, on vallley floor of north Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.445_degS_and_148.2672_degE:
     latitude (deg): -36.445
     longitude (deg): 148.2672
     locality: Kosciuszko National Park; near Main Range Walking Track c. 1.3 km NNE
       of Mount Kosciuszko summit.
-    collector: Nicotra, A.; McAuliffe, J.
+    recorded by: Nicotra, A.; McAuliffe, J.
   site_at_-36.445_degS_and_148.2822_degE:
     latitude (deg): -36.445
     longitude (deg): 148.2822
     locality: Kosciuszko National Park North of Seamans Hut (Waypoint 008); eastern
       side of rock outcrop in valley; c. 580 m north from Seamans Hut carpark - straight
       line GPS.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.445_degS_and_148.325_degE:
     latitude (deg): -36.445
     longitude (deg): 148.325
     locality: Kosciuszko National Park; Mount Stilwell peak. 36 deg 26 41.7 S, 148
       deg 19 30.4 E.
-    collector: Nicotra, A.
+    recorded by: Nicotra, A.
   site_at_-36.4461_degS_and_148.2683_degE:
     latitude (deg): -36.4461
     longitude (deg): 148.2683
     locality: Kosciuszko National Park Main Range Track, c. 800 m ~N from track turn-off
       from Kosciuszko Summit Road.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4461_degS_and_148.2808_degE:
     latitude (deg): -36.4461
     longitude (deg): 148.2808
     locality: Kosciuszko National Park North of Seamans Hut (Waypoint 007); 467 m
       north-west from Seamans Hut carpark - straight line GPS.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4461_degS_and_148.3111_degE:
     latitude (deg): -36.4461
     longitude (deg): 148.3111
     locality: Kosciuszko National Park; on road to Merritts.
-    collector: Sweet, H.; Briceno, V.; McAuliffe, J.
+    recorded by: Sweet, H.; Briceno, V.; McAuliffe, J.
   site_at_-36.4464_degS_and_148.2775_degE:
     latitude (deg): -36.4464
     longitude (deg): 148.2775
     locality: Kosciuszko National Park valley below Seamans Hut , north-west of Mt
       Clarke - in front, 100 m west of SF233.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4464_degS_and_148.2781_degE:
     latitude (deg): -36.4464
     longitude (deg): 148.2781
     locality: Kosciuszko National Park valley below Seamans Hut , north-west of Mt
       Clarke - in front.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4464_degS_and_148.2814_degE:
     latitude (deg): -36.4464
     longitude (deg): 148.2814
     locality: Kosciuszko National Park 1 km north of Seamans Hut opposite Mt Clarke.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4469_degS_and_148.2678_degE:
     latitude (deg): -36.4469
     longitude (deg): 148.2678
     locality: Kosciuszko National Park, IBRA region AA; along the Main Range walking
       track, 2.73 km N from Rawson Pass (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4472_degS_and_148.2817_degE:
     latitude (deg): -36.4472
     longitude (deg): 148.2817
     locality: Kosciuszko National Park 250 m downhill and to north from Seamans Hut
       along walking track.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4475_degS_and_148.2817_degE:
     latitude (deg): -36.4475
     longitude (deg): 148.2817
     locality: Kosciuszko National Park 200 m downhill and to north from Seamans Hut
       along walking track.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4475_degS_and_148.3092_degE:
     latitude (deg): -36.4475
     longitude (deg): 148.3092
     locality: Kosciuszko National Park, IBRA region AA; on the banks of Snowy River
       1.8 km NE of Merritts Creek bridge (straight line GPS measurement), c. 250 m
       due W of the Charlottes Pass to Rawson Pass vehicle track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4481_degS_and_141.78_degE:
     latitude (deg): -36.4481
     longitude (deg): 141.78
     locality: Little Desert National Park, on road to camping area, c. 16 km SE of
       Nhill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.4481_degS_and_148.2672_degE:
     latitude (deg): -36.4481
     longitude (deg): 148.2672
     locality: Kosciuszko National Park, IBRA region AA; on eastern slopes of the Main
       Range, below Main Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4481_degS_and_148.2683_degE:
     latitude (deg): -36.4481
     longitude (deg): 148.2683
     locality: Kosciuszko National Park; c. 1 km NNE of Mount Kosciuszko summit.
-    collector: Briceno, V.; Nicotra, A.; Sweet, H.
+    recorded by: Briceno, V.; Nicotra, A.; Sweet, H.
   site_at_-36.4483_degS_and_141.8003_degE:
     latitude (deg): -36.4483
     longitude (deg): 141.8003
     locality: Little Desert National Park, c. 18 km SE of Nhill, at camping ground.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.4483_degS_and_148.2669_degE:
     latitude (deg): -36.4483
     longitude (deg): 148.2669
     locality: Kosciuszko National Park; Mount Kosciuszko summit area.
-    collector: Nicotra, A.; Sweet, H.; Briceno, V.
+    recorded by: Nicotra, A.; Sweet, H.; Briceno, V.
   site_at_-36.4483_degS_and_148.2672_degE:
     latitude (deg): -36.4483
     longitude (deg): 148.2672
     locality: Kosciuszko National Park; c. 500 m N of Mt Kosciuszko track on Main
       Range track; in snow patch feldmark zone.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4483_degS_and_148.3092_degE:
     latitude (deg): -36.4483
     longitude (deg): 148.3092
     locality: Kosciuszko National Park, IBRA region AA; on the banks of Snowy River
       1.7 km NE of Merritts Creek bridge (straight line GPS measurement), c. 250 m
       due W of the Charlottes Pass to Rawson Pass vehicle track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4486_degS_and_141.7819_degE:
     latitude (deg): -36.4486
     longitude (deg): 141.7819
     locality: Little Desert National Park, on road to camping area, c. 16 km SE of
       Nhill.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.4486_degS_and_148.2708_degE:
     latitude (deg): -36.4486
     longitude (deg): 148.2708
     locality: Kosciuszko National Park; c. 1 km ~NE from the summit of Mount Kosciuszko.
-    collector: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.; Briceno, V.
+    recorded by: Nicotra, A.; Sweet, H.; Percival, J.; McAuliffe, J.; Briceno, V.
   site_at_-36.4489_degS_and_148.2725_degE:
     latitude (deg): -36.4489
     longitude (deg): 148.2725
     locality: Kosciuszko National Park; c. 1.2 km NE of Mount Kosciuszko summit.
-    collector: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
+    recorded by: Nicotra, A.; McAuliffe, J.; Percival, J.; Sweet, H.
   site_at_-36.4492_degS_and_148.2736_degE:
     latitude (deg): -36.4492
     longitude (deg): 148.2736
     locality: Kosciuszko National Park; 1.04 km N from Rawsons Pass (straigth line
       GPS); c. 270 m W (straight line GPS) from the summit of Mount Kosciuszko; Kosciuszko
       Road; in gully
-    collector: Percival, J.; McAuliffe, J.
+    recorded by: Percival, J.; McAuliffe, J.
   site_at_-36.4494_degS_and_141.7892_degE:
     latitude (deg): -36.4494
     longitude (deg): 141.7892
     locality: Little Desert National Park, junction of Salt Lake and camping ground
       tracks.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.4494_degS_and_148.2664_degE:
     latitude (deg): -36.4494
     longitude (deg): 148.2664
     locality: Kosciuszko National Park; above the Main Range walking track between
       Muellers Pass and Mount Kosciuszko.
-    collector: McAuliffe, J.; Percival, J.; Sweet, H.; Nicotra, A.
+    recorded by: McAuliffe, J.; Percival, J.; Sweet, H.; Nicotra, A.
   site_at_-36.4494_degS_and_148.2789_degE:
     latitude (deg): -36.4494
     longitude (deg): 148.2789
     locality: Kosciuszko National Park 500 m west of Seamans Hut.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4494_degS_and_148.31_degE:
     latitude (deg): -36.4494
     longitude (deg): 148.31
     locality: Kosciuszko National Park, along the Charlottes Pass to Rawsons Pass
       road about 2.4 km from the Charlottes Pass gate, at the edge of the N side of
       the road.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.45_degS_and_148.25_degE:
     latitude (deg): -36.45
     longitude (deg): 148.25
     locality: Kosciusko National Park,. Track N from Mt Kosciusko.
-    collector: Rymer, J.
+    recorded by: Rymer, J.
   site_at_-36.45_degS_and_148.2667_degE:
     latitude (deg): -36.45
     longitude (deg): 148.2667
     locality: Kosciuszko National Park; overlooking Lake C. Cootapatamba, facing Mount
       Kosciuszko; just below path, all along 200+ m.
-    collector: Hoyle, G.; Sweet, H.
+    recorded by: Hoyle, G.; Sweet, H.
   site_at_-36.45_degS_and_148.2833_degE:
     latitude (deg): -36.45
     longitude (deg): 148.2833
     locality: Kosciusko National Park; below Seamans Hut, 2 km ENE of Mt. Kosciusko.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-36.45_degS_and_148.3167_degE:
     latitude (deg): -36.45
     longitude (deg): 148.3167
     locality: 1.5 km S of Mount Stilwell. Kosciuszko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4503_degS_and_148.2822_degE:
     latitude (deg): -36.4503
     longitude (deg): 148.2822
     locality: Kosciuszko National Park; Seamans Hut area.
-    collector: Sweet, H.
+    recorded by: Sweet, H.
   site_at_-36.4508_degS_and_148.2769_degE:
     latitude (deg): -36.4508
     longitude (deg): 148.2769
     locality: Kosciuszko National Park; 20 m S of Rawsons Pass - Seamans Hut road
       on NW side of Etheridge Ridge; 530 m W of Seamans Hut. 36 deg 27 3.2 S, 148
       deg 16 36.8 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4508_degS_and_148.2856_degE:
     latitude (deg): -36.4508
     longitude (deg): 148.2856
     locality: Kosciuszko National Park; 0.5 km SE from Seamans Hut, beside track.
-    collector: Nicotra, A.; Hoyle, G.
+    recorded by: Nicotra, A.; Hoyle, G.
   site_at_-36.4522_degS_and_148.2536_degE:
     latitude (deg): -36.4522
     longitude (deg): 148.2536
     locality: Kosciuszko National Park, IBRA region AA; on valley floor along creek
       directly 1.5 km west from the summit of Mt Koszciusko.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4522_degS_and_148.2747_degE:
     latitude (deg): -36.4522
     longitude (deg): 148.2747
     locality: Kosciuszko National Park Kosciuszko summit road c. 1 km WSW from Seamans
       Hut. Small stream running nearby.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4525_degS_and_148.265_degE:
     latitude (deg): -36.4525
     longitude (deg): 148.265
     locality: Kosciuszko National Park; Lake Albina Track.
-    collector: McAuliffe, J.; Nicotra, A.
+    recorded by: McAuliffe, J.; Nicotra, A.
   site_at_-36.4528_degS_and_148.2656_degE:
     latitude (deg): -36.4528
     longitude (deg): 148.2656
     locality: Kosciuszko National Park; 500 m from peak of Mt Kosciuszko along main
       walking track - summit walking trail; in drain beside path.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4531_degS_and_148.2536_degE:
     latitude (deg): -36.4531
     longitude (deg): 148.2536
     locality: Kosciuszko National Park, IBRA region AA; at the bottom of the drainage
       line 1.5 km due west from the summit of Mt Koszciusko.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4533_degS_and_148.2789_degE:
     latitude (deg): -36.4533
     longitude (deg): 148.2789
     locality: Kosciuszko National Park; southern end of peak at the eastern end of
       Etheridge Ridge; 30 m from summit. 36 deg 27 12.4 S, 148 deg 16 44.0 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4536_degS_and_148.2536_degE:
     latitude (deg): -36.4536
     longitude (deg): 148.2536
     locality: Kosciuszko National Park, IBRA region AA; at the bottom of the drainage
       line exactly 1.5 km due west from the summit of Mt Koszciusko.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4536_degS_and_148.2622_degE:
     latitude (deg): -36.4536
     longitude (deg): 148.2622
     locality: Kosciuszko National Park, IBRA region AA; on the upper western slopes
       of Mount Kosciuszko, c. 50-100 m below the summit walking track. 262 m (GPS
       straight line) NW of Mount Kosciuszko summit..
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4536_degS_and_148.2633_degE:
     latitude (deg): -36.4536
     longitude (deg): 148.2633
     locality: Kosciuszko National Park; on track from Rawsons Pass to Mount Kosciuszko
       on western side of Mount Kosciuszko. 36 deg 27 12.5 S, 148 deg 15 48 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4539_degS_and_148.2656_degE:
     latitude (deg): -36.4539
     longitude (deg): 148.2656
     locality: Kosciuszko National Park; Mt Kosciuszko summit area, beside walking
       track.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4539_degS_and_148.275_degE:
     latitude (deg): -36.4539
     longitude (deg): 148.275
     locality: Kosciuszko National Park; Mt Kosciuszko, 400 m N from junction of Rawsons
       Pass, down slope in base of wet gully.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4542_degS_and_148.25_degE:
     latitude (deg): -36.4542
     longitude (deg): 148.25
     locality: E slope of Mt Kosciuszko.
-    collector: Rymer, J.J.
+    recorded by: Rymer, J.J.
   site_at_-36.4542_degS_and_148.2672_degE:
     latitude (deg): -36.4542
     longitude (deg): 148.2672
     locality: Kosciuszko National Park; NE slopes of Mt Kosciuszko, c. 200 m below
       the Main Range walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4544_degS_and_148.2644_degE:
     latitude (deg): -36.4544
     longitude (deg): 148.2644
     locality: Kosciuszko National Park, IBRA region AA; on the eastern slopes of Mt
       Koszciusko, c. 200 m N of the summit..
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4544_degS_and_148.2658_degE:
     latitude (deg): -36.4544
     longitude (deg): 148.2658
     locality: Kosciuszko National Park; Mt Kosciuszko summit area.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4547_degS_and_148.2658_degE:
     latitude (deg): -36.4547
     longitude (deg): 148.2658
     locality: Kosciuszko National Park; Mt Kosciuszko, 300 m from Rawsons Pass junction,
       left edge of path heading to summit of Mt Kosciuszko.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4547_degS_and_148.2733_degE:
     latitude (deg): -36.4547
     longitude (deg): 148.2733
     locality: Kosciuszko National Park; NE slopes of Mt Kosciuszko, 300 m N of Rawsons
       Pass in valley stream bank.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.455_degS_and_148.2883_degE:
     latitude (deg): -36.455
     longitude (deg): 148.2883
     locality: Kosciuszko National Park; roadside between Merritts and Seamans Hut.
-    collector: Hoyle, G.; Clarke, M.
+    recorded by: Hoyle, G.; Clarke, M.
   site_at_-36.4553_degS_and_148.2625_degE:
     latitude (deg): -36.4553
     longitude (deg): 148.2625
     locality: Kosciuszko National Park path to Mount Kosciuszko; 111 m north-west
       from summit of Mount Kosciuszko (straight line GPS).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4556_degS_and_148.2611_degE:
     latitude (deg): -36.4556
     longitude (deg): 148.2611
     locality: Kosciuszko National Park 207 m west of Mount Kosciuszko summit. (Waypoint
       007, 1.07 km south from Waypoint 004).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4556_degS_and_148.295_degE:
     latitude (deg): -36.4556
     longitude (deg): 148.295
     locality: Kosciuszko National Park; Merritts Creek, 0.5 km from bridge. Mini lake
       close to Snowy River.
-    collector: Hoyle, G.; Clarke, M.
+    recorded by: Hoyle, G.; Clarke, M.
   site_at_-36.4556_degS_and_148.2969_degE:
     latitude (deg): -36.4556
     longitude (deg): 148.2969
     locality: Kosciuszko National Park, IBRA region AA; 3.5 km from Charlottes Pass
       on the main walk to Mt Kosciuszko, within the flat soaks on the banks of the
       Snowy River headwaters.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4558_degS_and_148.2633_degE:
     latitude (deg): -36.4558
     longitude (deg): 148.2633
     locality: Kosciuszko National Park; Mt Kosciuszko summit area.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4558_degS_and_148.2642_degE:
     latitude (deg): -36.4558
     longitude (deg): 148.2642
     locality: 300m east of Mt Kosciuszko summit. Kosciuszko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4558_degS_and_148.2672_degE:
     latitude (deg): -36.4558
     longitude (deg): 148.2672
     locality: Kosciuszko National Park; 250 m along Kosciuszko Summit walking track,
       in drain beside path.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4558_degS_and_148.3075_degE:
     latitude (deg): -36.4558
     longitude (deg): 148.3075
     locality: 2 km SW of Mount Stilwell. Kosciuszko NP.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4564_degS_and_148.2728_degE:
     latitude (deg): -36.4564
     longitude (deg): 148.2728
     locality: Kosciuszko National Park; Mt Kosciuszko, 150 m NW of Rawsons Pass toilet,
       in wet gully.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4567_degS_and_148.27_degE:
     latitude (deg): -36.4567
     longitude (deg): 148.27
     locality: Kosciuszko National Park; Rawson Pass toilet block, beside track back
       towards Merritts Spur/Creek.
-    collector: Nicotra, A.; Hoyle, G.
+    recorded by: Nicotra, A.; Hoyle, G.
   site_at_-36.4569_degS_and_148.2967_degE:
     latitude (deg): -36.4569
     longitude (deg): 148.2967
     locality: Kosciuszko National Park c. 200 m NE of Summit Walk and Merritts Creek
       bridge.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4572_degS_and_148.2967_degE:
     latitude (deg): -36.4572
     longitude (deg): 148.2967
     locality: Kosciuszko National Park c. 180 m NE of Summit Walk and Merritts Creek
       bridge.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4572_degS_and_148.2992_degE:
     latitude (deg): -36.4572
     longitude (deg): 148.2992
     locality: Kosciuszko National Park; road side, Kosciuszko dirt road, 0.5 km from
       Merritts Bridge.
-    collector: Hoyle, G.; McIntosh, E.
+    recorded by: Hoyle, G.; McIntosh, E.
   site_at_-36.4572_degS_and_148.2997_degE:
     latitude (deg): -36.4572
     longitude (deg): 148.2997
     locality: Kosciuszko National Park; Merritts Creek, within 100 m radius of bridge,
       just off Kosciuszko dirt road, particularly on RHS of bridge.
-    collector: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
+    recorded by: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
   site_at_-36.4575_degS_and_148.2961_degE:
     latitude (deg): -36.4575
     longitude (deg): 148.2961
     locality: Kosciuszko National Park c. 120 m N of Summit Walk and Merritts Creek
       bridge on E side of Merritts Creek.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4578_degS_and_148.2717_degE:
     latitude (deg): -36.4578
     longitude (deg): 148.2717
     locality: Kosciuszko National Park, IBRA region AA; c. halfway between Rawson
       Pass and Etheridge Ridge (summit).
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4581_degS_and_148.2728_degE:
     latitude (deg): -36.4581
     longitude (deg): 148.2728
     locality: Kosciuszko National Park, IBRA region AA; summit of Etheridge Ridge.
-    collector: Clarke, B.G.
+    recorded by: Clarke, B.G.
   site_at_-36.4581_degS_and_148.2967_degE:
     latitude (deg): -36.4581
     longitude (deg): 148.2967
     locality: Kosciuszko National Park; Merritts Creek.
-    collector: Nicotra, A.; McIntosh, E.; Norrish, D.; Hoyle, G.
+    recorded by: Nicotra, A.; McIntosh, E.; Norrish, D.; Hoyle, G.
   site_at_-36.4583_degS_and_148.2936_degE:
     latitude (deg): -36.4583
     longitude (deg): 148.2936
     locality: Kosciuszko National Park; Merritts Creek, Snowy River (N) side of bridge.
-    collector: Nicotra, A.; Sweet, H.; Hoyle, G.
+    recorded by: Nicotra, A.; Sweet, H.; Hoyle, G.
   site_at_-36.4583_degS_and_148.2947_degE:
     latitude (deg): -36.4583
     longitude (deg): 148.2947
     locality: Kosciuszko National Park; between Snowy River and Merritts Creek.
-    collector: Sweet, H.; Nicotra, A.
+    recorded by: Sweet, H.; Nicotra, A.
   site_at_-36.4583_degS_and_148.2964_degE:
     latitude (deg): -36.4583
     longitude (deg): 148.2964
     locality: Kosciuszko National Park; Merritts Creek, next to Snowy, very close
       to bridge.
-    collector: Hoyle, G.; Clarke, M.
+    recorded by: Hoyle, G.; Clarke, M.
   site_at_-36.4583_degS_and_148.2969_degE:
     latitude (deg): -36.4583
     longitude (deg): 148.2969
     locality: Kosciuszko National Park, IBRA region AA. 3.5 km N of Rawson Pass towards
       Charlottes Pass on The Summit walk, near the Merritts Creek bridge on the Charlottes
       Pass side.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4583_degS_and_148.2989_degE:
     latitude (deg): -36.4583
     longitude (deg): 148.2989
     locality: Kosciuszko National Park, IBRA region AA; banks of Merritts Creek 40
       m east / upstream from Merritts Creek bridge on the main walking track to Rawson
       Pass.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4586_degS_and_148.2681_degE:
     latitude (deg): -36.4586
     longitude (deg): 148.2681
     locality: Kosciuszko National Park 150 m SW of Rawson Pass towards Lake Cootapatamba.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4586_degS_and_148.2972_degE:
     latitude (deg): -36.4586
     longitude (deg): 148.2972
     locality: Kosciuszko National Park; Merritts Creek, by water, close to bridge.
-    collector: McAuliffe, J.; Hoyle, G.
+    recorded by: McAuliffe, J.; Hoyle, G.
   site_at_-36.4586_degS_and_148.2975_degE:
     latitude (deg): -36.4586
     longitude (deg): 148.2975
     locality: Kosciuszko National Park, IBRA region AA. 4.1 km N of Charlottes Pass
       heading towards Mt Kosciuszko on the main walking track, c. 50 m E from the
       Merritts Creek bridge.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4589_degS_and_148.2661_degE:
     latitude (deg): -36.4589
     longitude (deg): 148.2661
     locality: Kosciuszko National Park; eastern slope of Mount Kosciuszko.
-    collector: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
+    recorded by: Hoyle, G.; McAuliffe, J.; McIntosh, E.; Bahar, N.A.
   site_at_-36.4589_degS_and_148.2664_degE:
     latitude (deg): -36.4589
     longitude (deg): 148.2664
     locality: Kosciuszko National Park, IBRA region AA; c. 250 m S of Rawson Pass
       toward Lake Cootapatamba; on the lower eastern slope of Mount Kosciuszko.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4589_degS_and_148.2711_degE:
     latitude (deg): -36.4589
     longitude (deg): 148.2711
     locality: 400m NE of path intersection at Rawson Pass, Kosciuszko National Park.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.4589_degS_and_148.2972_degE:
     latitude (deg): -36.4589
     longitude (deg): 148.2972
     locality: Kosciuszko National Park, IBRA region AA; 3.5 km N of Rawson Pass towards
       Charlottes Pass on The Summit walk, near the Merritts Creek bridge on the Charlottes
       Pass side.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4589_degS_and_148.2978_degE:
     latitude (deg): -36.4589
     longitude (deg): 148.2978
     locality: Kosciuszko National Park, IBRA region AA; Merritts Creek, on eastern
       bank, 100 m upstream from Bridge on Summit track (Kosciuszko Summit Road).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4592_degS_and_148.2656_degE:
     latitude (deg): -36.4592
     longitude (deg): 148.2656
     locality: Kosciuszko National Park, IBRA region AA; on eastern slopes of Mount
       Kosciuszko, below scree. 324 m S of Rawson Pass.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4592_degS_and_148.2975_degE:
     latitude (deg): -36.4592
     longitude (deg): 148.2975
     locality: Kosciuszko National Park 107 m SE of Merritts Creek bridge (straight
       line GPS, waypoint 018). Ca 4 km SW of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4594_degS_and_148.2669_degE:
     latitude (deg): -36.4594
     longitude (deg): 148.2669
     locality: Kosciuszko National Park 30 m SW of Rawson Pass towards Lake Cootapatamba.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4594_degS_and_148.2686_degE:
     latitude (deg): -36.4594
     longitude (deg): 148.2686
     locality: Kosciuszko National Park; 100 m S of Rawsons Pass towards Lake Coop
       Cootapatamba; below walking track.
-    collector: Hoyle, G.; Nicotra, A.
+    recorded by: Hoyle, G.; Nicotra, A.
   site_at_-36.4594_degS_and_148.2692_degE:
     latitude (deg): -36.4594
     longitude (deg): 148.2692
     locality: Kosciuszko National Park between Rawsons Pass and Lake Cootapatamba,
       c. 220 m from Rawsons Pass.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4597_degS_and_148.2686_degE:
     latitude (deg): -36.4597
     longitude (deg): 148.2686
     locality: Kosciuszko National Park, 210 m from Rawsons Pass down hill towards
       Lake Cootapatamba.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4597_degS_and_148.2914_degE:
     latitude (deg): -36.4597
     longitude (deg): 148.2914
     locality: Kosciuszko National Park 330 m SW of Merritts Creek bridge on eastern
       bank of Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.46_degS_and_148.2547_degE:
     latitude (deg): -36.46
     longitude (deg): 148.2547
     locality: Kosciuszko National Park WSW of Kosciuszko peak, c. 1 km W of Rawsons
       Pass, in valley floor; creek runing almost S-W parallel to standing water at
       valley centre.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4603_degS_and_148.2533_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2533
     locality: Kosciuszko National Park c. 700 m from Rawsons Pass along Thredbo River
       boardwalk and then 100 m back towards Rawsons Pass from Lake Cootapatamba Lookout.
-    collector: Perring, A.
+    recorded by: Perring, A.
   site_at_-36.4603_degS_and_148.2572_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2572
     locality: Kosciuszko National Park 1.09 km WSW from Rawsons Pass (straight line
       GPS). (Waypoint 005, 525 m from waypoint 004).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4603_degS_and_148.2672_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2672
     locality: Kosciuszko National Park, about 400 m from Rawsons Pass down hill towards
       Lake Cootapatamba, in drainage line on SW side of valley.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4603_degS_and_148.2678_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2678
     locality: Kosciuszko National Park 0.5 km SW of Rawsons Pass towards Lake Cootapatamba.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4603_degS_and_148.2697_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2697
     locality: Kosciuszko National Park; overlooking Lake Cootapatamba, +/- facing
       Mount Kosciuszko, S of Rawson Pass.
-    collector: Hoyle, G.; Sweet, H.
+    recorded by: Hoyle, G.; Sweet, H.
   site_at_-36.4603_degS_and_148.2928_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2928
     locality: Kosciuszko National Park Snowy River, c. 300 m S of bridge on Summit
       Road.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4603_degS_and_148.2972_degE:
     latitude (deg): -36.4603
     longitude (deg): 148.2972
     locality: Kosciuszko National Park 203 m south of Merritts Creek bridge (straight
       line GPS, waypoint 019). Ca 4 km SW of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4606_degS_and_148.2928_degE:
     latitude (deg): -36.4606
     longitude (deg): 148.2928
     locality: Kosciuszko National Park Snowy River, c. 300 m S of bridge on Summit
       Road.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.4614_degS_and_148.2661_degE:
     latitude (deg): -36.4614
     longitude (deg): 148.2661
     locality: Kosciuszko National Park, IBRA region AA; c. 400 m S from Rawson Pass
       heading directly towards Lake Cootapatamba.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4625_degS_and_148.2678_degE:
     latitude (deg): -36.4625
     longitude (deg): 148.2678
     locality: Kosciuszko National Park; 800 m ~NE from Lake Cootapatamba, on margin
       of bog.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4628_degS_and_148.2647_degE:
     latitude (deg): -36.4628
     longitude (deg): 148.2647
     locality: Kosciuszko National Park, 200 m N of Lake Cootapatamba.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4633_degS_and_148.2653_degE:
     latitude (deg): -36.4633
     longitude (deg): 148.2653
     locality: Kosciuszko National Park 100 m from Lake Cootapatamba, 750 south from
       Rawson Pass (waypoint 001) towards Lake Cootapatamba.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4633_degS_and_148.27_degE:
     latitude (deg): -36.4633
     longitude (deg): 148.27
     locality: Kosciuszko National Park 691 m south of Rawson Pass. (Waypoint 25).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4636_degS_and_148.2669_degE:
     latitude (deg): -36.4636
     longitude (deg): 148.2669
     locality: Kosciuszko National Park; c. 50 m S of Rawsons Pass c. 1 km ~SSE of
       Mt Kosciuszko summit.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4636_degS_and_148.3214_degE:
     latitude (deg): -36.4636
     longitude (deg): 148.3214
     locality: Kosciuszko National Park; bank of Snowy River at bottom of Heartbreak
       Hill after first crossing from Charlottes Pass.
-    collector: Good, R.; Nicotra, A.; Hoyle, G.; McAuliffe, J.; McIntosh, E.
+    recorded by: Good, R.; Nicotra, A.; Hoyle, G.; McAuliffe, J.; McIntosh, E.
   site_at_-36.4639_degS_and_148.2644_degE:
     latitude (deg): -36.4639
     longitude (deg): 148.2644
     locality: Kosciuszko National Park, IBRA region AA. On the northern bank of Lake
       Cootapatamba.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4639_degS_and_148.2647_degE:
     latitude (deg): -36.4639
     longitude (deg): 148.2647
     locality: Kosciuszko National Park, 1 to 10 m N of Lake Cootapatamba.
-    collector: Hadobas, H.
+    recorded by: Hadobas, H.
   site_at_-36.4642_degS_and_148.265_degE:
     latitude (deg): -36.4642
     longitude (deg): 148.265
     locality: Kosciuszko National Park 835 m S of Rawson Pass on northern edge of
       Lake Cootapatamba.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4644_degS_and_148.2678_degE:
     latitude (deg): -36.4644
     longitude (deg): 148.2678
     locality: Kosciuszko National Park 300 m west of Kosciuszko Walk and 200 m east
       of Lake Cootapatamba.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4647_degS_and_141.6542_degE:
     latitude (deg): -36.4647
     longitude (deg): 141.6542
     locality: 34.2 km north of Gymbowen, heading along the Nhill - Harrow road. Little
       Desert National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4656_degS_and_148.2683_degE:
     latitude (deg): -36.4656
     longitude (deg): 148.2683
     locality: Kosciuszko National Park; c. 100 m S towards Lake Cootapatamba from
       Rawsons Pass.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4658_degS_and_148.2658_degE:
     latitude (deg): -36.4658
     longitude (deg): 148.2658
     locality: Kosciuszko National Park; S slope of Mt Kosciuszko, c. 50 m below snow
       patch feldmark zone.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4667_degS_and_148.2833_degE:
     latitude (deg): -36.4667
     longitude (deg): 148.2833
     locality: Kosciusko National Park, Merritts Creek, 2 km ESE of Mt Kosciusko.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-36.4669_degS_and_148.2978_degE:
     latitude (deg): -36.4669
     longitude (deg): 148.2978
     locality: Kosciuszko National Park 948 m south of Merritts Creek bridge (straight
       line GPS, waypoint 020). Ca 5 km ~SW of Charlottes Pass.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4678_degS_and_148.2903_degE:
     latitude (deg): -36.4678
     longitude (deg): 148.2903
     locality: Kosciuszko National Park 1.1 km S from Merritts Creek bridge over Snowy
       River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4681_degS_and_148.2628_degE:
     latitude (deg): -36.4681
     longitude (deg): 148.2628
     locality: Kosciuszko National Park, IBRA region AA; c. 300 m S of Lake Cootapatamba
       on the soaks that form the headwaters of the Swampy Plain River.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4689_degS_and_148.2597_degE:
     latitude (deg): -36.4689
     longitude (deg): 148.2597
     locality: Kosciuszko National Park 1.54 km SSW from Rawson Pass (straight line
       GPS); south of Cootapatamba Hut.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4694_degS_and_148.2864_degE:
     latitude (deg): -36.4694
     longitude (deg): 148.2864
     locality: Kosciuszko National Park 1.4 km S of Merritts Creek bridge on eastern
       bank of Snowy River, 20 m from flowing water on perched boggy area.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4722_degS_and_148.2806_degE:
     latitude (deg): -36.4722
     longitude (deg): 148.2806
     locality: Kosciuszko National Park 705 m N of Snowy River sign on Thredbo - Kosciuszko
       boardwalk on slopes. On W side of Snowy River. 2 km SW of Merritts Creek.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4744_degS_and_148.2733_degE:
     latitude (deg): -36.4744
     longitude (deg): 148.2733
     locality: Kosciuszko National Park (Waypoint 022), 100 m east of Kosciuszko Walk
       - 1.96 km south of Rawson Pass (straight line GPS).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.475_degS_and_148.2717_degE:
     latitude (deg): -36.475
     longitude (deg): 148.2717
     locality: Kosciuszko National Park; on S side of ridge amongst large granite boulders;
       ca 460 m NW of Snowy River bridge. 36 deg 28 30.0 S, 148 deg 16 18.4 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4756_degS_and_148.2717_degE:
     latitude (deg): -36.4756
     longitude (deg): 148.2717
     locality: Kosciuszko National Park, IBRA region AA; headwaters of the Snowy River,
       eastern slopes of North Ramshead, 452 m W of Snowy River junction with Thredbo
       to Rawson Pass track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4756_degS_and_148.2728_degE:
     latitude (deg): -36.4756
     longitude (deg): 148.2728
     locality: Kosciuszko National Park (Waypoint 23) 2.07 km S of Rawson Pass (straight
       line GPS off Kosciuszko Walk), towards North Ramshead.
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4756_degS_and_148.2736_degE:
     latitude (deg): -36.4756
     longitude (deg): 148.2736
     locality: Kosciuszko National Park, IBRA region AA; boardwalk between Rawson Pass
       and Thredbo as it crosses Snowy River (straight line GPS measurement).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4764_degS_and_148.2811_degE:
     latitude (deg): -36.4764
     longitude (deg): 148.2811
     locality: Kosciuszko National Park; SE of the Snowy River on a creek running due
       N c. 500 m E of the Australian Alps Walking Track, Thredbo to Mount Kosciuszko
       section.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4772_degS_and_148.2708_degE:
     latitude (deg): -36.4772
     longitude (deg): 148.2708
     locality: Kosciuszko National Park 450 m north of North Ramshead, 2.24 km south
       of Rawson Pass. (Waypoint 24).
-    collector: Fethers, S.
+    recorded by: Fethers, S.
   site_at_-36.4775_degS_and_148.2772_degE:
     latitude (deg): -36.4775
     longitude (deg): 148.2772
     locality: Kosciuszko National Park 100 m E and downstream from intersection of
       Thredbo - Kosciuszko boardwalk and Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4775_degS_and_148.2775_degE:
     latitude (deg): -36.4775
     longitude (deg): 148.2775
     locality: Kosciuszko National Park; 70 m downstream from the Thredbo - Mount Kosciuszko
       board walk on the Snowy River.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4775_degS_and_148.2836_degE:
     latitude (deg): -36.4775
     longitude (deg): 148.2836
     locality: Kosciuszko National Park; N of the Rams Head range on an old cross country
       skiiing track below 2 hanging shallow ponds, above the Snowy River, W of Merritts
       spur.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4781_degS_and_148.2742_degE:
     latitude (deg): -36.4781
     longitude (deg): 148.2742
     locality: Kosciuszko National Park; c. 200 m W of Rawsons Pass - Eagle Nest walking
       track bridge over Snowy River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4789_degS_and_148.2733_degE:
     latitude (deg): -36.4789
     longitude (deg): 148.2733
     locality: Kosciuszko National Park, IBRA region AA; at the headwaters of the Snowy
       River, 296 m (straight line GPS measurement) SW from the junction of the Snowy
       River and the Thredbo-Kosciuszko walking track.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.48_degS_and_148.2756_degE:
     latitude (deg): -36.48
     longitude (deg): 148.2756
     locality: Kosciuszko National Park; Rams Head area in headwaters of Snowy River;
       220 m W of Mount Kosciszko lookout. 36 deg 28 48.4 S, 148 deg 16 31.6 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4817_degS_and_148.2786_degE:
     latitude (deg): -36.4817
     longitude (deg): 148.2786
     locality: Kosciuszko National Park; c. 2 km NW of Eagles Nest Mountain Hut, 40
       m left of metal walkway heading to Mt Kosciuszko; c. 3 km ~SSE of Mt Kosciuszko
       summit (map distance).
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-36.4847_degS_and_148.2733_degE:
     latitude (deg): -36.4847
     longitude (deg): 148.2733
     locality: Kosciuszko National Park; Rams Head Range; in depression 413 m (GPS)
       SE of Rams Head North.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4853_degS_and_148.2747_degE:
     latitude (deg): -36.4853
     longitude (deg): 148.2747
     locality: Kosciuszko National Park; S of Rams Head North on the junction of two
       creeks.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4878_degS_and_148.2825_degE:
     latitude (deg): -36.4878
     longitude (deg): 148.2825
     locality: Kosciuszko National Park, IBRA region AA; c. 50 m W of the track from
       Thredbos Eagles Nest restaurant at top of chairlift to Rawson Pass; 821 m (GPS)
       NW of Eagles Nest (Thredbo).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.4883_degS_and_148.2808_degE:
     latitude (deg): -36.4883
     longitude (deg): 148.2808
     locality: Kosciuszko National Park; between Rams Head and Eagles Nest, 200 m W
       of boardwalk, 740 m NW of Mount Kosciuszko lookout. 36 deg 29 17.6 S, 148 deg
       16 51.3 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4883_degS_and_148.2842_degE:
     latitude (deg): -36.4883
     longitude (deg): 148.2842
     locality: Kosciuszko National Park; 50 m N of Merritts Creek crossing on Australian
       Alps Walking Track c. 2.8 km ~NW of Thredbo.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4889_degS_and_148.2714_degE:
     latitude (deg): -36.4889
     longitude (deg): 148.2714
     locality: Kosciuszko National Park; W E of Rams Head on the top parts of Bogong
       Creek.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.4894_degS_and_148.2839_degE:
     latitude (deg): -36.4894
     longitude (deg): 148.2839
     locality: Kosciuszko National Park; side of Merritts Creek crossing, W of track
       on Australian Alps Walking Track c. 2.8 km ~NW of Thredbo.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4897_degS_and_148.2808_degE:
     latitude (deg): -36.4897
     longitude (deg): 148.2808
     locality: Kosciuszko National Park; between Rams Head and Eagles Nest, 300 m W
       of boardwalk, 740 m NW of Mount Kosciuszko lookout.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4906_degS_and_148.2844_degE:
     latitude (deg): -36.4906
     longitude (deg): 148.2844
     locality: Kosciuszko National Park; beside Eagle Nest next to Kosciuszko walking
       track. 36 deg 29 26.0 S, 148 deg 17 4.3 E (WGS84).
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.4933_degS_and_148.2833_degE:
     latitude (deg): -36.4933
     longitude (deg): 148.2833
     locality: Kosciuszko National Park; 20 m N of the bottom of Karels T-bar, Thredbo.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.4944_degS_and_148.2858_degE:
     latitude (deg): -36.4944
     longitude (deg): 148.2858
     locality: Kosciuszko National Park; 300 m W of Eagles Nest chairlift, Thredbo.
-    collector: Feilen, P.
+    recorded by: Feilen, P.
   site_at_-36.5_degS_and_144.3333_degE:
     latitude (deg): -36.5
     longitude (deg): 144.3333
     locality: NNE of Bendigo, 19 km N of Huntly along Millwood road.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-36.5_degS_and_144.375_degE:
     latitude (deg): -36.5
     longitude (deg): 144.375
     locality: 0.3 km S. of the entrance to the Bendigo Whipstick Forest Park on the
       Kamarooka-Bendigo road. The tree was c. 100 m W. of the road.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-36.5167_degS_and_149.6167_degE:
     latitude (deg): -36.5167
     longitude (deg): 149.6167
     locality: 5.5 km along Nelsons Ck Firetrail from Yankeys Flat junction.
-    collector: Butler, G.
+    recorded by: Butler, G.
   site_at_-36.5342_degS_and_148.2758_degE:
     latitude (deg): -36.5342
     longitude (deg): 148.2758
     locality: Kosciuszko National Park; along flowing creek 160 m E of the Cascade
       Trail beside the Thredbo River, 1.7 km in from locked gate.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.5375_degS_and_148.2767_degE:
     latitude (deg): -36.5375
     longitude (deg): 148.2767
     locality: Kosciuszko National Park; on Cascade Trail 2.2 km in from locked gate,
       adjacent to ford on W side of Thredbo River.
-    collector: Flowers, G.H.
+    recorded by: Flowers, G.H.
   site_at_-36.5431_degS_and_148.9889_degE:
     latitude (deg): -36.5431
     longitude (deg): 148.9889
     locality: Monaro; Maffra Lake. Population 2, 150 m S from Travelling Stock Reserve
       gate on lake foreshore.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.5492_degS_and_141.6472_degE:
     latitude (deg): -36.5492
     longitude (deg): 141.6472
     locality: 24.7 km north of Gymbowen. Along the Nhill-Harrow rd heading toward
       Nhill. Little Desert NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.5494_degS_and_141.5444_degE:
     latitude (deg): -36.5494
     longitude (deg): 141.5444
     locality: 3.4 km N of the McDonald Highway and Stans Camp Track, on Stans Camp
       Track.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.5497_degS_and_140.9872_degE:
     latitude (deg): -36.5497
     longitude (deg): 140.9872
     locality: 6.9 km north from the crossroads of  the east-west track and Moffat
       track. Along the Moffat track heading towards Serviceton. Little Desert National
       Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.55_degS_and_149.6_degE:
     latitude (deg): -36.55
     longitude (deg): 149.6
     locality: Wadbilliga National Park, c. 4km NNE of Indian Head Mtn.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-36.5592_degS_and_141.6483_degE:
     latitude (deg): -36.5592
     longitude (deg): 141.6483
     locality: 25.8 km north of Gymbowen. Along the Nhill-Harrow road heading toward
       Nhill. Little Desert National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.565_degS_and_141.2853_degE:
     latitude (deg): -36.565
     longitude (deg): 141.2853
     locality: 5.1 km from the junction of Kaniva-Edenhope road and McDonald Hwy. Heading
       east along the McDonald Hwy toward the Nhill-Harrow road. Little Desert National
       Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.5667_degS_and_148.6167_degE:
     latitude (deg): -36.5667
     longitude (deg): 148.6167
     locality: Kosciusko National Park, Little Peppercorn Plain.
-    collector: Taylor, J.
+    recorded by: Taylor, J.
   site_at_-36.5742_degS_and_141.5586_degE:
     latitude (deg): -36.5742
     longitude (deg): 141.5586
     locality: 0.3 km N of the Stand Camp Track and McDonnell Highway junction, on
       Stans Camp Track.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.5983_degS_and_141.3758_degE:
     latitude (deg): -36.5983
     longitude (deg): 141.3758
     locality: 900 m E from the junction of Sambella Lane and Sisters Track, on Sisters
       Track.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-36.6_degS_and_142.0167_degE:
     latitude (deg): -36.6
     longitude (deg): 142.0167
     locality: The Grampians (Gariwerd) National Park, c. 3 km along Serra Road from
       its junction with the Glenelg River Road.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.6_degS_and_149.45_degE:
     latitude (deg): -36.6
     longitude (deg): 149.45
     locality: 22.8 km E of Nimmitabel Post Office towards Bemboka; 50 m N of road.
-    collector: Jackson, R.
+    recorded by: Jackson, R.
   site_at_-36.6014_degS_and_141.3653_degE:
     latitude (deg): -36.6014
     longitude (deg): 141.3653
     locality: 15.4 km north of the Natimuk-Frances rd and Sambles rd junction west
       of Goroke. Along the Sambles rd toward Mt Turner at Sisters Hill turnoff. Little
       Desert NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6083_degS_and_141.7978_degE:
     latitude (deg): -36.6083
     longitude (deg): 141.7978
     locality: Little Desert National Park, Salt Lake Track, c. 17 km NNW of Mt Arapiles.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.6133_degS_and_141.1019_degE:
     latitude (deg): -36.6133
     longitude (deg): 141.1019
     locality: 15.4 km along the east-west track heading west towards the SA-Vic. border.
       Little Desert National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6147_degS_and_141.1267_degE:
     latitude (deg): -36.6147
     longitude (deg): 141.1267
     locality: 13 km along the east-west track heading west towards the SA-Victorian
       border. Little Desert National Park.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6161_degS_and_141.1497_degE:
     latitude (deg): -36.6161
     longitude (deg): 141.1497
     locality: At the crossroads of the east-west track and Jacobs track. 11 km along
       the east-west track heading west towards the SA-Vic. border.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6167_degS_and_149.7167_degE:
     latitude (deg): -36.6167
     longitude (deg): 149.7167
     locality: 3.5 km before Numbugga Road from Nimmitabel.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6186_degS_and_141.7831_degE:
     latitude (deg): -36.6186
     longitude (deg): 141.7831
     locality: Little Desert National Park, c. 15.5 km NNE of Mt Arapiles.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36.6281_degS_and_141.385_degE:
     latitude (deg): -36.6281
     longitude (deg): 141.385
     locality: 11.9 km north of the Natimuk-Frances rd and Sambles rd junction west
       of Goroke.  Along the Sambles rd toward Mt Turner.  Little Desert NP.
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.65_degS_and_150_degE:
     latitude (deg): -36.65
     longitude (deg): 150.0
     locality: Mimosa Rocks National Park, S end, Tanja Lagoon.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.665_degS_and_149.9092_degE:
     latitude (deg): -36.665
     longitude (deg): 149.9092
     locality: Dr George Mountain, overlooking Bega.
-    collector: Hearder, E.
+    recorded by: Hearder, E.
   site_at_-36.6653_degS_and_141.9311_degE:
     latitude (deg): -36.6653
     longitude (deg): 141.9311
     locality: Wimmera District Lake Road, c. 200 m S of Meyers Road, 8 km due N from
       Natimuk. E side of road (from voucher MEL 2275861).
-    collector: McAuliffe, J.
+    recorded by: McAuliffe, J.
   site_at_-36.6667_degS_and_149.9167_degE:
     latitude (deg): -36.6667
     longitude (deg): 149.9167
     locality: 9 km E of Bega on road over Dr George Mountain, 20 m off roadside.
-    collector: Stewart, G.
+    recorded by: Stewart, G.
   site_at_-36.7_degS_and_146.8167_degE:
     latitude (deg): -36.7
     longitude (deg): 146.8167
     locality: Mt Buffalo tourist road, Mackeys Lookout, adjacent to road edge.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-36.7333_degS_and_146.7667_degE:
     latitude (deg): -36.7333
     longitude (deg): 146.7667
     locality: Alpine National Park, Mt Buffalo, access trail to Stanley Rocks, 2-3
       m SSE of Stanley Rocks sign on path, either side.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-36.7333_degS_and_149.9667_degE:
     latitude (deg): -36.7333
     longitude (deg): 149.9667
     locality: Snowy Mountains Highway, Evans Hill, 2.2 km W of Tathra Pub.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.75_degS_and_147.1667_degE:
     latitude (deg): -36.75
     longitude (deg): 147.1667
     locality: Alpine National Park, Kiewa Valley, Mountain Creek Road, Peppermint
       Walk, 200 m above creek on NW-facing hill, left-hand side of path.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-36.7522_degS_and_149.435_degE:
     latitude (deg): -36.7522
     longitude (deg): 149.435
     locality: South East Forests National Park New Line Road, Nunnock or Dragon Swamp.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.7525_degS_and_149.4347_degE:
     latitude (deg): -36.7525
     longitude (deg): 149.4347
     locality: South East Forests National Park New Line Road, Nunnock or Dragon Swamp.
-    collector: Guja, L.K.
+    recorded by: Guja, L.K.
   site_at_-36.765_degS_and_149.4381_degE:
     latitude (deg): -36.765
     longitude (deg): 149.4381
     locality: South East Forest National Park; New Line Road, c. 5 km N from junction
       with Tantawangalo Mountain Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.8333_degS_and_147.2833_degE:
     latitude (deg): -36.8333
     longitude (deg): 147.2833
     locality: Alpine National Park, Ruined Castle.
-    collector: Mulcahy, T.
+    recorded by: Mulcahy, T.
   site_at_-36.8425_degS_and_149.4914_degE:
     latitude (deg): -36.8425
     longitude (deg): 149.4914
     locality: 9.8 km east of Cathcart on Pambula road (Mt Darragh Road).
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.8833_degS_and_142.35_degE:
     latitude (deg): -36.8833
     longitude (deg): 142.35
     locality: Mt Zero, Grampians, 24 km SE of Horsham.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-36.8833_degS_and_142.3667_degE:
     latitude (deg): -36.8833
     longitude (deg): 142.3667
     locality: Mt Zero, Grampians, 24 km SE of Horsham.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-36.8917_degS_and_147.1375_degE:
     latitude (deg): -36.8917
     longitude (deg): 147.1375
     locality: Mount Feathertop, North Peak.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.895_degS_and_149.905_degE:
     latitude (deg): -36.895
     longitude (deg): 149.905
     locality: Merimbula; on the walking track along N shore of Merimbula Lake between
       Bodalla Place and Merimbula bridge (town centre) on Market Street.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.8953_degS_and_149.9019_degE:
     latitude (deg): -36.8953
     longitude (deg): 149.9019
     locality: Merimbula; at the top of reserve above Merimbula boardwalk on N shore
       of lake, back of number 30 Tantawangalo Street.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.9119_degS_and_149.7922_degE:
     latitude (deg): -36.9119
     longitude (deg): 149.7922
     locality: Pambula River Travelling Stock Reserve on Mount Darragh Road 9.5 km
       by road W from Princes Highway intersection, c. 55 m N from entrance gate. S
       end of suckering stand.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.9119_degS_and_149.7925_degE:
     latitude (deg): -36.9119
     longitude (deg): 149.7925
     locality: Pambula River Travelling Stock Reserve on Mount Darragh Road 9.5 km
       by road W from Princes Highway intersection, c. 55 m N from entrance gate. S
       end of suckering stand, c. 1 m NE from J.L.Percival 316.
-    collector: Percival, J.L.
+    recorded by: Percival, J.L.
   site_at_-36.9194_degS_and_147.125_degE:
     latitude (deg): -36.9194
     longitude (deg): 147.125
     locality: Twin Knobs, Mount Feathertop Track.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.9267_degS_and_149.7581_degE:
     latitude (deg): -36.9267
     longitude (deg): 149.7581
     locality: Lochiel; Box Hill Station; 1.2 km SW of Mt Darragh Road junction with
       Box Range Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.9383_degS_and_149.3178_degE:
     latitude (deg): -36.9383
     longitude (deg): 149.3178
     locality: Coolumbooka Nature Reserve. Fire break on northern edge of central section
       of the reserve, 1.5 km W of intersectio of Heath Road and Bucky Springs Road.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-36.9411_degS_and_149.7639_degE:
     latitude (deg): -36.9411
     longitude (deg): 149.7639
     locality: Lochiel; Box Hill Station; 2.75 km S along Box Range Road from Mt Darragh
       Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.9475_degS_and_149.8156_degE:
     latitude (deg): -36.9475
     longitude (deg): 149.8156
     locality: Lochiel; 471 Mt Darragh Road; 300 m SE of junction of Mt Darragh Road
       and Back Creek Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.9478_degS_and_149.8153_degE:
     latitude (deg): -36.9478
     longitude (deg): 149.8153
     locality: Lochiel; 471 Mt Darragh Road; 300 m SE of junction of Mt Darragh Road
       and Back Creek Road.
-    collector: North, T.G.
+    recorded by: North, T.G.
   site_at_-36.95_degS_and_147.7_degE:
     latitude (deg): -36.95
     longitude (deg): 147.7
     locality: Roadside at Lake Omeo at Benambra. 8424 Benambra 624 105.
-    collector: Scarlett, N.H.
+    recorded by: Scarlett, N.H.
   site_at_-36.9533_degS_and_149.28_degE:
     latitude (deg): -36.9533
     longitude (deg): 149.28
     locality: Coolumbooka Nature Reserve, southen section. Located 1 km S along fire
       break running along western edge of pine plantation from Bucky Springs road,
       where it meets northern edge of reserve.
-    collector: Henery, M.L.
+    recorded by: Henery, M.L.
   site_at_-36.9639_degS_and_147.1583_degE:
     latitude (deg): -36.9639
     longitude (deg): 147.1583
     locality: c. 500 m SSE of Mt Loch.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-36.9833_degS_and_149.7833_degE:
     latitude (deg): -36.9833
     longitude (deg): 149.7833
     locality: Adjacent to Back Creek fire trail, 6 km NW of Nethercote, 9.25 km SW
       of Pambula.
-    collector: Parris, M.
+    recorded by: Parris, M.
   site_at_-36.9992_degS_and_148.6756_degE:
     latitude (deg): -36.9992
     longitude (deg): 148.6756
     locality: Alpine National Park, Mt Tingaringy summit.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-36_degS_and_149.55_degE:
     latitude (deg): -36.0
     longitude (deg): 149.55
     locality: Big Badja Hill, 48 km NE of Cooma.
-    collector: Telford, I.R.
+    recorded by: Telford, I.R.
   site_at_-37.025_degS_and_140.4722_degE:
     latitude (deg): -37.025
     longitude (deg): 140.4722
     locality: 6.7 km S of Naracoorte to Lucindale road on back road to Penola at turnoff
       to W side of Big Heath Conservation Park.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-37.0333_degS_and_149.75_degE:
     latitude (deg): -37.0333
     longitude (deg): 149.75
     locality: Nullica State Forest, c. 15 km directly SW of Pambula, c. 1 km S of
       Sugarloaf Mountain, alongside mining track. Map ref Sheet 8823 (Eden).
-    collector: Parris, M.
+    recorded by: Parris, M.
   site_at_-37.05_degS_and_149.7833_degE:
     latitude (deg): -37.05
     longitude (deg): 149.7833
     locality: Nullica State Forest, 250 m NE along Copelands Nob Road from its junction
       with Old Hut Creek Road.
-    collector: Parris, M.
+    recorded by: Parris, M.
   site_at_-37.0553_degS_and_148.0772_degE:
     latitude (deg): -37.0553
     longitude (deg): 148.0772
     locality: Nunniong Plateau, 50 m from Brumby Point.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.0569_degS_and_149.6944_degE:
     latitude (deg): -37.0569
     longitude (deg): 149.6944
     locality: Lot 450 (private property), 3 km almost due N of river crossing at Towamba,
       near Mitchell Creek / Stoney Creek Fire Trail.
-    collector: Nightingale, M.E.
+    recorded by: Nightingale, M.E.
   site_at_-37.0833_degS_and_142.1167_degE:
     latitude (deg): -37.0833
     longitude (deg): 142.1167
     locality: Black Range; c. 9.8 km from Cherrypool, along Black Range Road.
-    collector: Canning, E.M.
+    recorded by: Canning, E.M.
   site_at_-37.15_degS_and_142.2667_degE:
     latitude (deg): -37.15
     longitude (deg): 142.2667
     locality: Asses Ears Rd, Grampians, 24 km W. of Halls Gap.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-37.1667_degS_and_139.7833_degE:
     latitude (deg): -37.1667
     longitude (deg): 139.7833
     locality: 3 km from Robe along rd to Nora Creina Bay.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-37.1667_degS_and_147.3667_degE:
     latitude (deg): -37.1667
     longitude (deg): 147.3667
     locality: Spring Creek, Cobungra ca 11 km by track SW of Cobangra Station Homestead;
       Cobungra is ca 20 km W of Omeo
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-37.1833_degS_and_148.85_degE:
     latitude (deg): -37.1833
     longitude (deg): 148.85
     locality: 6 km from Bendoc along road to Orbost.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-37.1833_degS_and_149.7333_degE:
     latitude (deg): -37.1833
     longitude (deg): 149.7333
     locality: Mount Imlay National Park Mount Imlay, NE of Trig, just below top.
-    collector: Carmen, P.
+    recorded by: Carmen, P.
   site_at_-37.2167_degS_and_142.35_degE:
     latitude (deg): -37.2167
     longitude (deg): 142.35
     locality: Harrops Rd, Grampians, 31 km. N.E. of Cavendish.
-    collector: Streimann, H.
+    recorded by: Streimann, H.
   site_at_-37.2833_degS_and_148.8167_degE:
     latitude (deg): -37.2833
     longitude (deg): 148.8167
     locality: Errinundra State Forest.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-37.3167_degS_and_149.9_degE:
     latitude (deg): -37.3167
     longitude (deg): 149.9
     locality: Merrica River Ranger Station, near Rangers Hut.
-    collector: Ganter, W.F.
+    recorded by: Ganter, W.F.
   site_at_-37.3333_degS_and_141.6667_degE:
     latitude (deg): -37.3333
     longitude (deg): 141.6667
     locality: Murrindindi Falls.
-    collector: Wallace, B.J.
+    recorded by: Wallace, B.J.
   site_at_-37.375_degS_and_149.95_degE:
     latitude (deg): -37.375
     longitude (deg): 149.95
     locality: Nadgee Nature Reserve, Newtons Beach. 10 km from Rangers Station (by
       road), 1.5 km down beach track, RHS, N facing cliff.
-    collector: Hearder, E.
+    recorded by: Hearder, E.
   site_at_-37.3833_degS_and_148.35_degE:
     latitude (deg): -37.3833
     longitude (deg): 148.35
     locality: CULTIVATED Jenny Vaughans property, East Gippsland.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.3994_degS_and_149.8667_degE:
     latitude (deg): -37.3994
     longitude (deg): 149.8667
     locality: Nadgee Nature Reserve. Nadgee Trig, 600 m to the east.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-37.4253_degS_and_149.9511_degE:
     latitude (deg): -37.4253
     longitude (deg): 149.9511
     locality: Nadgee Nature Reserve, western edge of Impressa Moor.
-    collector: Pedersen, S.
+    recorded by: Pedersen, S.
   site_at_-37.4667_degS_and_146.4167_degE:
     latitude (deg): -37.4667
     longitude (deg): 146.4167
     locality: Jamieson-Licola road, 2.3 km S of Mt Skene summit, clearing on high
       side of road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.6_degS_and_146.5_degE:
     latitude (deg): -37.6
     longitude (deg): 146.5
     locality: 0.5 km past Licola-Heyfield turnoff on Mt Useful spur (South Road).
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.6333_degS_and_144.5_degE:
     latitude (deg): -37.6333
     longitude (deg): 144.5
     locality: Merrimu reserve
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-37.6833_degS_and_145.35_degE:
     latitude (deg): -37.6833
     longitude (deg): 145.35
     locality: At the N. end of Victoria Road, 1.8 km (direct) N.W. of sheds at Lilydale
       Airfield. 50 m E. of the junction of a drainage channel and the Yarra River.
-    collector: Pryor, L.D.
+    recorded by: Pryor, L.D.
   site_at_-37.7667_degS_and_145.5833_degE:
     latitude (deg): -37.7667
     longitude (deg): 145.5833
     locality: Yarra Yarra Lakes.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-37.8_degS_and_144.95_degE:
     latitude (deg): -37.8
     longitude (deg): 144.95
     locality: CULTIVATED  Melbourne Botanic Gardens, near herb garden. Horticultural
       provenance unknown.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.8_degS_and_145.2167_degE:
     latitude (deg): -37.8
     longitude (deg): 145.2167
     locality: CULTIVATED Kuranga Native Nursery.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-37.8167_degS_and_144.9667_degE:
     latitude (deg): -37.8167
     longitude (deg): 144.9667
     locality: CULTIVATED Melbourne Botanic Gardens.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.8333_degS_and_147.6167_degE:
     latitude (deg): -37.8333
     longitude (deg): 147.6167
     locality: CULTIVATED Bairnsdale, Mitchell Motor Inn.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.8667_degS_and_145_degE:
     latitude (deg): -37.8667
     longitude (deg): 145.0
     locality: CULTIVATED Melbourne Zoo, Asian Bear display.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-37.8667_degS_and_148.0667_degE:
     latitude (deg): -37.8667
     longitude (deg): 148.0667
     locality: Lake Bunga
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-37.8833_degS_and_147.3_degE:
     latitude (deg): -37.8833
     longitude (deg): 147.3
     locality: Railway line c. 1 km NNE of Perry River, c. 2 km ESE of Fernbank.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-37.9333_degS_and_145.6167_degE:
     latitude (deg): -37.9333
     longitude (deg): 145.6167
     locality: 6 km directly ENE of Gembrook, 4 km E along Black Snake Creek Road from
       Whites Corner.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-37_degS_and_149.8833_degE:
     latitude (deg): -37.0
     longitude (deg): 149.8833
     locality: Nullica State Forest, c. 4 km from Princes Highway along Broadwater
       Forest Road.
-    collector: Parris, M.
+    recorded by: Parris, M.
   site_at_-38.1833_degS_and_145.0833_degE:
     latitude (deg): -38.1833
     longitude (deg): 145.0833
     locality: Frankston, junction of Rossmith Road and Nepean Highway.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-38.4_degS_and_141.5667_degE:
     latitude (deg): -38.4
     longitude (deg): 141.5667
     locality: Western plains; 7 km SW of Portland, 4 km NNE of Cape Nelson lighthouse.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-38.4_degS_and_141.6333_degE:
     latitude (deg): -38.4
     longitude (deg): 141.6333
     locality: SE of Portland, Alcoa smelter site, 0.8 km W of Point Danger.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-38.4164_degS_and_144.0561_degE:
     latitude (deg): -38.4164
     longitude (deg): 144.0561
     locality: 50 m from NE side of Bambra Rd, 0.4 km past Loves Track turnoff towards
       Bambra. Angahook Lorne State Park.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-38.4167_degS_and_141.5333_degE:
     latitude (deg): -38.4167
     longitude (deg): 141.5333
     locality: 10 km SW of Portland, 0.6 km N of Cape Nelson lighthouse.
-    collector: Crisp, M.D.
+    recorded by: Crisp, M.D.
   site_at_-38.4167_degS_and_144.0833_degE:
     latitude (deg): -38.4167
     longitude (deg): 144.0833
     locality: Along Coalmine Ck. Track, +/- 300 m S of its junction with Moggs Ck.
       Track, ca 16 km W of Anglesea.
-    collector: Platt, S.J.
+    recorded by: Platt, S.J.
   site_at_-38.4333_degS_and_143.4_degE:
     latitude (deg): -38.4333
     longitude (deg): 143.4
     locality: Western Plains 6 km N of Lavers Hill along Cobden Road.
-    collector: Watt, A.
+    recorded by: Watt, A.
   site_at_-38.4333_degS_and_146.5667_degE:
     latitude (deg): -38.4333
     longitude (deg): 146.5667
     locality: 2 km past Balook on Ridge Road.
-    collector: Cayzer, L.W.
+    recorded by: Cayzer, L.W.
   site_at_-38.6833_degS_and_143.3833_degE:
     latitude (deg): -38.6833
     longitude (deg): 143.3833
     locality: CULTIVATED Alistair and Julie Watt, Lavers Hill.
-    collector: Nightingale, J.
+    recorded by: Nightingale, J.
   site_at_-38.6833_degS_and_143.4_degE:
     latitude (deg): -38.6833
     longitude (deg): 143.4
     locality: Otway Ranges, 1 km N of Lavers Hill along Morris Track.
-    collector: Watt, A.
+    recorded by: Watt, A.
   site_at_-38.7692_degS_and_143.4178_degE:
     latitude (deg): -38.7692
     longitude (deg): 143.4178
     locality: 200 m on dirt track through maintenance access gate. Gate located 0.4
       km off highway opposite Glenaire Cottages entrance off Great Ocean Rd, 3.5 km
       from Red Johnna Rd heading to Apollo Bay.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-38.8333_degS_and_146.2333_degE:
     latitude (deg): -38.8333
     longitude (deg): 146.2333
     locality: 3.5 km along road from Wilsons Promontory National Park boundary towards
       Yanakie.
-    collector: Lyne, A.M.
+    recorded by: Lyne, A.M.
   site_at_-38.8403_degS_and_143.5464_degE:
     latitude (deg): -38.8403
     longitude (deg): 143.5464
     locality: 1.5 km off Cape Otway Rd, on Blanket Bay Rd.
-    collector: Cosgrove, C.
+    recorded by: Cosgrove, C.
   site_at_-40.8667_degS_and_145.5_degE:
     latitude (deg): -40.8667
     longitude (deg): 145.5
     locality: Rocky Cape National Park, Burgess Cove, ca. 50 m W of beach.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-40.9333_degS_and_145.5833_degE:
     latitude (deg): -40.9333
     longitude (deg): 145.5833
     locality: Rocky Cape National Park, Irbys Road, c. 500 m E of Lake Llewellyn.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-41.1_degS_and_146.6667_degE:
     latitude (deg): -41.1
     longitude (deg): 146.6667
     locality: Asbestos Range National Park, coastal track to Bakers Beach. c. 1 km
       NW from start of track, Badger Head.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-41.1333_degS_and_144.6833_degE:
     latitude (deg): -41.1333
     longitude (deg): 144.6833
     locality: Temma road near Nelson Bay.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-41.1333_degS_and_146.7167_degE:
     latitude (deg): -41.1333
     longitude (deg): 146.7167
     locality: Between Asbestos Range and Flowers Hill, 1.3 km WNW along track which
       intersects with Asbestos Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-41.4764_degS_and_146.2528_degE:
     latitude (deg): -41.4764
     longitude (deg): 146.2528
     locality: 3 km E of Gowrie Park towards Mt Roland, 1 km along Vandyke Track at
       end of road.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-41.8167_degS_and_146.0833_degE:
     latitude (deg): -41.8167
     longitude (deg): 146.0833
     locality: Cradle Mountain - Lake St. Clair National Park, Arm River Track, just
       E of Lake Ayr.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-41.8333_degS_and_145.5333_degE:
     latitude (deg): -41.8333
     longitude (deg): 145.5333
     locality: Mount Read.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-41.9_degS_and_146.4333_degE:
     latitude (deg): -41.9
     longitude (deg): 146.4333
     locality: Talinah Lagoon, NW corner.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-41.9167_degS_and_145.175_degE:
     latitude (deg): -41.9167
     longitude (deg): 145.175
     locality: W of Zeehan, Granville Harbour road, 2 km from Ocean.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-41.9167_degS_and_145.1833_degE:
     latitude (deg): -41.9167
     longitude (deg): 145.1833
     locality: 2 km N of Trial Harbour, 1.5 km from coast.
-    collector: Croft, J.R.
+    recorded by: Croft, J.R.
   site_at_-41.9667_degS_and_146.2833_degE:
     latitude (deg): -41.9667
     longitude (deg): 146.2833
     locality: Wild Dog Creek, near crossing by Walls of Jerusalem Track.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-41.9783_degS_and_146.3742_degE:
     latitude (deg): -41.9783
     longitude (deg): 146.3742
     locality: Gowan Brae (Tasmanian Aboriginal Council property), Johnsons Lagoon.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-41.9794_degS_and_146.3719_degE:
     latitude (deg): -41.9794
     longitude (deg): 146.3719
     locality: Gowan Brae (Tasmanian Aboriginal Council property), Johnsons Lagoon.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-41.9839_degS_and_146.4767_degE:
     latitude (deg): -41.9839
     longitude (deg): 146.4767
     locality: Gowan Brae (Tasmanian Aboriginal Council property), north-east corner
       of Circular Marsh.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-41.9839_degS_and_146.4769_degE:
     latitude (deg): -41.9839
     longitude (deg): 146.4769
     locality: Gowan Brae (Tasmanian Aboriginal Council property), north-east corner
       of Circular Marsh.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-41.9842_degS_and_146.41_degE:
     latitude (deg): -41.9842
     longitude (deg): 146.41
     locality: Gowan Brae (Tasmanian Aboriginal Council property), unnamed marsh draining
       into Little River.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-42.0167_degS_and_146.4844_degE:
     latitude (deg): -42.0167
     longitude (deg): 146.4844
     locality: Roscarborough (Tasmanian Land Conservancy property), unnamed marsh,
       north end on property.
-    collector: Clifton, E.J.
+    recorded by: Clifton, E.J.
   site_at_-42.0333_degS_and_146.7833_degE:
     latitude (deg): -42.0333
     longitude (deg): 146.7833
     locality: Wihareja.
-    collector: ANBG
+    recorded by: ANBG
   site_at_-42.0875_degS_and_146.3208_degE:
     latitude (deg): -42.0875
     longitude (deg): 146.3208
     locality: Clarence Lagoon, adjacent to Clarence River at exit of lagoon, Central
       Highlands.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   site_at_-42.1_degS_and_146.3167_degE:
     latitude (deg): -42.1
     longitude (deg): 146.3167
     locality: Central Plateau. 600 m from Clarence Lagoon, SW of where it enters Clarence
       River. On old road from Lyell Highway.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-42.1167_degS_and_147.2833_degE:
     latitude (deg): -42.1167
     longitude (deg): 147.2833
     locality: 13.5 km W of Tunbridge along Tunbridge Tier Road to Interlaken.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-42.1333_degS_and_146.75_degE:
     latitude (deg): -42.1333
     longitude (deg): 146.75
     locality: edge of Ouse River, 500 m downstream from power station at Waddamana.
-    collector: Richardson, M.M.
+    recorded by: Richardson, M.M.
   site_at_-42.15_degS_and_148.2833_degE:
     latitude (deg): -42.15
     longitude (deg): 148.2833
     locality: Freycinet National Park, Hazards Beach Track.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-42.2333_degS_and_145.45_degE:
     latitude (deg): -42.2333
     longitude (deg): 145.45
     locality: West. 4.5 km SSE of Teepookana Bridge, Teepookana Forest Reserve/Plateau,
       near Strahan.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-42.6667_degS_and_146.6167_degE:
     latitude (deg): -42.6667
     longitude (deg): 146.6167
     locality: Lake Fenton, Mt Field National Park. Grid ref 469250E, 5274900N. Tyenna
       1100,000 Map Sheet. 1100,000 Map Sheet.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   site_at_-42.6833_degS_and_146.6_degE:
     latitude (deg): -42.6833
     longitude (deg): 146.6
     locality: Mount Field National Park, 1 km E of Lake Dobson, N of Lake Dobson Road.
-    collector: Croft, J.R.
+    recorded by: Croft, J.R.
   site_at_-42.6861_degS_and_146.5944_degE:
     latitude (deg): -42.6861
     longitude (deg): 146.5944
     locality: Lake Dobson, 200m N along the Urquhart track towards ski huts, Mt Field
       National Park. Grid ref 466300E, 5274100N, 125000 Dobson.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-42.75_degS_and_147.8167_degE:
     latitude (deg): -42.75
     longitude (deg): 147.8167
     locality: N of Kellivie, 1 km along Franklins Road, by Hospital Creek, S side
       of road.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-42.8722_degS_and_146.2333_degE:
     latitude (deg): -42.8722
     longitude (deg): 146.2333
     locality: SW Tasmania. Between Lakes Pedder and Gordon. At the summit of The Sentinels
       adjacent to track, near the rock ledge to the left.
-    collector: Barnes, R.
+    recorded by: Barnes, R.
   site_at_-42.9333_degS_and_147.25_degE:
     latitude (deg): -42.9333
     longitude (deg): 147.25
     locality: Summerleas Road, Mt Nelson.
-    collector: Statham, M.
+    recorded by: Statham, M.
   site_at_-42.95_degS_and_147.5167_degE:
     latitude (deg): -42.95
     longitude (deg): 147.5167
     locality: Cremorne, Culverts Hill.
-    collector: Briggs, J.D.
+    recorded by: Briggs, J.D.
   site_at_-42.9833_degS_and_147.2167_degE:
     latitude (deg): -42.9833
     longitude (deg): 147.2167
     locality: Huon Highway, 500 m N from Sandfly junction with Southern Outlet Road.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-42_degS_and_146.75_degE:
     latitude (deg): -42.0
     longitude (deg): 146.75
     locality: Shannon
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-43.1833_degS_and_147.8667_degE:
     latitude (deg): -43.1833
     longitude (deg): 147.8667
     locality: Remarkable Cave Beach, 4.5 km directly S of Port Arthur.
-    collector: Davies, F.E.
+    recorded by: Davies, F.E.
   site_at_-43.1969_degS_and_146.7669_degE:
     latitude (deg): -43.1969
     longitude (deg): 146.7669
     locality: Ca. 2.5 km down road from Hartz Mountain Peak Trail carpark, Hartz Mountain
       National Park.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-43.2253_degS_and_146.7744_degE:
     latitude (deg): -43.2253
     longitude (deg): 146.7744
     locality: Ca 1 km from carpark along walking track to Hartz Mountain, Hartz Mountain
       National Park.
-    collector: Marges, J.D.
+    recorded by: Marges, J.D.
   site_at_-43.2833_degS_and_146.6167_degE:
     latitude (deg): -43.2833
     longitude (deg): 146.6167
     locality: Foot-track to Lake Sydney, above Pine Lake.
-    collector: Burns, R.
+    recorded by: Burns, R.
   site_at_-53.0083_degS_and_73.4125_degE:
     latitude (deg): -53.0083
     longitude (deg): 73.4125
     locality: Azorella Peninsula.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-53.0167_degS_and_73.4083_degE:
     latitude (deg): -53.0167
     longitude (deg): 73.4083
     locality: Walrus Beach, Azorella Peninsula.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-53.1028_degS_and_73.7139_degE:
     latitude (deg): -53.1028
     longitude (deg): 73.7139
     locality: W side of Stephenson Lagoon, c. 2 km NW of Spit Bay Station.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-53.1417_degS_and_73.7194_degE:
     latitude (deg): -53.1417
     longitude (deg): 73.7194
     locality: Spit Bay, Azorella Peninsula.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-54.5008_degS_and_158.8828_degE:
     latitude (deg): -54.5008
     longitude (deg): 158.8828
     locality: Handspike Point.
-    collector: Jackson, J.
+    recorded by: Jackson, J.
   site_at_-54.5167_degS_and_158.9167_degE:
     latitude (deg): -54.5167
     longitude (deg): 158.9167
     locality: Nuggets Rookery
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-54.5333_degS_and_158.9333_degE:
     latitude (deg): -54.5333
     longitude (deg): 158.9333
     locality: Mt. Elder
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-54.55_degS_and_158.8667_degE:
     latitude (deg): -54.55
     longitude (deg): 158.8667
     locality: West of Bauer Creek
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-54.5722_degS_and_158.8806_degE:
     latitude (deg): -54.5722
     longitude (deg): 158.8806
     locality: c. 500 m S of Bauer Bay.
-    collector: Jackson, J.
+    recorded by: Jackson, J.
   site_at_-54.6167_degS_and_158.8833_degE:
     latitude (deg): -54.6167
     longitude (deg): 158.8833
     locality: Green Gorge Basin
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-54.6475_degS_and_158.82_degE:
     latitude (deg): -54.6475
     longitude (deg): 158.82
     locality: Davis Pt.
-    collector: Donaldson, S.
+    recorded by: Donaldson, S.
   site_at_-31.05_degS_and_121.05_degE:
     latitude (deg): -31.05
     longitude (deg): 121.05
@@ -13217,12 +13218,12 @@ sites:
     longitude (deg): .na.real
     locality: The Needles, South-west Tasmania. Grid ref 526880E, 4555430N. Wedge
       1100,000 Map Sheet.
-    collector: Edwards, D.
+    recorded by: Edwards, D.
   Uluru - Kata Tjuta National Park.:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: Uluru - Kata Tjuta National Park.
-    collector: Bennison, K.
+    recorded by: Bennison, K.
   Wild seed donated by CSIRO ex Dr Andrew Youngs research; collected in the ACT between:
     latitude (deg): .na.real
     longitude (deg): .na.real
@@ -13230,12 +13231,12 @@ sites:
       the ACT between 1994 and 1997 by CSIRO and New South Wales National Parks. Seed
       packet numbers/codes refer to different collection sites but no guide/interpretation
       has been provided.
-    collector: ANBG Nursery
+    recorded by: ANBG Nursery
   without locality:
     latitude (deg): .na.real
     longitude (deg): .na.real
     locality: without locality
-    collector: Unspecified collector of live material
+    recorded by: Unspecified collector of live material
 contexts: .na
 config:
   data_is_long_format: yes
@@ -13930,7 +13931,7 @@ substitutions:
   find: cilliate
   replace: ciliate
 - trait_name: germination_treatment
-  find: "soak the seed for a time period."
+  find: soak the seed for a time period.
   replace: imbibed
 taxonomic_updates:
 - find: Luzula acutifolia var. acutifolia
@@ -13995,4 +13996,3 @@ exclude_observations:
   find: Pittosporum obcordatum
   reason: non-native - NZ species (E Wenk, 2020.06.18)
 questions: .na
-

--- a/data/Ahrens_2019/metadata.yml
+++ b/data/Ahrens_2019/metadata.yml
@@ -11,7 +11,7 @@ source:
       differentially affected by climate change
     volume: 10
     number: 1
-    pages: '232-248'
+    pages: 232-248
     doi: 10.1002/ece3.5890
 people:
 - name: Collin W. Ahrens
@@ -70,75 +70,75 @@ sites:
   BOO:
     latitude (deg): -34.638944
     longitude (deg): 116.123806
-    max temp (C): 25.6
-    MAP (mm): 1159.0
-    aridity index: 1.05
+    temperature, max (C): 25.6
+    precipitation, MAP (mm): 1159.0
+    aridity index (MAP/PET): 1.05
   BRA:
     latitude (deg): -33.916389
     longitude (deg): 115.083278
-    max temp (C): 26.1
-    MAP (mm): 1072.0
-    aridity index: 0.96
+    temperature, max (C): 26.1
+    precipitation, MAP (mm): 1072.0
+    aridity index (MAP/PET): 0.96
   CAR:
     latitude (deg): -34.419639
     longitude (deg): 115.821306
-    max temp (C): 25.9
-    MAP (mm): 1106.0
-    aridity index: 0.98
+    temperature, max (C): 25.9
+    precipitation, MAP (mm): 1106.0
+    aridity index (MAP/PET): 0.98
   CHID:
     latitude (deg): -31.8682
     longitude (deg): 116.222973
-    max temp (C): 32.2
-    MAP (mm): 900.0
-    aridity index: 0.65
+    temperature, max (C): 32.2
+    precipitation, MAP (mm): 900.0
+    aridity index (MAP/PET): 0.65
   CRI:
     latitude (deg): -34.6015
     longitude (deg): 118.742665
-    max temp (C): 26.2
-    MAP (mm): 579.0
-    aridity index: 0.48
+    temperature, max (C): 26.2
+    precipitation, MAP (mm): 579.0
+    aridity index (MAP/PET): 0.48
   HRI:
     latitude (deg): -30.3114
     longitude (deg): 115.201584
-    max temp (C): 31.7
-    MAP (mm): 563.0
-    aridity index: 0.39
+    temperature, max (C): 31.7
+    precipitation, MAP (mm): 563.0
+    aridity index (MAP/PET): 0.39
   KIN:
     latitude (deg): -34.081167
     longitude (deg): 116.330444
-    max temp (C): 27.7
-    MAP (mm): 820.0
-    aridity index: 0.67
+    temperature, max (C): 27.7
+    precipitation, MAP (mm): 820.0
+    aridity index (MAP/PET): 0.67
   LUP:
     latitude (deg): -32.520667
     longitude (deg): 116.499
-    max temp (C): 31.6
-    MAP (mm): 635.0
-    aridity index: 0.45
+    temperature, max (C): 31.6
+    precipitation, MAP (mm): 635.0
+    aridity index (MAP/PET): 0.45
   MOG:
     latitude (deg): -31.0986
     longitude (deg): 116.0508938
-    max temp (C): 33.3
-    MAP (mm): 579.0
-    aridity index: 0.39
+    temperature, max (C): 33.3
+    precipitation, MAP (mm): 579.0
+    aridity index (MAP/PET): 0.39
   PEE:
     latitude (deg): -32.684667
     longitude (deg): 115.742667
-    max temp (C): 30.4
-    MAP (mm): 885.0
-    aridity index: 0.67
+    temperature, max (C): 30.4
+    precipitation, MAP (mm): 885.0
+    aridity index (MAP/PET): 0.67
   PLA:
     latitude (deg): -34.653417
     longitude (deg): 117.499083
-    max temp (C): 26.7
-    MAP (mm): 733.0
-    aridity index: 0.63
+    temperature, max (C): 26.7
+    precipitation, MAP (mm): 733.0
+    aridity index (MAP/PET): 0.63
   SER:
     latitude (deg): -32.352694
     longitude (deg): 116.076472
-    max temp (C): 30.5
-    MAP (mm): 1173.0
-    aridity index: 0.89
+    temperature, max (C): 30.5
+    precipitation, MAP (mm): 1173.0
+    aridity index (MAP/PET): 0.89
 contexts: .na
 config:
   data_is_long_format: no
@@ -263,4 +263,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Angevin_2011/metadata.yml
+++ b/data/Angevin_2011/metadata.yml
@@ -175,4 +175,3 @@ taxonomic_updates:
   reason: Align to current genus (E. Wenk, 2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Apgaua_2017/metadata.yml
+++ b/data/Apgaua_2017/metadata.yml
@@ -78,9 +78,9 @@ sites:
     longitude (deg): 145.4444444
     description: lowland tropical rainforest, locally known as 'complex mesophyll
       vine forest'
-    MAT (C): 24.4
-    MAP (mm): 4900
-    soils: high fertility soils developed over metamorphic and granitic colluvium
+    temperature, MAT (C): 24.4
+    precipitation, MAP (mm): 4900
+    soil type: high fertility soils developed over metamorphic and granitic colluvium
 contexts:
   Maturephase tree:
     type: field
@@ -419,4 +419,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2021-02-15)
 exclude_observations: .na
 questions: .na
-

--- a/data/Atkinson_2020/metadata.yml
+++ b/data/Atkinson_2020/metadata.yml
@@ -27,182 +27,182 @@ sites:
   site_at_ 41.2087822 _deg_S_and_ 146.7094075 _deg_E:
     latitude (deg): -41.2087822
     longitude (deg): 146.7094075
-    region: North Dazzler
+    locality: North Dazzler
     population: 8.0
   site_at_ 41.2435589 _deg_S_and_ 146.7305208 _deg_E:
     latitude (deg): -41.2435589
     longitude (deg): 146.7305208
-    region: South Dazzler
+    locality: South Dazzler
     population: 9.0
   site_at_ 41.2576111 _deg_S_and_ 148.0504711 _deg_E:
     latitude (deg): -41.2576111
     longitude (deg): 148.0504711
-    region: Goulds Country
+    locality: Goulds Country
     population: 14.0
   site_at_ 41.2711881 _deg_S_and_ 147.9701228 _deg_E:
     latitude (deg): -41.2711881
     longitude (deg): 147.9701228
-    region: Pyengana
+    locality: Pyengana
     population: 13.0
   site_at_ 41.7031675 _deg_S_and_ 146.7199567 _deg_E:
     latitude (deg): -41.7031675
     longitude (deg): 146.7199567
-    region: Quamby Bluff
+    locality: Quamby Bluff
     population: 18.0
   site_at_ 41.7101675 _deg_S_and_ 146.7280281 _deg_E:
     latitude (deg): -41.7101675
     longitude (deg): 146.7280281
-    region: Projection Bluff
+    locality: Projection Bluff
     population: 15.0
   site_at_ 41.8927231 _deg_S_and_ 146.6551211 _deg_E:
     latitude (deg): -41.8927231
     longitude (deg): 146.6551211
-    region: Liawenee
+    locality: Liawenee
     population: 17.0
   site_at_ 41.9791114 _deg_S_and_ 146.6816817 _deg_E:
     latitude (deg): -41.9791114
     longitude (deg): 146.6816817
-    region: Miena
+    locality: Miena
     population: 16.0
   site_at_ 42.1829828 _deg_S_and_ 148.3237603 _deg_E:
     latitude (deg): -42.1829828
     longitude (deg): 148.3237603
-    region: Freycinet Peninsula
+    locality: Freycinet Peninsula
     population: 4.0
   site_at_ 42.6095028 _deg_S_and_ 147.8817661 _deg_E:
     latitude (deg): -42.6095028
     longitude (deg): 147.8817661
-    region: Three Thumbs lookout
+    locality: Three Thumbs lookout
     population: 3.0
   site_at_ 42.8898689 _deg_S_and_ 147.2358006 _deg_E:
     latitude (deg): -42.8898689
     longitude (deg): 147.2358006
-    region: kunanyi/Mt Wellington Chalet
+    locality: kunanyi/Mt Wellington Chalet
     population: 11.0
   site_at_ 42.9034225 _deg_S_and_ 147.2903625 _deg_E:
     latitude (deg): -42.9034225
     longitude (deg): 147.2903625
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9034589 _deg_S_and_ 147.29024 _deg_E:
     latitude (deg): -42.9034589
     longitude (deg): 147.29024
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9034672 _deg_S_and_ 147.2904361 _deg_E:
     latitude (deg): -42.9034672
     longitude (deg): 147.2904361
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9035581 _deg_S_and_ 147.2901547 _deg_E:
     latitude (deg): -42.9035581
     longitude (deg): 147.2901547
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9036108 _deg_S_and_ 147.290645 _deg_E:
     latitude (deg): -42.9036108
     longitude (deg): 147.290645
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9037728 _deg_S_and_ 147.2907314 _deg_E:
     latitude (deg): -42.9037728
     longitude (deg): 147.2907314
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.903945 _deg_S_and_ 147.2902669 _deg_E:
     latitude (deg): -42.903945
     longitude (deg): 147.2902669
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9040339 _deg_S_and_ 147.2907328 _deg_E:
     latitude (deg): -42.9040339
     longitude (deg): 147.2907328
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9040344 _deg_S_and_ 147.2904633 _deg_E:
     latitude (deg): -42.9040344
     longitude (deg): 147.2904633
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9040522 _deg_S_and_ 147.2905981 _deg_E:
     latitude (deg): -42.9040522
     longitude (deg): 147.2905981
-    region: Hobart
+    locality: Hobart
     population: 2.0
   site_at_ 42.9153761 _deg_S_and_ 147.3161353 _deg_E:
     latitude (deg): -42.9153761
     longitude (deg): 147.3161353
-    region: Mt Nelson
+    locality: Mt Nelson
     population: 10.0
   site_at_ 42.9484753 _deg_S_and_ 147.8661669 _deg_E:
     latitude (deg): -42.9484753
     longitude (deg): 147.8661669
-    region: Murdunna
+    locality: Murdunna
     population: 5.0
   site_at_ 43.0314447 _deg_S_and_ 147.9174019 _deg_E:
     latitude (deg): -43.0314447
     longitude (deg): 147.9174019
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0315825 _deg_S_and_ 147.9170603 _deg_E:
     latitude (deg): -43.0315825
     longitude (deg): 147.9170603
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0316636 _deg_S_and_ 147.9181786 _deg_E:
     latitude (deg): -43.0316636
     longitude (deg): 147.9181786
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0316822 _deg_S_and_ 147.9169636 _deg_E:
     latitude (deg): -43.0316822
     longitude (deg): 147.9169636
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0317403 _deg_S_and_ 147.9175906 _deg_E:
     latitude (deg): -43.0317403
     longitude (deg): 147.9175906
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0318514 _deg_S_and_ 147.9171992 _deg_E:
     latitude (deg): -43.0318514
     longitude (deg): 147.9171992
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0319303 _deg_S_and_ 147.9174706 _deg_E:
     latitude (deg): -43.0319303
     longitude (deg): 147.9174706
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0319861 _deg_S_and_ 147.9172503 _deg_E:
     latitude (deg): -43.0319861
     longitude (deg): 147.9172503
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0320092 _deg_S_and_ 147.9177539 _deg_E:
     latitude (deg): -43.0320092
     longitude (deg): 147.9177539
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0320183 _deg_S_and_ 147.9177172 _deg_E:
     latitude (deg): -43.0320183
     longitude (deg): 147.9177172
-    region: Tasman Peninsula
+    locality: Tasman Peninsula
     population: 1.0
   site_at_ 43.0445911 _deg_S_and_ 147.7506856 _deg_E:
     latitude (deg): -43.0445911
     longitude (deg): 147.7506856
-    region: Prices Bay
+    locality: Prices Bay
     population: 7.0
   site_at_ 43.0578456 _deg_S_and_ 147.947415 _deg_E:
     latitude (deg): -43.0578456
     longitude (deg): 147.947415
-    region: Waterfall Bay
+    locality: Waterfall Bay
     population: 6.0
   site_at_ 43.4658894 _deg_S_and_ 147.1495739 _deg_E:
     latitude (deg): -43.4658894
     longitude (deg): 147.1495739
-    region: Bruny Island
+    locality: Bruny Island
     population: 12.0
 contexts: .na
 config:
@@ -242,4 +242,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Blackman_2010/metadata.yml
+++ b/data/Blackman_2010/metadata.yml
@@ -155,4 +155,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -78,88 +78,88 @@ sites:
   Alice Mulga:
     latitude (deg): -22.3468
     longitude (deg): 133.3276
-    description: Alice Mulga SuperSite, Mulga, Woodforde River, Ti Tree sites
-    altitude (m): 606.0
+    locality: Alice Mulga SuperSite, Mulga, Woodforde River, Ti Tree sites
+    elevation (m): 606.0
     biome: Topical savanna
-    vegetation: low, open, arid woodland
+    description: low, open, arid woodland
     leaf area index: 0.34
-    canopy height (m): 6.5
+    crown height, max (m): 6.5
     soil type: Eutrophic, red Kandosol
-    MAT (): 22.5
-    MAP (mm): 357.0
+    temperature, MAT (C): 22.5
+    precipitation, MAP (mm): 357.0
   Calperum mallee:
     latitude (deg): -34.003
     longitude (deg): 140.58
-    description: Calperum Mallee SuperSite, Mallee Plot
-    altitude (m): 64.0
+    locality: Calperum Mallee SuperSite, Mallee Plot
+    elevation (m): 64.0
     biome: Mediterranean woodland
-    vegetation: sparse, mallee woodland
+    description: sparse, mallee woodland
     leaf area index: 0.88
-    canopy height (m): 3.0
+    crown height, max (m): 3.0
     soil type: Tenosol (Calcisol)
-    MAT (): 17.4
-    MAP (mm): 268.0
+    temperature, MAT (C): 17.4
+    precipitation, MAP (mm): 268.0
   Cumberland Plain:
     latitude (deg): -33.619
     longitude (deg): 150.738
-    description: Cumberland Plain SuperSite, EucFACE site
-    altitude (m): 26.0
+    locality: Cumberland Plain SuperSite, EucFACE site
+    elevation (m): 26.0
     biome: Temperate forest
-    vegetation: dry woodland
+    description: dry woodland
     leaf area index: 1.2
-    canopy height (m): 23.0
+    crown height, max (m): 23.0
     soil type: Grey podsol
-    MAT (): 17.7
-    MAP (mm): 788.0
+    temperature, MAT (C): 17.7
+    precipitation, MAP (mm): 788.0
   FNQ, Daintree:
     latitude (deg): -16.103
     longitude (deg): 145.447
-    description: Far North Queensland Rainforest SuperSite, Daintree Rainforest Observatory,
+    locality: Far North Queensland Rainforest SuperSite, Daintree Rainforest Observatory,
       Cape Tribulation
-    altitude (m): 66.0
+    elevation (m): 66.0
     biome: tropical moist forest
-    vegetation: closed forest
+    description: closed forest
     leaf area index: 2.65
-    canopy height (m): 25.0
+    crown height, max (m): 25.0
     soil type: Acidic, dystrophic, brown, Dermosol
-    MAT (): 24.3
-    MAP (mm): 3671.0
+    temperature, MAT (C): 24.3
+    precipitation, MAP (mm): 3671.0
   FNQ, Robson:
     latitude (deg): -17.117
     longitude (deg): 145.63
-    description: Far North Queensland Rainforest SuperSite, Robson Creek
-    altitude (m): 710.0
+    locality: Far North Queensland Rainforest SuperSite, Robson Creek
+    elevation (m): 710.0
     biome: tropical moist forest
-    vegetation: closed forest
+    description: closed forest
     leaf area index: 3.19
-    canopy height (m): 28.0
+    crown height, max (m): 28.0
     soil type: Acidic, dystrophic, brown, Dermosol
-    MAT (): 20.4
-    MAP (mm): 1813.0
+    temperature, MAT (C): 20.4
+    precipitation, MAP (mm): 1813.0
   Great Western Woodlands:
     latitude (deg): -30.191
     longitude (deg): 120.654
-    description: Great Western Woodlands SuperSite, Salmon gum, Gimlet plots
-    altitude (m): 449.0
+    locality: Great Western Woodlands SuperSite, Salmon gum, Gimlet plots
+    elevation (m): 449.0
     biome: Mediterranean woodland
-    vegetation: Semi-arid woodland
+    description: Semi-arid woodland
     leaf area index: 1.07
-    canopy height (m): 18.0
+    crown height, max (m): 18.0
     soil type: Kandosol
-    MAT (): 18.9
-    MAP (mm): 291.0
+    temperature, MAT (C): 18.9
+    precipitation, MAP (mm): 291.0
   Warra:
     latitude (deg): -43.095
     longitude (deg): 146.65
-    description: Warra Tall Eucalypt SuperSite
-    altitude (m): 111.0
+    locality: Warra Tall Eucalypt SuperSite
+    elevation (m): 111.0
     biome: Temperate forest
-    vegetation: tall, wet forest
+    description: tall, wet forest
     leaf area index: 5.84
-    canopy height (m): 55.0
+    crown height, max (m): 55.0
     soil type: Kurosolic, redoxic Hydrosol
-    MAT (): 9.9
-    MAP (mm): 1591.0
+    temperature, MAT (C): 9.9
+    precipitation, MAP (mm): 1591.0
 contexts:
   Dry:
     type: field_harsh
@@ -614,4 +614,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Bragg_2002/metadata.yml
+++ b/data/Bragg_2002/metadata.yml
@@ -37,7 +37,7 @@ sites:
   Ku-ring-gai Chase National Park:
     latitude (deg): -33.6938889
     longitude (deg): 151.1430556
-    soil_total_P (mgP/kg): 94
+    soil P, total (mg/kg): 94
     description: The vegetation type was fire-prone, low, open sclerophyll woodland,
       dominated by woody shrub species, with emergent eucalypt trees up to 9 m tall.
       The site was last burnt in 1990. The geology of the site is Hawkesbury sandstone,
@@ -73,4 +73,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Briggs_2010/metadata.yml
+++ b/data/Briggs_2010/metadata.yml
@@ -40,7 +40,7 @@ sites:
   Terrick Terrick National Park:
     latitude (deg): -36.1738
     longitude (deg): 144.227
-    rainfall (mm): 400
+    precipitation, MAP (mm): 400
     description: Soil samples for this experiment were collected from Terrick Terrick
       National Park (TTNP), 225 km northwest of Melbourne, Victoria, Australia. TTNP
       is situated within the Patho Plains, a sub-section of the Victorian Northern
@@ -74,4 +74,3 @@ taxonomic_updates:
   reason: Align to current genus (E. Wenk, 2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Buckton_2019/metadata.yml
+++ b/data/Buckton_2019/metadata.yml
@@ -75,7 +75,7 @@ sites:
     latitude (deg): -16.1
     longitude (deg): 145.4
     description: lowland tropical rainforest
-    MAP (mm): 4207
+    precipitation, MAP (mm): 4207
 contexts:
   Sun:
     type: field
@@ -603,4 +603,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Burrows_2001/metadata.yml
+++ b/data/Burrows_2001/metadata.yml
@@ -36,7 +36,7 @@ sites:
   The Rock:
     latitude (deg): -35.2666667
     longitude (deg): 147.0666667
-    rainfall (mm): 585
+    precipitation, MAP (mm): 585
     description: The Rock Nature Reserve (lat. 357169S, long. 1477049E), South Western
       Slopes, New South Wales, is a small (341 ha) island of remnant vegetation surrounded
       by an extensively modified agricultural landscape. A north-south ridge, the
@@ -153,4 +153,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: detailed anatomy of photosynthetic organs.
-

--- a/data/Caldwell_2016/metadata.yml
+++ b/data/Caldwell_2016/metadata.yml
@@ -71,17 +71,17 @@ sites:
     longitude (deg): 145.8
     description: drier north-facing site at Bunyip State Park
     elevation (m): 170-220
-    soil: sandy clay loam over Devonian granite
-    mean summer maximum temperature (C): 23-26
-    mean winter maximum temperature (C): 4-5
+    soil type: sandy clay loam over Devonian granite
+    temperature, mean summer max (C): 23-26
+    temperature, mean winter max (C): 4-5
   Wet:
     latitude (deg): -37.983
     longitude (deg): 145.8
     description: damp south-facing gully at Bunyip State Park
     elevation (m): 170-220
-    soil: sandy clay loam over Devonian granite
-    mean summer maximum temperature (C): 23-26
-    mean winter maximum temperature (C): 4-5
+    soil type: sandy clay loam over Devonian granite
+    temperature, mean summer max (C): 23-26
+    temperature, mean winter max (C): 4-5
 contexts: .na
 config:
   data_is_long_format: no
@@ -164,4 +164,3 @@ exclude_observations: .na
 questions:
   additional_traits: leaf mechanical traits, additional chemical data, to be provided
     in the future by the author (after additional publications are complete)
-

--- a/data/Catford_2014/metadata.yml
+++ b/data/Catford_2014/metadata.yml
@@ -471,4 +471,3 @@ exclude_observations:
 questions:
   additional_traits: germination conditions (wet vs. dry), native  vs. introduced,
     and detailed information on exact amounts of moisture species require/tolerate
-

--- a/data/Cernusak_2006/metadata.yml
+++ b/data/Cernusak_2006/metadata.yml
@@ -50,10 +50,10 @@ sites:
     latitude (deg): -12.495
     longitude (deg): 131.15
     description: open-forest savanna, with an overstory dominated by evergreen eucalypts
-    elevation: 38
-    min MAT (C): 19.3 - 25.3
-    max MAT (C): 30.5 - 33.2
-    MAP (mm): 1700
+    elevation (m): 38
+    temperature, min MAT (C): 19.3 - 25.3
+    temperature, max MAT (C): 30.5 - 33.2
+    precipitation, MAP (mm): 1700
 contexts:
   burn tree sampled in January:
     burn_status: burn
@@ -333,4 +333,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -46,43 +46,43 @@ sites:
     latitude (deg): -13.077
     longitude (deg): 131.118
     elevation (m): 75.0
-    MAP (mm): 1532.0
-    MAT (C): 27.0
+    precipitation, MAP (mm): 1532.0
+    temperature, MAT (C): 27.0
     description: eucalypt-dominated savannas
   Boulia:
     latitude (deg): -22.994
     longitude (deg): 139.945
     elevation (m): 151.0
-    MAP (mm): 291.0
-    MAT (C): 24.9
+    precipitation, MAP (mm): 291.0
+    temperature, MAT (C): 24.9
     description: Acacia-dominated shrublands
   Daly River:
     latitude (deg): -14.159
     longitude (deg): 131.388
     elevation (m): 73.0
-    MAP (mm): 1170.0
-    MAT (C): 27.2
+    precipitation, MAP (mm): 1170.0
+    temperature, MAT (C): 27.2
     description: eucalypt-dominated savannas
   Dry Creek:
     latitude (deg): -15.259
     longitude (deg): 132.371
     elevation (m): 167.0
-    MAP (mm): 958.0
-    MAT (C): 27.1
+    precipitation, MAP (mm): 958.0
+    temperature, MAT (C): 27.1
     description: eucalypt-dominated savannas
   Howard Springs:
     latitude (deg): -12.485
     longitude (deg): 131.146
     elevation (m): 37.0
-    MAP (mm): 1714.0
-    MAT (C): 27.8
+    precipitation, MAP (mm): 1714.0
+    temperature, MAT (C): 27.8
     description: eucalypt-dominated savannas
   Sturt Plains:
     latitude (deg): -17.133
     longitude (deg): 133.329
     elevation (m): 228.0
-    MAP (mm): 672.0
-    MAT (C): 26.8
+    precipitation, MAP (mm): 672.0
+    temperature, MAT (C): 26.8
     description: low woodland dominated by Acacia cowleana, Eucalyptus dichromophloia,
       and Lysophyllum cunninghamii; transition from eucalypt-dominated savannas to
       acacia-dominated shrublands
@@ -645,4 +645,3 @@ taxonomic_updates:
   reason: Change spelling to Align to APC accepted name (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Choat_2006/metadata.yml
+++ b/data/Choat_2006/metadata.yml
@@ -64,22 +64,25 @@ sites:
     longitude (deg): 146.764445
     description: region classified as semi-arid tropics and does not share the predictable
       monsoonal climate with far northern Australia
-    MAP (mm): 1100
-    rainfall notes: 80% of rainfall usually occurs during the summer wet season (December-March)
+    precipitation, MAP (mm): 1100
+    precipitation, description: 80% of rainfall usually occurs during the summer wet season
+      (December-March)
   Many Peaks site 2:
     latitude (deg): -19.19422
     longitude (deg): 146.764445
     description: region classified as semi-arid tropics and does not share the predictable
       monsoonal climate with far northern Australia
-    MAP (mm): 1100
-    rainfall notes: 80% of rainfall usually occurs during the summer wet season (December-March)
+    precipitation, MAP (mm): 1100
+    precipitation, description: 80% of rainfall usually occurs during the summer wet season
+      (December-March)
   Many Peaks:
     latitude (deg): -19.19422
     longitude (deg): 146.764445
     description: region classified as semi-arid tropics and does not share the predictable
       monsoonal climate with far northern Australia
-    MAP (mm): 1100
-    rainfall notes: 80% of rainfall usually occurs during the summer wet season (December-March)
+    precipitation, MAP (mm): 1100
+    precipitation, description: 80% of rainfall usually occurs during the summer wet season
+      (December-March)
 contexts:
   measurements made in the Dry season at 05:00:00:
     Time: '05:00:00'
@@ -642,4 +645,3 @@ taxonomic_updates:
   reason: Alignment with existing species identified by TaxonStand (2020-06-04)
 exclude_observations: .na
 questions: .na
-

--- a/data/Choat_2012/metadata.yml
+++ b/data/Choat_2012/metadata.yml
@@ -74,7 +74,7 @@ source:
       species'
     volume: '54'
     number: '2'
-    pages: '173--179'
+    pages: 173--179
     doi: 10.1071/bt05081
   secondary_06:
     key: Hacke_2007
@@ -181,45 +181,45 @@ sites:
     longitude (deg): 117.8667
     elevation (m): 300.0
     description: woodland/shrubland
-    MAT (C): 17.15
-    MAP (mm): 375.0
-    mean precipitation of the driest quarter (mm): 41.0
-    PET (mm): 1434.0
-    AI (aridity index): 0.2615
-    Reference: Mitchell et al. unpublished
+    temperature, MAT (C): 17.15
+    precipitation, MAP (mm): 375.0
+    precipitation, driest quarter mean (mm): 41.0
+    PET (mm/yr): 1434.0
+    aridity index (MAP/PET): 0.2615
+    reference: Mitchell et al. unpublished
   Hobart:
     latitude (deg): -42.905
     longitude (deg): 147.3247
     elevation (m): 60.0
     description: temperate seasonal forest
-    MAT (C): 11.11
-    MAP (mm): 671.0
-    mean precipitation of the driest quarter (mm): 135.0
-    PET (mm): 913.0
-    AI (aridity index): 0.7349
-    Reference: Cochard et al. unpublished
+    temperature, MAT (C): 11.11
+    precipitation, MAP (mm): 671.0
+    precipitation, driest quarter mean (mm): 135.0
+    PET (mm/yr): 913.0
+    aridity index (MAP/PET): 0.7349
+    reference: Cochard et al. unpublished
   Julimar forest, Western Australia:
     latitude (deg): -31.4
     longitude (deg): 116.3167
     elevation (m): 300.0
     description: woodland/shrubland
-    MAT (C): 17.7
-    MAP (mm): 700.0
-    mean precipitation of the driest quarter (mm): 40.0
-    PET (mm): 1465.0
-    AI (aridity index): 0.4778
-    Reference: Poot P, Veneklaas EJ. unpublished
+    temperature, MAT (C): 17.7
+    precipitation, MAP (mm): 700.0
+    precipitation, driest quarter mean (mm): 40.0
+    PET (mm/yr): 1465.0
+    aridity index (MAP/PET): 0.4778
+    reference: Poot P, Veneklaas EJ. unpublished
   Macquarie U:
     latitude (deg): -33.7712
     longitude (deg): 151.1132
     elevation (m): 50.0
     description: temperate rainforest
-    MAT (C): 17.0
-    MAP (mm): 1140.0
-    mean precipitation of the driest quarter (mm): 187.0
-    PET (mm): 1196.0
-    AI (aridity index): 0.9532
-    Reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
+    temperature, MAT (C): 17.0
+    precipitation, MAP (mm): 1140.0
+    precipitation, driest quarter mean (mm): 187.0
+    PET (mm/yr): 1196.0
+    aridity index (MAP/PET): 0.9532
+    reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
       Water transport in vesselless angiosperms: conducting efficiency and cavitation
       safety. International Journal of Plant Sciences 168: 1113-1126.'
   Many Peaks Range, Queensland:
@@ -227,12 +227,12 @@ sites:
     longitude (deg): 145.75
     elevation (m): 60.0
     description: tropical seasonal forest
-    MAT (C): 18.5
-    MAP (mm): 1132.0
-    mean precipitation of the driest quarter (mm): 26.0
-    PET (mm): 1646.0
-    AI (aridity index): 0.6877
-    Reference: 'Choat B, Ball MC,  Luly JG, Holtum JAM. 2005. Hydraulic architecture
+    temperature, MAT (C): 18.5
+    precipitation, MAP (mm): 1132.0
+    precipitation, driest quarter mean (mm): 26.0
+    PET (mm/yr): 1646.0
+    aridity index (MAP/PET): 0.6877
+    reference: 'Choat B, Ball MC,  Luly JG, Holtum JAM. 2005. Hydraulic architecture
       of deciduous and evergreen dry rainforest tree species from north-eastern Australia.
       Trees - Structure and Function 19: 305-311.'
   New South Wales:
@@ -240,12 +240,12 @@ sites:
     longitude (deg): 152.124
     elevation (m): 1150.0
     description: temperate seasonal forest
-    MAT (C): 12.38
-    MAP (mm): 1134.0
-    mean precipitation of the driest quarter (mm): 182.0
-    PET (mm): 1193.0
-    AI (aridity index): 0.9505
-    Reference: 'Sperry JS, Hacke UG, Field TS, Sano Y, Sikkema EH. 2007. Hydraulic
+    temperature, MAT (C): 12.38
+    precipitation, MAP (mm): 1134.0
+    precipitation, driest quarter mean (mm): 182.0
+    PET (mm/yr): 1193.0
+    aridity index (MAP/PET): 0.9505
+    reference: 'Sperry JS, Hacke UG, Field TS, Sano Y, Sikkema EH. 2007. Hydraulic
       consequences of vessel evolution in angiosperms. International Journal of Plant
       Sciences 168: 1127-1139.'
   North Queensland:
@@ -253,12 +253,12 @@ sites:
     longitude (deg): 145.2657
     elevation (m): 1080.0
     description: tropical rainforest
-    MAT (C): 27.0
-    MAP (mm): 3100.0
-    mean precipitation of the driest quarter (mm): 83.0
-    PET (mm): 1463.0
-    AI (aridity index): 2.1189
-    Reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
+    temperature, MAT (C): 27.0
+    precipitation, MAP (mm): 3100.0
+    precipitation, driest quarter mean (mm): 83.0
+    PET (mm/yr): 1463.0
+    aridity index (MAP/PET): 2.1189
+    reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
       Water transport in vesselless angiosperms: conducting efficiency and cavitation
       safety. International Journal of Plant Sciences 168: 1113-1126.'
   Northern New SW:
@@ -266,12 +266,12 @@ sites:
     longitude (deg): 152.1168
     elevation (m): 1050.0
     description: temperate rainforest
-    MAT (C): 20.0
-    MAP (mm): 1500.0
-    mean precipitation of the driest quarter (mm): 182.0
-    PET (mm): 1198.0
-    AI (aridity index): 1.2521
-    Reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
+    temperature, MAT (C): 20.0
+    precipitation, MAP (mm): 1500.0
+    precipitation, driest quarter mean (mm): 182.0
+    PET (mm/yr): 1198.0
+    aridity index (MAP/PET): 1.2521
+    reference: 'Hacke UG, Sperry JS, Field TS, Sano Y, Sikkema H, Pittermann J. 2007.
       Water transport in vesselless angiosperms: conducting efficiency and cavitation
       safety. International Journal of Plant Sciences 168: 1113-1126.'
   Pemberton-Manjimup, Western Australia:
@@ -279,24 +279,24 @@ sites:
     longitude (deg): 116.0
     elevation (m): 200.0
     description: temperate seasonal forest
-    MAT (C): 15.5
-    MAP (mm): 1200.0
-    mean precipitation of the driest quarter (mm): 56.0
-    PET (mm): 1249.0
-    AI (aridity index): 0.9608
-    Reference: 'Burgess SSO, Dawson TE. 2006. Predicting the limits to tree height
+    temperature, MAT (C): 15.5
+    precipitation, MAP (mm): 1200.0
+    precipitation, driest quarter mean (mm): 56.0
+    PET (mm/yr): 1249.0
+    aridity index (MAP/PET): 0.9608
+    reference: 'Burgess SSO, Dawson TE. 2006. Predicting the limits to tree height
       using statistical regressions of leaf traits. New Phytologist 174: 626-636.'
   Queensland:
     latitude (deg): -16.8993
     longitude (deg): 145.7507
     elevation (m): 10.0
     description: tropical rainforest
-    MAT (C): 21.66
-    MAP (mm): 2241.0
-    mean precipitation of the driest quarter (mm): 107.0
-    PET (mm): 1491.0
-    AI (aridity index): 1.503
-    Reference: 'Sperry JS, Hacke UG, Field TS, Sano Y, Sikkema EH. 2007. Hydraulic
+    temperature, MAT (C): 21.66
+    precipitation, MAP (mm): 2241.0
+    precipitation, driest quarter mean (mm): 107.0
+    PET (mm/yr): 1491.0
+    aridity index (MAP/PET): 1.503
+    reference: 'Sperry JS, Hacke UG, Field TS, Sano Y, Sikkema EH. 2007. Hydraulic
       consequences of vessel evolution in angiosperms. International Journal of Plant
       Sciences 168: 1127-1139.'
   Ravenswood, Queensland:
@@ -304,12 +304,12 @@ sites:
     longitude (deg): 146.8833
     elevation (m): 20.0
     description: tropical seasonal forest
-    MAT (C): 20.87
-    MAP (mm): 684.0
-    mean precipitation of the driest quarter (mm): 33.0
-    PET (mm): 1664.0
-    AI (aridity index): 0.4111
-    Reference: 'Rice KJ, Matzner SL, Byer W, Brown JR. 2004. Patterns of tree dieback
+    temperature, MAT (C): 20.87
+    precipitation, MAP (mm): 684.0
+    precipitation, driest quarter mean (mm): 33.0
+    PET (mm/yr): 1664.0
+    aridity index (MAP/PET): 0.4111
+    reference: 'Rice KJ, Matzner SL, Byer W, Brown JR. 2004. Patterns of tree dieback
       in Queensland, Australia: the importance of drought stress and the role of resistance
       to cavitation. Oecologia 139: 190-198.'
   Swan Coastal Plain(Yalgorup N.P.), Western Australia:
@@ -317,24 +317,24 @@ sites:
     longitude (deg): 115.69
     elevation (m): 20.0
     description: woodland/shrubland
-    MAT (C): 15.2
-    MAP (mm): 875.0
-    mean precipitation of the driest quarter (mm): 38.0
-    PET (mm): 1333.0
-    AI (aridity index): 0.6564
-    Reference: Drake PL. 2007. Drought traits of Eucalyptus gomphocephala in Yalgorup
+    temperature, MAT (C): 15.2
+    precipitation, MAP (mm): 875.0
+    precipitation, driest quarter mean (mm): 38.0
+    PET (mm/yr): 1333.0
+    aridity index (MAP/PET): 0.6564
+    reference: Drake PL. 2007. Drought traits of Eucalyptus gomphocephala in Yalgorup
       National Park.  PhD Thesis, Edith Cowan University, Perth.
   Swan Coastal Plain, Western Australia:
     latitude (deg): -31.75
     longitude (deg): 115.95
     elevation (m): 20.0
     description: woodland/shrubland
-    MAT (C): 16.1
-    MAP (mm): 868.0
-    mean precipitation of the driest quarter (mm): 34.0
-    PET (mm): 1398.0
-    AI (aridity index): 0.6209
-    Reference: 'Froend RH, Drake PL. 2006.  Defining phreatophyte responses to reduced
+    temperature, MAT (C): 16.1
+    precipitation, MAP (mm): 868.0
+    precipitation, driest quarter mean (mm): 34.0
+    PET (mm/yr): 1398.0
+    aridity index (MAP/PET): 0.6209
+    reference: 'Froend RH, Drake PL. 2006.  Defining phreatophyte responses to reduced
       water availability: preliminary investigations on the use of xylem vulnerability
       in Banksia woodland species. Australian Journal of Botany 54: 173-179.'
   Tasmania:
@@ -342,24 +342,24 @@ sites:
     longitude (deg): 147.324
     elevation (m): 42.0
     description: woodland/shrubland
-    MAT (C): 11.11
-    MAP (mm): 671.0
-    mean precipitation of the driest quarter (mm): 135.0
-    PET (mm): 913.0
-    AI (aridity index): 0.7349
-    Reference: 'Brodribb TJ, Cochard H. 2009. Hydraulic failure defines the recovery
+    temperature, MAT (C): 11.11
+    precipitation, MAP (mm): 671.0
+    precipitation, driest quarter mean (mm): 135.0
+    PET (mm/yr): 913.0
+    aridity index (MAP/PET): 0.7349
+    reference: 'Brodribb TJ, Cochard H. 2009. Hydraulic failure defines the recovery
       and point of death in water-stressed conifers. Plant physiology 149: 575-84.'
   Western Australia:
     latitude (deg): -27.6547
     longitude (deg): 114.3199
     elevation (m): 168.0
     description: woodland/shrubland
-    MAT (C): 21.02
-    MAP (mm): 361.5
-    mean precipitation of the driest quarter (mm): 18.0
-    PET (mm): 1582.0
-    AI (aridity index): 0.2285
-    Reference: Brodribb unpublished
+    temperature, MAT (C): 21.02
+    precipitation, MAP (mm): 361.5
+    precipitation, driest quarter mean (mm): 18.0
+    PET (mm/yr): 1582.0
+    aridity index (MAP/PET): 0.2285
+    reference: Brodribb unpublished
 contexts: .na
 config:
   data_is_long_format: no
@@ -417,4 +417,3 @@ taxonomic_updates:
   reason: Synonym reported by TaxonStand (2020-06-04)
 exclude_observations: .na
 questions: .na
-

--- a/data/Crous_2019/metadata.yml
+++ b/data/Crous_2019/metadata.yml
@@ -40,12 +40,12 @@ sites:
     longitude (deg): 150.7333
     description: remnant patch of native Cumberland Plain woodland on an ancient alluvial
       floodplain in western Sydney
-    soil: loamy sand
-    pH: 5.2
-    total P (mg/kg): 76
-    MAT (C): 17
-    MAP (mm): 800
-    vegetation: dominated by Eucalyptus tereticornis in the overstory with a few scattered
+    soil type: loamy sand
+    soil pH (H2O): 5.2
+    soil P, total (mg/kg): 76
+    temperature, MAT (C): 17
+    precipitation, MAP (mm): 800
+    notes: dominated by Eucalyptus tereticornis in the overstory with a few scattered
       individuals of Eucalyptus amplifolia, while the understory is dominated by Microlaena
       stipoides (a C3 grass) and some shrubs
 contexts:
@@ -385,4 +385,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Cunningham_1999/metadata.yml
+++ b/data/Cunningham_1999/metadata.yml
@@ -61,155 +61,155 @@ sites:
     latitude (deg): -33.617
     longitude (deg): 150.715
     elevation (m): 15
-    MAP (mm): 778
-    soil P (ug/g): 148
+    precipitation, MAP (mm): 778
+    soil P, total (mg/kg): 148
     description: unknown
   Cunningham_Braidwood_600m:
     latitude (deg): -35.533
     longitude (deg): 149.933
     elevation (m): 600
-    MAP (mm): 1273
-    soil P (ug/g): 139
+    precipitation, MAP (mm): 1273
+    soil P, total (mg/kg): 139
     description: unknown
   Cunningham_Castlereagh_15m:
     latitude (deg): -33.683
     longitude (deg): 150.745
     elevation (m): 15
-    MAP (mm): 790
-    soil P (ug/g): 114
+    precipitation, MAP (mm): 790
+    soil P, total (mg/kg): 114
     description: unknown
   Cunningham_Copper Range_300m:
     latitude (deg): -30.852
     longitude (deg): 142.585
     elevation (m): 300
-    MAP (mm): 241
-    soil P (ug/g): 276
+    precipitation, MAP (mm): 241
+    soil P, total (mg/kg): 276
     description: unknown
   Cunningham_Hillston_125m:
     latitude (deg): -33.525
     longitude (deg): 145.571
     elevation (m): 125
-    MAP (mm): 358
-    soil P (ug/g): 218
+    precipitation, MAP (mm): 358
+    soil P, total (mg/kg): 218
     description: unknown
   Cunningham_Iluka_Beach_1m:
     latitude (deg): -35.127
     longitude (deg): 150.717
     elevation (m): 1
-    MAP (mm): 1323
-    soil P (ug/g): 1
+    precipitation, MAP (mm): 1323
+    soil P, total (mg/kg): 1
     description: unknown
   Cunningham_Knights Hill_665m:
     latitude (deg): -34.633
     longitude (deg): 150.7
     elevation (m): 665
-    MAP (mm): 2286
-    soil P (ug/g): 319
+    precipitation, MAP (mm): 2286
+    soil P, total (mg/kg): 319
     description: unknown
   Cunningham_KNP-Barrenjoey_33m:
     latitude (deg): -33.581
     longitude (deg): 151.325
     elevation (m): 33
-    MAP (mm): 1248
-    soil P (ug/g): 117
+    precipitation, MAP (mm): 1248
+    soil P, total (mg/kg): 117
     description: unknown
   Cunningham_KNP-Bobbin Head_115m:
     latitude (deg): -33.685
     longitude (deg): 151.182
     elevation (m): 115
-    MAP (mm): 1222
-    soil P (ug/g): 55
+    precipitation, MAP (mm): 1222
+    soil P, total (mg/kg): 55
     description: unknown
   Cunningham_KNP-Waratah_165m:
     latitude (deg): -33.641
     longitude (deg): 151.25
     elevation (m): 165
-    MAP (mm): 1258
-    soil P (ug/g): 66
+    precipitation, MAP (mm): 1258
+    soil P, total (mg/kg): 66
     description: unknown
   Cunningham_KNP-West Head_152m:
     latitude (deg): -33.585
     longitude (deg): 151.299
     elevation (m): 152
-    MAP (mm): 1241
-    soil P (ug/g): 934
+    precipitation, MAP (mm): 1241
+    soil P, total (mg/kg): 934
     description: unknown
   Cunningham_Londonderry_15m:
     latitude (deg): -33.663
     longitude (deg): 150.733
     elevation (m): 15
-    MAP (mm): 786
-    soil P (ug/g): 234
+    precipitation, MAP (mm): 786
+    soil P, total (mg/kg): 234
     description: unknown
   Cunningham_Mitchell Park_45m:
     latitude (deg): -33.571
     longitude (deg): 150.929
     elevation (m): 45
-    MAP (mm): 841
-    soil P (ug/g): 59
+    precipitation, MAP (mm): 841
+    soil P, total (mg/kg): 59
     description: unknown
   Cunningham_Narooma_25m:
     latitude (deg): -36.239
     longitude (deg): 150.119
     elevation (m): 25
-    MAP (mm): 953
-    soil P (ug/g): 212
+    precipitation, MAP (mm): 953
+    soil P, total (mg/kg): 212
     description: unknown
   Cunningham_Nombinnie_160m:
     latitude (deg): -33.044
     longitude (deg): 146.009
     elevation (m): 160
-    MAP (mm): 270
-    soil P (ug/g): 218
+    precipitation, MAP (mm): 270
+    soil P, total (mg/kg): 218
     description: unknown
   Cunningham_Nuntherungie_190m:
     latitude (deg): -30.801
     longitude (deg): 142.477
     elevation (m): 190
-    MAP (mm): 219
-    soil P (ug/g): 30
+    precipitation, MAP (mm): 219
+    soil P, total (mg/kg): 30
     description: unknown
   Cunningham_Patonga_5m:
     latitude (deg): -33.546
     longitude (deg): 151.269
     elevation (m): 5
-    MAP (mm): 1183
-    soil P (ug/g): 90
+    precipitation, MAP (mm): 1183
+    soil P, total (mg/kg): 90
     description: unknown
   Cunningham_Rankins-Springs_170m:
     latitude (deg): -33.936
     longitude (deg): 146.115
     elevation (m): 170
-    MAP (mm): 408
-    soil P (ug/g): 106
+    precipitation, MAP (mm): 408
+    soil P, total (mg/kg): 106
     description: unknown
   Cunningham_RNP-Audley_5m:
     latitude (deg): -34.072
     longitude (deg): 151.057
     elevation (m): 5
-    MAP (mm): 1112
-    soil P (ug/g): 118
+    precipitation, MAP (mm): 1112
+    soil P, total (mg/kg): 118
     description: unknown
   Cunningham_RNP-Bola Creek_50m:
     latitude (deg): -34.149
     longitude (deg): 151.03
     elevation (m): 50
-    MAP (mm): 1226
-    soil P (ug/g): 788
+    precipitation, MAP (mm): 1226
+    soil P, total (mg/kg): 788
     description: unknown
   Cunningham_RNP-Fosters Flat_50m:
     latitude (deg): -34.152
     longitude (deg): 151.021
     elevation (m): 50
-    MAP (mm): 1222
-    soil P (ug/g): 137
+    precipitation, MAP (mm): 1222
+    soil P, total (mg/kg): 137
     description: unknown
   Cunningham_White Cliffs_80m:
     latitude (deg): -31.085
     longitude (deg): 143.091
     elevation (m): 80
-    MAP (mm): 216
-    soil P (ug/g): 258
+    precipitation, MAP (mm): 216
+    soil P, total (mg/kg): 258
     description: unknown
 contexts: .na
 config:
@@ -636,4 +636,3 @@ questions:
   additional_traits: Sclerification (proportion); cell cross-sectional areas; essential
     oil content; Phenolics index; Tannins index; neutral detergent fiber; Alkaloids
     presence
-

--- a/data/Curran_2009/metadata.yml
+++ b/data/Curran_2009/metadata.yml
@@ -9,7 +9,7 @@ source:
       edaphic compensation account for dry rainforest distribution?'
     volume: '57'
     number: '8'
-    pages: '629--639'
+    pages: 629--639
     doi: 10.1071/bt09128
 people:
 - name: Timothy Curran
@@ -73,61 +73,61 @@ dataset:
   notes: none
 sites:
   southern slope Planchonella Nature Reserve:
-    site: 1
+    site code: 1
     description: 'Loam #1'
-    Location: southern slope Planchonella Nature Reserve
+    locality: southern slope Planchonella Nature Reserve
     latitude (deg): -29.1408333
     longitude (deg): 150.5969444
     soil type: silty loam
-    sand (%): 41.2
-    silt (%): 39.6
-    clay (%): 19.3
-    mean Total P (ug g-1): 1028.0
-    se Total P (ug g-1): 93.0
+    soil sand (%): 41.2
+    soil silt (%): 39.6
+    soil clay (%): 19.3
+    soil P, total (mg/kg): 1028.0
+    soil P, SE total (mg/kg): 93.0
     elevation (m): 455.0
-    aspect (degrees True): 220.0
+    slope aspect (degrees): 220.0
   Bondi, S of Warialda:
-    site: 2
+    site code: 2
     description: 'Sand #1'
-    Location: '"Bondi", S of Warialda'
+    locality: '"Bondi", S of Warialda'
     latitude (deg): -29.6372222
     longitude (deg): 150.5261111
     soil type: loamy sand
-    sand (%): 72.9
-    silt (%): 17.3
-    clay (%): 9.9
-    mean Total P (ug g-1): 522.0
-    se Total P (ug g-1): 48.0
+    soil sand (%): 72.9
+    soil silt (%): 17.3
+    soil clay (%): 9.9
+    soil P, total (mg/kg): 522.0
+    soil P, SE total (mg/kg): 48.0
     elevation (m): 420.0
-    aspect (degrees True): 340.0
+    slope aspect (degrees): 340.0
   Tank Stand Travelling Stock Route, NW of Warialda:
-    site: 3
+    site code: 3
     description: 'Sand #2'
-    Location: Tank Stand Travelling Stock Route, NW of Warialda
+    locality: Tank Stand Travelling Stock Route, NW of Warialda
     latitude (deg): -29.4658333
     longitude (deg): 150.4513889
     soil type: loamy sand
-    sand (%): 80.7
-    silt (%): 9.9
-    clay (%): 9.4
-    mean Total P (ug g-1): 291.0
-    se Total P (ug g-1): 29.0
+    soil sand (%): 80.7
+    soil silt (%): 9.9
+    soil clay (%): 9.4
+    soil P, total (mg/kg): 291.0
+    soil P, SE total (mg/kg): 29.0
     elevation (m): 409.0
-    aspect (degrees True): 110.0
+    slope aspect (degrees): 110.0
   eastern slope Planchonella Nature Reserve:
-    site: 4
+    site code: 4
     description: 'Loam #2'
-    Location: eastern slope Planchonella Nature Reserve
+    locality: eastern slope Planchonella Nature Reserve
     latitude (deg): -29.1402778
     longitude (deg): 150.6202778
     soil type: silty loam
-    sand (%): 61.6
-    silt (%): 27.4
-    clay (%): 11.0
-    mean Total P (ug g-1): 1544.0
-    se Total P (ug g-1): 183.0
+    soil sand (%): 61.6
+    soil silt (%): 27.4
+    soil clay (%): 11.0
+    soil P, total (mg/kg): 1544.0
+    soil P, SE total (mg/kg): 183.0
     elevation (m): 386.0
-    aspect (degrees True): 116.0
+    slope aspect (degrees): 116.0
 contexts: .na
 config:
   data_is_long_format: no
@@ -270,4 +270,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2021-02-19)
 exclude_observations: .na
 questions: .na
-

--- a/data/Curtis_2012/metadata.yml
+++ b/data/Curtis_2012/metadata.yml
@@ -9,7 +9,7 @@ source:
       modes of thermal protection'
     volume: '60'
     number: '6'
-    pages: '471--483'
+    pages: 471--483
     doi: 10.1071/bt11284
 people:
 - name: Andrea Leigh
@@ -52,30 +52,30 @@ sites:
     description: hot, arid climate
     latitude (deg): -31.28
     longitude (deg): 142.3
-    location notes: lat/lon approximate, based on place names
-    MAP (mm): < 250
-    average maximum summer temperature (C): 44.0
+    lat/lon notes: lat/lon approximate, based on place names
+    precipitation, MAP (mm): < 250
+    temperature, mean summer max (C): 44.0
   Mutawintji National Park in Mutawintji Gorge:
     description: hot, arid climate
     latitude (deg): -31.27
     longitude (deg): 142.31
-    location notes: lat/lon approximate, based on place names
-    MAP (mm): < 250
-    average maximum summer temperature (C): 44.0
+    lat/lon notes: lat/lon approximate, based on place names
+    precipitation, MAP (mm): < 250
+    temperature, mean summer max (C): 44.0
   Silver City Highway near Fowlers Gap:
     description: hot, arid climate
     latitude (deg): -31.41
     longitude (deg): 141.62
-    location notes: lat/lon approximate, based on place names
-    MAP (mm): < 250
-    average maximum summer temperature (C): 44.0
+    lat/lon notes: lat/lon approximate, based on place names
+    precipitation, MAP (mm): < 250
+    temperature, mean summer max (C): 44.0
   Sturt National Park, around Olive Downs Homestead:
     description: hot, arid climate
     latitude (deg): -29.05
     longitude (deg): 141.86
-    location notes: lat/lon approximate, based on place names
-    MAP (mm): < 250
-    average maximum summer temperature (C): 44.0
+    lat/lon notes: lat/lon approximate, based on place names
+    precipitation, MAP (mm): < 250
+    temperature, mean summer max (C): 44.0
 contexts: .na
 config:
   data_is_long_format: no
@@ -328,4 +328,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Curtis_2012/metadata.yml
+++ b/data/Curtis_2012/metadata.yml
@@ -52,28 +52,28 @@ sites:
     description: hot, arid climate
     latitude (deg): -31.28
     longitude (deg): 142.3
-    lat/lon notes: lat/lon approximate, based on place names
+    georeference remarks: lat/lon approximate, based on place names
     precipitation, MAP (mm): < 250
     temperature, mean summer max (C): 44.0
   Mutawintji National Park in Mutawintji Gorge:
     description: hot, arid climate
     latitude (deg): -31.27
     longitude (deg): 142.31
-    lat/lon notes: lat/lon approximate, based on place names
+    georeference remarks: lat/lon approximate, based on place names
     precipitation, MAP (mm): < 250
     temperature, mean summer max (C): 44.0
   Silver City Highway near Fowlers Gap:
     description: hot, arid climate
     latitude (deg): -31.41
     longitude (deg): 141.62
-    lat/lon notes: lat/lon approximate, based on place names
+    georeference remarks: lat/lon approximate, based on place names
     precipitation, MAP (mm): < 250
     temperature, mean summer max (C): 44.0
   Sturt National Park, around Olive Downs Homestead:
     description: hot, arid climate
     latitude (deg): -29.05
     longitude (deg): 141.86
-    lat/lon notes: lat/lon approximate, based on place names
+    georeference remarks: lat/lon approximate, based on place names
     precipitation, MAP (mm): < 250
     temperature, mean summer max (C): 44.0
 contexts: .na

--- a/data/Denton_2007/metadata.yml
+++ b/data/Denton_2007/metadata.yml
@@ -46,27 +46,27 @@ sites:
   site_-29.404092S_115.088485E:
     latitude (deg): -29.404092
     longitude (deg): 115.088485
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
   site_-30.469025S_115.760399E:
     latitude (deg): -30.469025
     longitude (deg): 115.760399
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
   site_-30.055578S_115.628028E:
     latitude (deg): -30.055578
     longitude (deg): 115.628028
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
   site_-30.054978S_115.332677E:
     latitude (deg): -30.054978
     longitude (deg): 115.332677
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
   site_-31.086681S_115.749598E:
     latitude (deg): -31.086681
     longitude (deg): 115.749598
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
   site_-28.938042S_115.087018E:
     latitude (deg): -28.938042
     longitude (deg): 115.087018
-    lat/lon notes: Lat/lon coordinates indicate seed and soil source location
+    georeference remarks: Lat/lon coordinates indicate seed and soil source location
 contexts:
   field_measurement:
     type: field

--- a/data/Denton_2007/metadata.yml
+++ b/data/Denton_2007/metadata.yml
@@ -316,4 +316,3 @@ substitutions:
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Detombeur_2021/metadata.yml
+++ b/data/Detombeur_2021/metadata.yml
@@ -99,203 +99,203 @@ sites:
   B.HR.2:
     latitude (deg): -30.295
     longitude (deg): 115.1876389
-    Chronosequence stage: Stage 5
-    Cation exchange capacity (cmolc/kg): 3.23
-    pH-CaCl2: 4.92
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 9.0
+    choronosequence stage: Stage 5
+    soil cation exchange capacity (cmol/kg): 3.23
+    soil pH (CaCl2): 4.92
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 9.0
   B.HR.5:
     latitude (deg): -30.2941667
     longitude (deg): 115.1849167
-    Chronosequence stage: Stage 5
-    Cation exchange capacity (cmolc/kg): 1.68
-    pH-CaCl2: 4.83
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 8.02
+    choronosequence stage: Stage 5
+    soil cation exchange capacity (cmol/kg): 1.68
+    soil pH (CaCl2): 4.83
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 8.02
   B.L.5:
     latitude (deg): -30.1641667
     longitude (deg): 115.1226389
-    Chronosequence stage: Stage 5
-    Cation exchange capacity (cmolc/kg): 2.96
-    pH-CaCl2: 4.45
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 6.59
+    choronosequence stage: Stage 5
+    soil cation exchange capacity (cmol/kg): 2.96
+    soil pH (CaCl2): 4.45
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 6.59
   B.NL.1:
     latitude (deg): -30.1294444
     longitude (deg): 115.1074444
-    Chronosequence stage: Stage 5
-    Cation exchange capacity (cmolc/kg): 2.04
-    pH-CaCl2: 5.1
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 5.57
+    choronosequence stage: Stage 5
+    soil cation exchange capacity (cmol/kg): 2.04
+    soil pH (CaCl2): 5.1
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 5.57
   B.NL.3:
     latitude (deg): -30.1266667
     longitude (deg): 115.1063056
-    Chronosequence stage: Stage 5
-    Cation exchange capacity (cmolc/kg): 2.66
-    pH-CaCl2: 4.91
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 3.9
+    choronosequence stage: Stage 5
+    soil cation exchange capacity (cmol/kg): 2.66
+    soil pH (CaCl2): 4.91
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 3.9
   Q.M.25:
     latitude (deg): -30.2241667
     longitude (deg): 115.0106667
-    Chronosequence stage: Stage 2
-    Cation exchange capacity (cmolc/kg): 13.53
-    pH-CaCl2: 7.75
-    Soil carbonates content (%): 65.0
-    Soil total P (mg/kg): 405.99
+    choronosequence stage: Stage 2
+    soil cation exchange capacity (cmol/kg): 13.53
+    soil pH (CaCl2): 7.75
+    soil carbontates content (%): 65.0
+    soil P, total (mg/kg): 405.99
   Q.M.26:
     latitude (deg): -30.2138889
     longitude (deg): 115.0103611
-    Chronosequence stage: Stage 2
-    Cation exchange capacity (cmolc/kg): 7.39
-    pH-CaCl2: 7.93
-    Soil carbonates content (%): 80.1
-    Soil total P (mg/kg): 423.12
+    choronosequence stage: Stage 2
+    soil cation exchange capacity (cmol/kg): 7.39
+    soil pH (CaCl2): 7.93
+    soil carbontates content (%): 80.1
+    soil P, total (mg/kg): 423.12
   Q.M.33:
     latitude (deg): -30.0902778
     longitude (deg): 114.9986111
-    Chronosequence stage: Stage 2
-    Cation exchange capacity (cmolc/kg): 13.78
-    pH-CaCl2: 7.79
-    Soil carbonates content (%): 75.6
-    Soil total P (mg/kg): 489.76
+    choronosequence stage: Stage 2
+    soil cation exchange capacity (cmol/kg): 13.78
+    soil pH (CaCl2): 7.79
+    soil carbontates content (%): 75.6
+    soil P, total (mg/kg): 489.76
   Q.M.7:
     latitude (deg): -30.2741667
     longitude (deg): 115.047
-    Chronosequence stage: Stage 2
-    Cation exchange capacity (cmolc/kg): 12.77
-    pH-CaCl2: 7.93
-    Soil carbonates content (%): 80.4
-    Soil total P (mg/kg): 428.12
+    choronosequence stage: Stage 2
+    soil cation exchange capacity (cmol/kg): 12.77
+    soil pH (CaCl2): 7.93
+    soil carbontates content (%): 80.4
+    soil P, total (mg/kg): 428.12
   Q.M.8:
     latitude (deg): -30.2261111
     longitude (deg): 115.0183889
-    Chronosequence stage: Stage 2
-    Cation exchange capacity (cmolc/kg): 13.4
-    pH-CaCl2: 7.83
-    Soil carbonates content (%): 76.3
-    Soil total P (mg/kg): 374.8
+    choronosequence stage: Stage 2
+    soil cation exchange capacity (cmol/kg): 13.4
+    soil pH (CaCl2): 7.83
+    soil carbontates content (%): 76.3
+    soil P, total (mg/kg): 374.8
   Q.O.14:
     latitude (deg): -30.2405556
     longitude (deg): 115.0669167
-    Chronosequence stage: Stage 3
-    Cation exchange capacity (cmolc/kg): 11.36
-    pH-CaCl2: 7.72
-    Soil carbonates content (%): 18.9
-    Soil total P (mg/kg): 168.38
+    choronosequence stage: Stage 3
+    soil cation exchange capacity (cmol/kg): 11.36
+    soil pH (CaCl2): 7.72
+    soil carbontates content (%): 18.9
+    soil P, total (mg/kg): 168.38
   Q.O.15:
     latitude (deg): -30.2405556
     longitude (deg): 115.0643056
-    Chronosequence stage: Stage 3
-    Cation exchange capacity (cmolc/kg): 12.81
-    pH-CaCl2: 7.8
-    Soil carbonates content (%): 39.1
-    Soil total P (mg/kg): 269.73
+    choronosequence stage: Stage 3
+    soil cation exchange capacity (cmol/kg): 12.81
+    soil pH (CaCl2): 7.8
+    soil carbontates content (%): 39.1
+    soil P, total (mg/kg): 269.73
   Q.O.17:
     latitude (deg): -30.2136111
     longitude (deg): 115.0638889
-    Chronosequence stage: Stage 3
-    Cation exchange capacity (cmolc/kg): 10.09
-    pH-CaCl2: 7.84
-    Soil carbonates content (%): 19.4
-    Soil total P (mg/kg): 169.54
+    choronosequence stage: Stage 3
+    soil cation exchange capacity (cmol/kg): 10.09
+    soil pH (CaCl2): 7.84
+    soil carbontates content (%): 19.4
+    soil P, total (mg/kg): 169.54
   Q.O.24:
     latitude (deg): -30.2708333
     longitude (deg): 115.0708056
-    Chronosequence stage: Stage 3
-    Cation exchange capacity (cmolc/kg): 11.78
-    pH-CaCl2: 7.72
-    Soil carbonates content (%): 24.5
-    Soil total P (mg/kg): 214.53
+    choronosequence stage: Stage 3
+    soil cation exchange capacity (cmol/kg): 11.78
+    soil pH (CaCl2): 7.72
+    soil carbontates content (%): 24.5
+    soil P, total (mg/kg): 214.53
   Q.O.5:
     latitude (deg): -30.2255556
     longitude (deg): 115.0648889
-    Chronosequence stage: Stage 3
-    Cation exchange capacity (cmolc/kg): 8.32
-    pH-CaCl2: 7.88
-    Soil carbonates content (%): 26.2
-    Soil total P (mg/kg): 206.42
+    choronosequence stage: Stage 3
+    soil cation exchange capacity (cmol/kg): 8.32
+    soil pH (CaCl2): 7.88
+    soil carbontates content (%): 26.2
+    soil P, total (mg/kg): 206.42
   Q.Y.1:
     latitude (deg): -30.4058333
     longitude (deg): 115.0947778
-    Chronosequence stage: Stage 1
-    Cation exchange capacity (cmolc/kg): 25.48
-    pH-CaCl2: 8.01
-    Soil carbonates content (%): 63.3
-    Soil total P (mg/kg): 318.66
+    choronosequence stage: Stage 1
+    soil cation exchange capacity (cmol/kg): 25.48
+    soil pH (CaCl2): 8.01
+    soil carbontates content (%): 63.3
+    soil P, total (mg/kg): 318.66
   Q.Y.15:
     latitude (deg): -30.4066667
     longitude (deg): 115.082
-    Chronosequence stage: Stage 1
-    Cation exchange capacity (cmolc/kg): 43.15
-    pH-CaCl2: 8.14
-    Soil carbonates content (%): 78.6
-    Soil total P (mg/kg): 350.07
+    choronosequence stage: Stage 1
+    soil cation exchange capacity (cmol/kg): 43.15
+    soil pH (CaCl2): 8.14
+    soil carbontates content (%): 78.6
+    soil P, total (mg/kg): 350.07
   Q.Y.16:
     latitude (deg): -30.115
     longitude (deg): 115.0064722
-    Chronosequence stage: Stage 1
-    Cation exchange capacity (cmolc/kg): 21.63
-    pH-CaCl2: 8.18
-    Soil carbonates content (%): 76.8
-    Soil total P (mg/kg): 355.18
+    choronosequence stage: Stage 1
+    soil cation exchange capacity (cmol/kg): 21.63
+    soil pH (CaCl2): 8.18
+    soil carbontates content (%): 76.8
+    soil P, total (mg/kg): 355.18
   Q.Y.17:
     latitude (deg): -30.0452778
     longitude (deg): 114.9625556
-    Chronosequence stage: Stage 1
-    Cation exchange capacity (cmolc/kg): 15.27
-    pH-CaCl2: 8.2
-    Soil carbonates content (%): 84.4
-    Soil total P (mg/kg): 329.55
+    choronosequence stage: Stage 1
+    soil cation exchange capacity (cmol/kg): 15.27
+    soil pH (CaCl2): 8.2
+    soil carbontates content (%): 84.4
+    soil P, total (mg/kg): 329.55
   Q.Y.18:
     latitude (deg): -30.2236111
     longitude (deg): 115.0081667
-    Chronosequence stage: Stage 1
-    Cation exchange capacity (cmolc/kg): 46.96
-    pH-CaCl2: 8.38
-    Soil carbonates content (%): 73.0
-    Soil total P (mg/kg): 401.64
+    choronosequence stage: Stage 1
+    soil cation exchange capacity (cmol/kg): 46.96
+    soil pH (CaCl2): 8.38
+    soil carbontates content (%): 73.0
+    soil P, total (mg/kg): 401.64
   S.W.14:
     latitude (deg): -30.0825
     longitude (deg): 115.0524722
-    Chronosequence stage: Stage 4
-    Cation exchange capacity (cmolc/kg): 3.04
-    pH-CaCl2: 5.82
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 20.44
+    choronosequence stage: Stage 4
+    soil cation exchange capacity (cmol/kg): 3.04
+    soil pH (CaCl2): 5.82
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 20.44
   S.W.17:
     latitude (deg): -30.2286111
     longitude (deg): 115.0685
-    Chronosequence stage: Stage 4
-    Cation exchange capacity (cmolc/kg): 2.99
-    pH-CaCl2: 5.73
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 17.74
+    choronosequence stage: Stage 4
+    soil cation exchange capacity (cmol/kg): 2.99
+    soil pH (CaCl2): 5.73
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 17.74
   S.W.34:
     latitude (deg): -30.0275
     longitude (deg): 115.0388889
-    Chronosequence stage: Stage 4
-    Cation exchange capacity (cmolc/kg): 4.21
-    pH-CaCl2: 6.07
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 12.83
+    choronosequence stage: Stage 4
+    soil cation exchange capacity (cmol/kg): 4.21
+    soil pH (CaCl2): 6.07
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 12.83
   S.W.6:
     latitude (deg): -30.0977778
     longitude (deg): 115.0579722
-    Chronosequence stage: Stage 4
-    Cation exchange capacity (cmolc/kg): 4.02
-    pH-CaCl2: 5.82
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 26.96
+    choronosequence stage: Stage 4
+    soil cation exchange capacity (cmol/kg): 4.02
+    soil pH (CaCl2): 5.82
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 26.96
   S.W.8:
     latitude (deg): -30.2352778
     longitude (deg): 115.0706667
-    Chronosequence stage: Stage 4
-    Cation exchange capacity (cmolc/kg): 3.77
-    pH-CaCl2: 5.48
-    Soil carbonates content (%): 0.0
-    Soil total P (mg/kg): 14.76
+    choronosequence stage: Stage 4
+    soil cation exchange capacity (cmol/kg): 3.77
+    soil pH (CaCl2): 5.48
+    soil carbontates content (%): 0.0
+    soil P, total (mg/kg): 14.76
 contexts: .na
 config:
   data_is_long_format: no
@@ -433,4 +433,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   query: Note to update reference information and include DOI once available.
-

--- a/data/Detombeur_2021/metadata.yml
+++ b/data/Detombeur_2021/metadata.yml
@@ -102,7 +102,7 @@ sites:
     choronosequence stage: Stage 5
     soil cation exchange capacity (cmol/kg): 3.23
     soil pH (CaCl2): 4.92
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 9.0
   B.HR.5:
     latitude (deg): -30.2941667
@@ -110,7 +110,7 @@ sites:
     choronosequence stage: Stage 5
     soil cation exchange capacity (cmol/kg): 1.68
     soil pH (CaCl2): 4.83
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 8.02
   B.L.5:
     latitude (deg): -30.1641667
@@ -118,7 +118,7 @@ sites:
     choronosequence stage: Stage 5
     soil cation exchange capacity (cmol/kg): 2.96
     soil pH (CaCl2): 4.45
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 6.59
   B.NL.1:
     latitude (deg): -30.1294444
@@ -126,7 +126,7 @@ sites:
     choronosequence stage: Stage 5
     soil cation exchange capacity (cmol/kg): 2.04
     soil pH (CaCl2): 5.1
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 5.57
   B.NL.3:
     latitude (deg): -30.1266667
@@ -134,7 +134,7 @@ sites:
     choronosequence stage: Stage 5
     soil cation exchange capacity (cmol/kg): 2.66
     soil pH (CaCl2): 4.91
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 3.9
   Q.M.25:
     latitude (deg): -30.2241667
@@ -142,7 +142,7 @@ sites:
     choronosequence stage: Stage 2
     soil cation exchange capacity (cmol/kg): 13.53
     soil pH (CaCl2): 7.75
-    soil carbontates content (%): 65.0
+    soil carbonates content (%): 65.0
     soil P, total (mg/kg): 405.99
   Q.M.26:
     latitude (deg): -30.2138889
@@ -150,7 +150,7 @@ sites:
     choronosequence stage: Stage 2
     soil cation exchange capacity (cmol/kg): 7.39
     soil pH (CaCl2): 7.93
-    soil carbontates content (%): 80.1
+    soil carbonates content (%): 80.1
     soil P, total (mg/kg): 423.12
   Q.M.33:
     latitude (deg): -30.0902778
@@ -158,7 +158,7 @@ sites:
     choronosequence stage: Stage 2
     soil cation exchange capacity (cmol/kg): 13.78
     soil pH (CaCl2): 7.79
-    soil carbontates content (%): 75.6
+    soil carbonates content (%): 75.6
     soil P, total (mg/kg): 489.76
   Q.M.7:
     latitude (deg): -30.2741667
@@ -166,7 +166,7 @@ sites:
     choronosequence stage: Stage 2
     soil cation exchange capacity (cmol/kg): 12.77
     soil pH (CaCl2): 7.93
-    soil carbontates content (%): 80.4
+    soil carbonates content (%): 80.4
     soil P, total (mg/kg): 428.12
   Q.M.8:
     latitude (deg): -30.2261111
@@ -174,7 +174,7 @@ sites:
     choronosequence stage: Stage 2
     soil cation exchange capacity (cmol/kg): 13.4
     soil pH (CaCl2): 7.83
-    soil carbontates content (%): 76.3
+    soil carbonates content (%): 76.3
     soil P, total (mg/kg): 374.8
   Q.O.14:
     latitude (deg): -30.2405556
@@ -182,7 +182,7 @@ sites:
     choronosequence stage: Stage 3
     soil cation exchange capacity (cmol/kg): 11.36
     soil pH (CaCl2): 7.72
-    soil carbontates content (%): 18.9
+    soil carbonates content (%): 18.9
     soil P, total (mg/kg): 168.38
   Q.O.15:
     latitude (deg): -30.2405556
@@ -190,7 +190,7 @@ sites:
     choronosequence stage: Stage 3
     soil cation exchange capacity (cmol/kg): 12.81
     soil pH (CaCl2): 7.8
-    soil carbontates content (%): 39.1
+    soil carbonates content (%): 39.1
     soil P, total (mg/kg): 269.73
   Q.O.17:
     latitude (deg): -30.2136111
@@ -198,7 +198,7 @@ sites:
     choronosequence stage: Stage 3
     soil cation exchange capacity (cmol/kg): 10.09
     soil pH (CaCl2): 7.84
-    soil carbontates content (%): 19.4
+    soil carbonates content (%): 19.4
     soil P, total (mg/kg): 169.54
   Q.O.24:
     latitude (deg): -30.2708333
@@ -206,7 +206,7 @@ sites:
     choronosequence stage: Stage 3
     soil cation exchange capacity (cmol/kg): 11.78
     soil pH (CaCl2): 7.72
-    soil carbontates content (%): 24.5
+    soil carbonates content (%): 24.5
     soil P, total (mg/kg): 214.53
   Q.O.5:
     latitude (deg): -30.2255556
@@ -214,7 +214,7 @@ sites:
     choronosequence stage: Stage 3
     soil cation exchange capacity (cmol/kg): 8.32
     soil pH (CaCl2): 7.88
-    soil carbontates content (%): 26.2
+    soil carbonates content (%): 26.2
     soil P, total (mg/kg): 206.42
   Q.Y.1:
     latitude (deg): -30.4058333
@@ -222,7 +222,7 @@ sites:
     choronosequence stage: Stage 1
     soil cation exchange capacity (cmol/kg): 25.48
     soil pH (CaCl2): 8.01
-    soil carbontates content (%): 63.3
+    soil carbonates content (%): 63.3
     soil P, total (mg/kg): 318.66
   Q.Y.15:
     latitude (deg): -30.4066667
@@ -230,7 +230,7 @@ sites:
     choronosequence stage: Stage 1
     soil cation exchange capacity (cmol/kg): 43.15
     soil pH (CaCl2): 8.14
-    soil carbontates content (%): 78.6
+    soil carbonates content (%): 78.6
     soil P, total (mg/kg): 350.07
   Q.Y.16:
     latitude (deg): -30.115
@@ -238,7 +238,7 @@ sites:
     choronosequence stage: Stage 1
     soil cation exchange capacity (cmol/kg): 21.63
     soil pH (CaCl2): 8.18
-    soil carbontates content (%): 76.8
+    soil carbonates content (%): 76.8
     soil P, total (mg/kg): 355.18
   Q.Y.17:
     latitude (deg): -30.0452778
@@ -246,7 +246,7 @@ sites:
     choronosequence stage: Stage 1
     soil cation exchange capacity (cmol/kg): 15.27
     soil pH (CaCl2): 8.2
-    soil carbontates content (%): 84.4
+    soil carbonates content (%): 84.4
     soil P, total (mg/kg): 329.55
   Q.Y.18:
     latitude (deg): -30.2236111
@@ -254,7 +254,7 @@ sites:
     choronosequence stage: Stage 1
     soil cation exchange capacity (cmol/kg): 46.96
     soil pH (CaCl2): 8.38
-    soil carbontates content (%): 73.0
+    soil carbonates content (%): 73.0
     soil P, total (mg/kg): 401.64
   S.W.14:
     latitude (deg): -30.0825
@@ -262,7 +262,7 @@ sites:
     choronosequence stage: Stage 4
     soil cation exchange capacity (cmol/kg): 3.04
     soil pH (CaCl2): 5.82
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 20.44
   S.W.17:
     latitude (deg): -30.2286111
@@ -270,7 +270,7 @@ sites:
     choronosequence stage: Stage 4
     soil cation exchange capacity (cmol/kg): 2.99
     soil pH (CaCl2): 5.73
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 17.74
   S.W.34:
     latitude (deg): -30.0275
@@ -278,7 +278,7 @@ sites:
     choronosequence stage: Stage 4
     soil cation exchange capacity (cmol/kg): 4.21
     soil pH (CaCl2): 6.07
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 12.83
   S.W.6:
     latitude (deg): -30.0977778
@@ -286,7 +286,7 @@ sites:
     choronosequence stage: Stage 4
     soil cation exchange capacity (cmol/kg): 4.02
     soil pH (CaCl2): 5.82
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 26.96
   S.W.8:
     latitude (deg): -30.2352778
@@ -294,7 +294,7 @@ sites:
     choronosequence stage: Stage 4
     soil cation exchange capacity (cmol/kg): 3.77
     soil pH (CaCl2): 5.48
-    soil carbontates content (%): 0.0
+    soil carbonates content (%): 0.0
     soil P, total (mg/kg): 14.76
 contexts: .na
 config:

--- a/data/Dong_2017/metadata.yml
+++ b/data/Dong_2017/metadata.yml
@@ -22,7 +22,7 @@ source:
     journal: New Phytologist
     title: Components of leaf-trait variation along environmental gradients
     volume: 228
-    pages: '82--94'
+    pages: 82--94
     doi: 10.1111/nph.16558
 people:
 - name: Ning Dong
@@ -63,10 +63,10 @@ sites:
     elevation (m): 548.082
     growing degree days: 22.544
     moisture index: 0.157
-    PET (mm): 2162.539
+    PET (mm/yr): 2162.539
     AET (mm): 457.962
-    MAT (C): 22.575
-    MAP (mm): 339.973
+    temperature, MAT (C): 22.575
+    precipitation, MAP (mm): 339.973
     mean vapor pressure deficit (kPa): 2.109
   NTABRT0006:
     longitude (deg): 133.613
@@ -74,10 +74,10 @@ sites:
     elevation (m): 548.082
     growing degree days: 22.544
     moisture index: 0.157
-    PET (mm): 2162.55
+    PET (mm/yr): 2162.55
     AET (mm): 457.965
-    MAT (C): 22.575
-    MAP (mm): 339.973
+    temperature, MAT (C): 22.575
+    precipitation, MAP (mm): 339.973
     mean vapor pressure deficit (kPa): 2.109
   NTADAC0001:
     longitude (deg): 130.778
@@ -85,10 +85,10 @@ sites:
     elevation (m): 212.453
     growing degree days: 26.517
     moisture index: 0.817
-    PET (mm): 2113.543
+    PET (mm/yr): 2113.543
     AET (mm): 1247.719
-    MAT (C): 26.524
-    MAP (mm): 1726.128
+    temperature, MAT (C): 26.524
+    precipitation, MAP (mm): 1726.128
     mean vapor pressure deficit (kPa): 1.41
   NTAFIN0019:
     longitude (deg): 132.936
@@ -96,10 +96,10 @@ sites:
     elevation (m): 465.576
     growing degree days: 21.808
     moisture index: 0.13
-    PET (mm): 2091.912
+    PET (mm/yr): 2091.912
     AET (mm): 403.99
-    MAT (C): 21.843
-    MAP (mm): 272.279
+    temperature, MAT (C): 21.843
+    precipitation, MAP (mm): 272.279
     mean vapor pressure deficit (kPa): 2.062
   NTAFIN0022:
     longitude (deg): 133.452
@@ -107,10 +107,10 @@ sites:
     elevation (m): 416.855
     growing degree days: 21.71
     moisture index: 0.117
-    PET (mm): 2086.261
+    PET (mm/yr): 2086.261
     AET (mm): 402.383
-    MAT (C): 21.744
-    MAP (mm): 244.947
+    temperature, MAT (C): 21.744
+    precipitation, MAP (mm): 244.947
     mean vapor pressure deficit (kPa): 2.054
   NTAFIN0031:
     longitude (deg): 133.897
@@ -118,10 +118,10 @@ sites:
     elevation (m): 444.664
     growing degree days: 21.09
     moisture index: 0.112
-    PET (mm): 2038.804
+    PET (mm/yr): 2038.804
     AET (mm): 392.929
-    MAT (C): 21.125
-    MAP (mm): 228.74
+    temperature, MAT (C): 21.125
+    precipitation, MAP (mm): 228.74
     mean vapor pressure deficit (kPa): 1.953
   NTAFIN0033:
     longitude (deg): 133.972
@@ -129,10 +129,10 @@ sites:
     elevation (m): 577.032
     growing degree days: 20.794
     moisture index: 0.144
-    PET (mm): 2071.905
+    PET (mm/yr): 2071.905
     AET (mm): 403.068
-    MAT (C): 20.828
-    MAP (mm): 299.126
+    temperature, MAT (C): 20.828
+    precipitation, MAP (mm): 299.126
     mean vapor pressure deficit (kPa): 1.944
   NTAGFU0001:
     longitude (deg): 137.069
@@ -140,10 +140,10 @@ sites:
     elevation (m): 265.831
     growing degree days: 25.448
     moisture index: 0.221
-    PET (mm): 2208.348
+    PET (mm/yr): 2208.348
     AET (mm): 637.569
-    MAT (C): 25.47
-    MAP (mm): 487.614
+    temperature, MAT (C): 25.47
+    precipitation, MAP (mm): 487.614
     mean vapor pressure deficit (kPa): 2.235
   NTAGFU0008:
     longitude (deg): 136.865
@@ -151,10 +151,10 @@ sites:
     elevation (m): 301.818
     growing degree days: 25.258
     moisture index: 0.233
-    PET (mm): 2204.204
+    PET (mm/yr): 2204.204
     AET (mm): 657.312
-    MAT (C): 25.28
-    MAP (mm): 512.685
+    temperature, MAT (C): 25.28
+    precipitation, MAP (mm): 512.685
     mean vapor pressure deficit (kPa): 2.186
   NTAGFU0010:
     longitude (deg): 137.101
@@ -162,10 +162,10 @@ sites:
     elevation (m): 238.684
     growing degree days: 25.681
     moisture index: 0.296
-    PET (mm): 2185.93
+    PET (mm/yr): 2185.93
     AET (mm): 792.68
-    MAT (C): 25.7
-    MAP (mm): 647.059
+    temperature, MAT (C): 25.7
+    precipitation, MAP (mm): 647.059
     mean vapor pressure deficit (kPa): 2.055
   NTAGFU0017:
     longitude (deg): 137.158
@@ -173,10 +173,10 @@ sites:
     elevation (m): 250.131
     growing degree days: 25.576
     moisture index: 0.359
-    PET (mm): 2165.993
+    PET (mm/yr): 2165.993
     AET (mm): 913.17
-    MAT (C): 25.593
-    MAP (mm): 777.249
+    temperature, MAT (C): 25.593
+    precipitation, MAP (mm): 777.249
     mean vapor pressure deficit (kPa): 1.899
   NTAGFU0031:
     longitude (deg): 134.387
@@ -184,10 +184,10 @@ sites:
     elevation (m): 98.592
     growing degree days: 27.374
     moisture index: 0.429
-    PET (mm): 2210.171
+    PET (mm/yr): 2210.171
     AET (mm): 1091.916
-    MAT (C): 27.385
-    MAP (mm): 948.038
+    temperature, MAT (C): 27.385
+    precipitation, MAP (mm): 948.038
     mean vapor pressure deficit (kPa): 1.842
   NTAGFU0040:
     longitude (deg): 133.845
@@ -195,10 +195,10 @@ sites:
     elevation (m): 56.852
     growing degree days: 27.62
     moisture index: 0.397
-    PET (mm): 2239.233
+    PET (mm/yr): 2239.233
     AET (mm): 1041.709
-    MAT (C): 27.633
-    MAP (mm): 888.099
+    temperature, MAT (C): 27.633
+    precipitation, MAP (mm): 888.099
     mean vapor pressure deficit (kPa): 1.991
   NTASSD0005:
     longitude (deg): 136.545
@@ -206,10 +206,10 @@ sites:
     elevation (m): 95.553
     growing degree days: 22.919
     moisture index: 0.074
-    PET (mm): 2081.381
+    PET (mm/yr): 2081.381
     AET (mm): 401.423
-    MAT (C): 22.956
-    MAP (mm): 154.385
+    temperature, MAT (C): 22.956
+    precipitation, MAP (mm): 154.385
     mean vapor pressure deficit (kPa): 2.281
   NTASSD0009:
     longitude (deg): 136.01
@@ -217,10 +217,10 @@ sites:
     elevation (m): 171.165
     growing degree days: 22.794
     moisture index: 0.081
-    PET (mm): 2099.145
+    PET (mm/yr): 2099.145
     AET (mm): 405.021
-    MAT (C): 22.83
-    MAP (mm): 170.113
+    temperature, MAT (C): 22.83
+    precipitation, MAP (mm): 170.113
     mean vapor pressure deficit (kPa): 2.264
   SAASTP0001:
     longitude (deg): 134.999
@@ -228,10 +228,10 @@ sites:
     elevation (m): 194.869
     growing degree days: 22.209
     moisture index: 0.108
-    PET (mm): 2044.977
+    PET (mm/yr): 2044.977
     AET (mm): 394.317
-    MAT (C): 22.245
-    MAP (mm): 221.565
+    temperature, MAT (C): 22.245
+    precipitation, MAP (mm): 221.565
     mean vapor pressure deficit (kPa): 2.147
   SAASTP0004:
     longitude (deg): 135.452
@@ -239,10 +239,10 @@ sites:
     elevation (m): 144.005
     growing degree days: 22.53
     moisture index: 0.091
-    PET (mm): 2058.635
+    PET (mm/yr): 2058.635
     AET (mm): 396.916
-    MAT (C): 22.567
-    MAP (mm): 187.842
+    temperature, MAT (C): 22.567
+    precipitation, MAP (mm): 187.842
     mean vapor pressure deficit (kPa): 2.206
   SATFLB0001:
     longitude (deg): 138.861
@@ -250,10 +250,10 @@ sites:
     elevation (m): 198.456
     growing degree days: 15.824
     moisture index: 0.365
-    PET (mm): 1431.912
+    PET (mm/yr): 1431.912
     AET (mm): 573.701
-    MAT (C): 15.852
-    MAP (mm): 522.135
+    temperature, MAT (C): 15.852
+    precipitation, MAP (mm): 522.135
     mean vapor pressure deficit (kPa): 0.903
   SATFLB0005:
     longitude (deg): 138.566
@@ -261,10 +261,10 @@ sites:
     elevation (m): 645.086
     growing degree days: 16.284
     moisture index: 0.183
-    PET (mm): 1724.106
+    PET (mm/yr): 1724.106
     AET (mm): 401.251
-    MAT (C): 16.318
-    MAP (mm): 315.135
+    temperature, MAT (C): 16.318
+    precipitation, MAP (mm): 315.135
     mean vapor pressure deficit (kPa): 1.214
   SATFLB0008:
     longitude (deg): 137.954
@@ -272,10 +272,10 @@ sites:
     elevation (m): 692.636
     growing degree days: 14.882
     moisture index: 0.276
-    PET (mm): 1606.677
+    PET (mm/yr): 1606.677
     AET (mm): 493.601
-    MAT (C): 14.914
-    MAP (mm): 443.548
+    temperature, MAT (C): 14.914
+    precipitation, MAP (mm): 443.548
     mean vapor pressure deficit (kPa): 0.925
   SATFLB0010:
     longitude (deg): 138.033
@@ -283,10 +283,10 @@ sites:
     elevation (m): 221.684
     growing degree days: 17.083
     moisture index: 0.258
-    PET (mm): 1602.754
+    PET (mm/yr): 1602.754
     AET (mm): 475.204
-    MAT (C): 17.114
-    MAP (mm): 412.994
+    temperature, MAT (C): 17.114
+    precipitation, MAP (mm): 412.994
     mean vapor pressure deficit (kPa): 1.017
   SATFLB0012:
     longitude (deg): 138.708
@@ -294,10 +294,10 @@ sites:
     elevation (m): 209.396
     growing degree days: 16.147
     moisture index: 0.478
-    PET (mm): 1406.255
+    PET (mm/yr): 1406.255
     AET (mm): 684.903
-    MAT (C): 16.173
-    MAP (mm): 672.08
+    temperature, MAT (C): 16.173
+    precipitation, MAP (mm): 672.08
     mean vapor pressure deficit (kPa): 0.882
   SATFLB0014:
     longitude (deg): 138.959
@@ -305,10 +305,10 @@ sites:
     elevation (m): 555.178
     growing degree days: 14.021
     moisture index: 0.34
-    PET (mm): 1437.706
+    PET (mm/yr): 1437.706
     AET (mm): 529.582
-    MAT (C): 14.05
-    MAP (mm): 489.335
+    temperature, MAT (C): 14.05
+    precipitation, MAP (mm): 489.335
     mean vapor pressure deficit (kPa): 0.812
   SATFLB0015:
     longitude (deg): 138.727
@@ -316,10 +316,10 @@ sites:
     elevation (m): 486.415
     growing degree days: 13.658
     moisture index: 0.77
-    PET (mm): 1330.999
+    PET (mm/yr): 1330.999
     AET (mm): 759.509
-    MAT (C): 13.683
-    MAP (mm): 1024.668
+    temperature, MAT (C): 13.683
+    precipitation, MAP (mm): 1024.668
     mean vapor pressure deficit (kPa): 0.636
   SATKAN0001:
     longitude (deg): 138.261
@@ -327,10 +327,10 @@ sites:
     elevation (m): 297.36
     growing degree days: 13.661
     moisture index: 0.653
-    PET (mm): 1277.577
+    PET (mm/yr): 1277.577
     AET (mm): 690.721
-    MAT (C): 13.682
-    MAP (mm): 834.421
+    temperature, MAT (C): 13.682
+    precipitation, MAP (mm): 834.421
     mean vapor pressure deficit (kPa): 0.476
   SATKAN0002:
     longitude (deg): 138.69
@@ -338,10 +338,10 @@ sites:
     elevation (m): 321.105
     growing degree days: 14.216
     moisture index: 0.639
-    PET (mm): 1319.477
+    PET (mm/yr): 1319.477
     AET (mm): 706.21
-    MAT (C): 14.24
-    MAP (mm): 842.648
+    temperature, MAT (C): 14.24
+    precipitation, MAP (mm): 842.648
     mean vapor pressure deficit (kPa): 0.646
   SATSTP0002:
     longitude (deg): 139.547
@@ -349,10 +349,10 @@ sites:
     elevation (m): 16.687
     growing degree days: 20.411
     moisture index: 0.098
-    PET (mm): 1854.074
+    PET (mm/yr): 1854.074
     AET (mm): 355.829
-    MAT (C): 20.445
-    MAP (mm): 182.457
+    temperature, MAT (C): 20.445
+    precipitation, MAP (mm): 182.457
     mean vapor pressure deficit (kPa): 1.685
 contexts: .na
 config:
@@ -554,4 +554,3 @@ exclude_observations: .na
 questions:
   additional_traits: There is additional data in Dong_2020 that Ning will make available
     to us later in 2020.
-

--- a/data/Duncan_1998/metadata.yml
+++ b/data/Duncan_1998/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: David H. Duncan
     year: 1998
-    title: 'Unpublished data: Structural basis of variation in leaf mass per area in three plant clades, Macquarie University'
+    title: 'Unpublished data: Structural basis of variation in leaf mass per area
+      in three plant clades, Macquarie University'
 people:
 - name: David Duncan
   institution: Melbourne University
@@ -60,32 +61,32 @@ sites:
     longitude (deg): 150.715
     latitude (deg): -33.617
     description: unknown
-    soil_total_P (ppm): 31
+    soil P, total (mg/kg): 31
   BoxCrossing:
     longitude (deg): 144.848
     latitude (deg): -31.587
     description: unknown
-    soil_total_P (ppm): 101
+    soil P, total (mg/kg): 101
   CastlereaghNR:
     longitude (deg): 150.745
     latitude (deg): -33.683
     description: unknown
-    soil_total_P (ppm): 175
+    soil P, total (mg/kg): 175
   CocoparraNP:
     longitude (deg): 146.22
     latitude (deg): -34.12
     description: unknown
-    soil_total_P (ppm): 105
+    soil P, total (mg/kg): 105
   DennyDF:
     longitude (deg): 146.115
     latitude (deg): -33.936
     description: unknown
-    soil_total_P (ppm): 122
+    soil P, total (mg/kg): 122
   EastCobar:
     longitude (deg): 145.901
     latitude (deg): -31.506
     description: unknown
-    soil_total_P (ppm): 122
+    soil P, total (mg/kg): 122
   GoobangNP1:
     longitude (deg): 148.401
     latitude (deg): -32.942
@@ -106,52 +107,52 @@ sites:
     longitude (deg): 146.556
     latitude (deg): -31.561
     description: unknown
-    soil_total_P (ppm): 441
+    soil P, total (mg/kg): 441
   KCNP_hiP:
     longitude (deg): 151.292
     latitude (deg): -33.579
     description: unknown
-    soil_total_P (ppm): 695
+    soil P, total (mg/kg): 695
   KCNP_loP:
     longitude (deg): 151.143
     latitude (deg): -33.694
     description: unknown
-    soil_total_P (ppm): 105
+    soil P, total (mg/kg): 105
   MacquariePass:
     longitude (deg): 150.656
     latitude (deg): -34.567
     description: unknown
-    soil_total_P (ppm): 607
+    soil P, total (mg/kg): 607
   MortonNP:
     longitude (deg): 150.335
     latitude (deg): -34.779
     description: unknown
-    soil_total_P (ppm): 87
+    soil P, total (mg/kg): 87
   MyallLakesNP2:
     longitude (deg): 152.475
     latitude (deg): -32.423
     description: unknown
-    soil_total_P (ppm): 22
+    soil P, total (mg/kg): 22
   NombinnieNR:
     longitude (deg): 146.004
     latitude (deg): -33.044
     description: unknown
-    soil_total_P (ppm): 175
+    soil P, total (mg/kg): 175
   RoundHillNR:
     longitude (deg): 146.155
     latitude (deg): -32.967
     description: unknown
-    soil_total_P (ppm): 227
+    soil P, total (mg/kg): 227
   ShanesPark:
     longitude (deg): 150.781
     latitude (deg): -33.719
     description: unknown
-    soil_total_P (ppm): 105
+    soil P, total (mg/kg): 105
   Talleeban:
     longitude (deg): 146.464
     latitude (deg): -33.929
     description: unknown
-    soil_total_P (ppm): 175
+    soil P, total (mg/kg): 175
 contexts: .na
 config:
   data_is_long_format: no
@@ -456,4 +457,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Dwyer_2017/metadata.yml
+++ b/data/Dwyer_2017/metadata.yml
@@ -73,97 +73,97 @@ sites:
     latitude (deg): -32.39621
     longitude (deg): 118.38705
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 15.31
-    soil P: 6.07
-    soil K: 111.64
+    soil N, total (%): 15.31
+    soil P, total: 6.07
+    soil K (mg/kg): 111.64
     soil pH: 5.52
   buntine:
     latitude (deg): -29.97383
     longitude (deg): 116.58449
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 11.4
-    soil P: 2.13
-    soil K: 148.18
+    soil N, total (%): 11.4
+    soil P, total: 2.13
+    soil K (mg/kg): 148.18
     soil pH: 5.79
   camelsoak:
     latitude (deg): -29.41817
     longitude (deg): 116.61992
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 7.14
-    soil P: 3.84
-    soil K: 147.44
+    soil N, total (%): 7.14
+    soil P, total: 3.84
+    soil K (mg/kg): 147.44
     soil pH: 5.87
   kunjin:
     latitude (deg): -32.3556
     longitude (deg): 117.76057
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 14.31
-    soil P: 5.0
-    soil K: 64.53
+    soil N, total (%): 14.31
+    soil P, total: 5.0
+    soil K (mg/kg): 64.53
     soil pH: 5.28
   mn10:
     latitude (deg): -31.23751
     longitude (deg): 118.40677
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 26.42
-    soil P: 3.16
-    soil K: 304.02
+    soil N, total (%): 26.42
+    soil P, total: 3.16
+    soil K (mg/kg): 304.02
     soil pH: 5.59
   nam:
     latitude (deg): -31.18729
     longitude (deg): 117.19027
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 32.46
-    soil P: 3.8
-    soil K: 75.38
+    soil N, total (%): 32.46
+    soil P, total: 3.8
+    soil K (mg/kg): 75.38
     soil pH: 4.99
   perenjori:
     latitude (deg): -29.47803
     longitude (deg): 116.20386
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 7.11
-    soil P: 3.87
-    soil K: 258.02
+    soil N, total (%): 7.11
+    soil P, total: 3.87
+    soil K (mg/kg): 258.02
     soil pH: 5.88
   quair:
     latitude (deg): -32.02246
     longitude (deg): 117.37704
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 6.66
-    soil P: 4.89
-    soil K: 134.38
+    soil N, total (%): 6.66
+    soil P, total: 4.89
+    soil K (mg/kg): 134.38
     soil pH: 5.54
   solomon:
     latitude (deg): -29.33558
     longitude (deg): 116.3667
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 8.64
-    soil P: 6.31
-    soil K: 348.49
+    soil N, total (%): 8.64
+    soil P, total: 6.31
+    soil K (mg/kg): 348.49
     soil pH: 6.31
   stokes:
     latitude (deg): -29.38087
     longitude (deg): 115.66232
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 6.61
-    soil P: 5.38
-    soil K: 399.16
+    soil N, total (%): 6.61
+    soil P, total: 5.38
+    soil K (mg/kg): 399.16
     soil pH: 5.91
   white:
     latitude (deg): -31.07996
     longitude (deg): 116.81925
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 7.13
-    soil P: 5.53
-    soil K: 127.07
+    soil N, total (%): 7.13
+    soil P, total: 5.53
+    soil K (mg/kg): 127.07
     soil pH: 5.59
   yandi:
     latitude (deg): -29.26923
     longitude (deg): 115.57293
     description: York gum (Eucalyptus loxophleba)-jam (Acacia acuminata) woodlands
-    total soil N (%): 4.53
-    soil P: 4.36
-    soil K: 356.2
+    soil N, total (%): 4.53
+    soil P, total: 4.36
+    soil K (mg/kg): 356.2
     soil pH: 5.82
 contexts: .na
 config:
@@ -273,4 +273,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Dwyer_2018/metadata.yml
+++ b/data/Dwyer_2018/metadata.yml
@@ -43,7 +43,7 @@ sites:
   Bulli State Forest:
     latitude (deg): -28.036347
     longitude (deg): 150.92267
-    rainfall (mm): 625
+    precipitation, MAP (mm): 625
     description: Brigalow refers to Acacia harpophylla, a long-lived Acacia growing
       to 25m under optimal conditions (Boland et al. 1992), and to the open forests
       and woodlands in which A. harpophylla is a characteristic species. Lower layers
@@ -96,4 +96,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Eamus_1998/metadata.yml
+++ b/data/Eamus_1998/metadata.yml
@@ -37,7 +37,7 @@ sites:
   Berrimah:
     latitude (deg): -12.4339
     longitude (deg): 130.9228
-    rainfall (mm): 1600
+    precipitation, MAP (mm): 1600
     description: Vegetation is open forest (sensu Specht 1981) dominated by Eucalyptus
       tetrodonta F. Muell. and E. miniata A. Cunn. ex Schauer with sub-canopy dominants
       mostly comprised of Erythrophleum chlorystachys (F. Muell.) Baillon, Xanthostemum
@@ -295,4 +295,3 @@ exclude_observations: .na
 questions:
   additional_traits: ash content, lipid content, heat of combustion; there should
     be data for leaf area and leaf lifespan, but not in manuscript tables
-

--- a/data/Eamus_1999/metadata.yml
+++ b/data/Eamus_1999/metadata.yml
@@ -55,7 +55,7 @@ sites:
   Solar Village:
     latitude (deg): -12.5753
     longitude (deg): 131.1022
-    rainfall (mm): 1600
+    precipitation, MAP (mm): 1600
     description: The study was conducted at Solar Village (12 deg 37' S, 131 deg 10'
       E), 35 km southeast of Darwin, Australia. Vegetation is open forest (sensu Specht
       1981) dominated by Eucalyptus tetrodonta F. Muell. and E. miniata A. Cunn. ex
@@ -201,4 +201,3 @@ questions:
   additional_traits: Measurements were made on 7 replicate individuals per species
     on 6 occasions over 1.5 years. We have only the mean value for wet-season gas
     exchange.
-

--- a/data/Edwards_2000/metadata.yml
+++ b/data/Edwards_2000/metadata.yml
@@ -52,14 +52,17 @@ dataset:
     from sunlit branches. The acacia foliage comprises phyllodes but these are referred
     to as leaves for simplicity.
   original_file: Read_WilsonsProm.xls
-  notes: Punch test values for Goodenia ovata and Bedfordia salicina have been removed, as the authors had difficulty measuring values for the thinnest, softest leaves at that time and believe these values should be used in broader comparative studies. The values are in the data.csv file but have been excluded from AusTraits.
+  notes: Punch test values for Goodenia ovata and Bedfordia salicina have been removed,
+    as the authors had difficulty measuring values for the thinnest, softest leaves
+    at that time and believe these values should be used in broader comparative studies.
+    The values are in the data.csv file but have been excluded from AusTraits.
 sites:
   ReadWilsonsProm_forest:
     latitude (deg): -39.01667
     longitude (deg): 146.3333
-    soil_total_P (ppm): 410
-    soil_total_N (%): 0.31
-    rainfall (mm): 1000
+    soil P, total (mg/kg): 410
+    soil N, total (%): 0.31
+    precipitation, MAP (mm): 1000
     description: Leaves were collected in November 1995 from Lilly Pilly Gully at
       Wilson's Promontory National Park in the far south-eastern Australian mainland
       (39 deg 1'S, 146 deg 0'E). The climate is relatively mild with few extremes
@@ -78,14 +81,14 @@ sites:
       and the forest on sands derived from granite, the latter commonly with more
       clay and organic matter (PARSONS, 1966) and in this study with higher levels
       of phosphorus and exchangeable cations (Table 2).
-    lat_lon_explanation: The lat/longs given is the mid-point of the area used for
-      sample collection.
+    lat/lon notes: The lat/longs given is the mid-point of the area used for sample
+      collection.
   ReadWilsonsProm_heath:
     latitude (deg): -39.01667
     longitude (deg): 146.3333
-    soil_total_P (ppm): 90
-    soil_total_N (%): 0.4
-    rainfall (mm): 1000
+    soil P, total (mg/kg): 90
+    soil N, total (%): 0.4
+    precipitation, MAP (mm): 1000
     description: Leaves were collected in November 1995 from Lilly Pilly Gully at
       Wilson's Promontory National Park in the far south-eastern Australian mainland
       (39 deg 1'S, 146 deg 20'E). The climate is relatively mild with few extremes
@@ -104,8 +107,8 @@ sites:
       and the forest on sands derived from granite, the latter commonly with more
       clay and organic matter (PARSONS, 1966) and in this study with higher levels
       of phosphorus and exchangeable cations (Table 2).
-    lat_lon_explanation: The lat/longs given is the mid-point of the area used for
-      sample collection.
+    lat/lon notes: The lat/longs given is the mid-point of the area used for sample
+      collection.
 contexts: .na
 config:
   data_is_long_format: no
@@ -594,5 +597,5 @@ taxonomic_updates:
   reason: Alignment with existing species identified by TaxonStand (2020-05-14)
 exclude_observations: .na
 questions:
-  additional_traits: there are also various measures of leaf strength, measured through punching, tearing, shearing
-
+  additional_traits: there are also various measures of leaf strength, measured through
+    punching, tearing, shearing

--- a/data/Edwards_2000/metadata.yml
+++ b/data/Edwards_2000/metadata.yml
@@ -81,7 +81,7 @@ sites:
       and the forest on sands derived from granite, the latter commonly with more
       clay and organic matter (PARSONS, 1966) and in this study with higher levels
       of phosphorus and exchangeable cations (Table 2).
-    lat/lon notes: The lat/longs given is the mid-point of the area used for sample
+    georeference remarks: The lat/longs given is the mid-point of the area used for sample
       collection.
   ReadWilsonsProm_heath:
     latitude (deg): -39.01667
@@ -107,7 +107,7 @@ sites:
       and the forest on sands derived from granite, the latter commonly with more
       clay and organic matter (PARSONS, 1966) and in this study with higher levels
       of phosphorus and exchangeable cations (Table 2).
-    lat/lon notes: The lat/longs given is the mid-point of the area used for sample
+    georeference remarks: The lat/longs given is the mid-point of the area used for sample
       collection.
 contexts: .na
 config:

--- a/data/Falster_2003/metadata.yml
+++ b/data/Falster_2003/metadata.yml
@@ -69,19 +69,19 @@ sites:
     latitude (deg): -33.57889
     longitude (deg): 151.2922
     description: fire-sensitive closed forest, with an overstorey to 20 m
-    soil total P (mg/kg): 440
-    MAP (mm): 1220
-    soils: weathered volcanic dyke
-    LAI: low
+    soil P, total (mg/kg): 440
+    precipitation, MAP (mm): 1220
+    geology (parent material): weathered volcanic dyke
+    leaf area index: low
   Ku-ring-gai Chase National Park low nutrient:
     latitude (deg): -33.69389
     longitude (deg): 151.1431
     description: fire-prone low open sclerophyll woodland with a species rich understorey
       of woody shrubs
-    soil total P (mg/kg): 94
-    MAP (mm): 1220
-    soils: derived from Hawkesbury Sandstone
-    LAI: medium
+    soil P, total (mg/kg): 94
+    precipitation, MAP (mm): 1220
+    geology (parent material): derived from Hawkesbury Sandstone
+    leaf area index: medium
 contexts: .na
 config:
   data_is_long_format: no
@@ -284,4 +284,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Falster_2005_1/metadata.yml
+++ b/data/Falster_2005_1/metadata.yml
@@ -43,13 +43,13 @@ sites:
     elevation (m): 800
     latitude (deg): -17.1166667
     longitude (deg): 145.65
-    rainfall (mm): 2000
+    precipitation, MAP (mm): 2000
   Cape Tribulation:
     description: Complex mesophyll vine forest in tropical rain forest.
     elevation (m): 25
     latitude (deg): -16.1
     longitude (deg): 145.45
-    rainfall (mm): 3500
+    precipitation, MAP (mm): 3500
 contexts: .na
 config:
   data_is_long_format: no
@@ -292,4 +292,3 @@ taxonomic_updates:
   reason: Align to name in APC (D Falster, 2020.05.23)
 exclude_observations: .na
 questions: .na
-

--- a/data/Falster_2005_2/metadata.yml
+++ b/data/Falster_2005_2/metadata.yml
@@ -44,7 +44,7 @@ sites:
     latitude (deg): -32.68
     longitude (deg): 152.15
     elevation (m): 50
-    rainfall (mm): 1352
+    precipitation, MAP (mm): 1352
     description: The study was conducted in low-open sclerophyll forest situated in
       Myall Lakes National Park in southeastern Australia. Annual precipitation is
       moderate (1352 mm, 105 year average, Sugarloaf point), with some rain in all
@@ -311,4 +311,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Firn_2019/metadata.yml
+++ b/data/Firn_2019/metadata.yml
@@ -57,49 +57,49 @@ sites:
   Bogong:
     latitude (deg): -36.874
     longitude (deg): 147.254
-    MAT (C): 5.7
-    temperature variation: 47.59
-    MAP (mm): 1592.0
-    precipitaqtion variation: 26.0
+    temperature, MAT (C): 5.7
+    temperature variation (C): 47.59
+    precipitation, MAP (mm): 1592.0
+    precipitation, variation: 26.0
     elevation (m): 1760
-    soil_total_N (%): 0.722
-    soil_total_P (ppm): 43
-    soil_total_K (ppm): 193
+    soil N, total (%): 0.722
+    soil P, total (mg/kg): 43
+    soil K (mg/kg): 193
     description: Alpine grassland.
   Burrawan:
     latitude (deg): -27.7348
     longitude (deg): 151.1395
-    MAT (C): 18.4
-    temperature variation: 50.49
-    MAP (mm): 683.0
-    precipitaqtion variation: 36.0
-    soil_total_N (%): 0.085
-    soil_total_P (ppm): 21
-    soil_total_K (ppm): 79
+    temperature, MAT (C): 18.4
+    temperature variation (C): 50.49
+    precipitation, MAP (mm): 683.0
+    precipitation, variation: 36.0
+    soil N, total (%): 0.085
+    soil P, total (mg/kg): 21
+    soil K (mg/kg): 79
     elevation (m): 425
     description: Semi arid grassland.
   Kinypanial:
     latitude (deg): -36.2
     longitude (deg): 143.75
-    MAT (C): 15.5
-    temperature variation: 49.26
-    MAP (mm): 426.0
-    precipitaqtion variation: 21.0
-    soil_total_N (%): 0.12
-    soil_total_P (ppm): 11
-    soil_total_K (ppm): 677
+    temperature, MAT (C): 15.5
+    temperature variation (C): 49.26
+    precipitation, MAP (mm): 426.0
+    precipitation, variation: 21.0
+    soil N, total (%): 0.12
+    soil P, total (mg/kg): 11
+    soil K (mg/kg): 677
     elevation (m): 90
     description: Semi arid grassland.
   Mt. Caroline:
     latitude (deg): -31.7821
     longitude (deg): 117.6108
-    MAT (C): 17.3
-    temperature variation: 52.55
-    MAP (mm): 330.0
-    precipitaqtion variation: 55.0
-    soil_total_N (%): 0.09
-    soil_total_P (ppm): 9
-    soil_total_K (ppm): 190
+    temperature, MAT (C): 17.3
+    temperature variation (C): 52.55
+    precipitation, MAP (mm): 330.0
+    precipitation, variation: 55.0
+    soil N, total (%): 0.09
+    soil P, total (mg/kg): 9
+    soil K (mg/kg): 190
     elevation (m): 285
     description: Savanna grassland.
 contexts:
@@ -238,4 +238,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (known names) (2020-06-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Fonseca_2000/metadata.yml
+++ b/data/Fonseca_2000/metadata.yml
@@ -103,454 +103,465 @@ sites:
     longitude (deg): 142.071
     latitude (deg): -31.817
     elevation (m): 150
-    soil_total_P (ppm): 330
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 330
+    soil N, total (ppm): 0.06
     description: shrubland
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 206
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 206
   Balranald:
     longitude (deg): 143.596
     latitude (deg): -34.356
     elevation (m): 60
-    soil_total_P (ppm): 242
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 242
+    soil N, total (ppm): 0.06
     description: shrubland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 288
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 288
   Bola Creek:
     longitude (deg): 151.033
     latitude (deg): -34.15
     elevation (m): 50
-    soil_total_P (ppm): 650
+    soil P, total (mg/kg): 650
     description: rainforest
-    geology: Triassic - Massive quartz sanstone, minor shale lenses (Rh)
-    rainfall (mm): 1229
+    geology (parent material): Triassic - Massive quartz sanstone, minor shale lenses
+      (Rh)
+    precipitation, MAP (mm): 1229
   Brummagen Creek:
     longitude (deg): 148.363
     latitude (deg): -32.239
     elevation (m): 300
-    soil_total_P (ppm): 431
-    soil_total_N (ppm): 0.08
+    soil P, total (mg/kg): 431
+    soil N, total (ppm): 0.08
     description: woodland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 527
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 527
   Burbie:
     longitude (deg): 148.979
     latitude (deg): -31.291
     elevation (m): 550
-    soil_total_P (ppm): 316
-    soil_total_N (ppm): 0.2
+    soil P, total (mg/kg): 316
+    soil N, total (ppm): 0.2
     description: woodland
-    geology: Tertiary - Basaltic dolerite, minor trachyte, teschenite, phonolite,
-      andesite flows, plugs and sills,minor tuff, breccia, diatomite (Tb)
-    rainfall (mm): 630
+    geology (parent material): Tertiary - Basaltic dolerite, minor trachyte, teschenite,
+      phonolite, andesite flows, plugs and sills,minor tuff, breccia, diatomite (Tb)
+    precipitation, MAP (mm): 630
   Cedar Brush:
     longitude (deg): 150.686
     latitude (deg): -31.851
     elevation (m): 800
-    soil_total_P (ppm): 2063
-    soil_total_N (ppm): 0.45
+    soil P, total (mg/kg): 2063
+    soil N, total (ppm): 0.45
     description: rainforest
-    geology: Tertiary - Basalt, dolerite, polymictic conglomerate, quartzose sandstone,
-      shale, bole (Tl)
-    rainfall (mm): 863
+    geology (parent material): Tertiary - Basalt, dolerite, polymictic conglomerate,
+      quartzose sandstone, shale, bole (Tl)
+    precipitation, MAP (mm): 863
   Cobar:
     longitude (deg): 145.798
     latitude (deg): -31.51
     elevation (m): 250
-    soil_total_P (ppm): 407
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 407
+    soil N, total (ppm): 0.06
     description: tall shrubland
-    geology: Silurian - Feldspathic and lithic greywacke, siltstone, mudstone, argillaceous
-      and quartzitic sandstone, basalt quartz pebble conglomerate (Slc)
-    rainfall (mm): 341
+    geology (parent material): Silurian - Feldspathic and lithic greywacke, siltstone,
+      mudstone, argillaceous and quartzitic sandstone, basalt quartz pebble conglomerate
+      (Slc)
+    precipitation, MAP (mm): 341
   Coffs Harbour:
     longitude (deg): 152.972
     latitude (deg): -30.321
     elevation (m): 195
-    soil_total_P (ppm): 249
-    soil_total_N (ppm): 0.39
+    soil P, total (mg/kg): 249
+    soil N, total (ppm): 0.39
     description: wet sclerophyll forest
-    geology: Devonian - Siliceous argilite, slate, minor siliceous greywacke (Db)
-    rainfall (mm): 2034
+    geology (parent material): Devonian - Siliceous argilite, slate, minor siliceous
+      greywacke (Db)
+    precipitation, MAP (mm): 2034
   Copeland:
     longitude (deg): 151.816
     latitude (deg): -31.982
     elevation (m): 520
-    soil_total_P (ppm): 753
+    soil P, total (mg/kg): 753
     description: dry sclerophyll forest
-    geology: Devonian - Laminated siltstone, sandstone, minor limestone (Do)
-    rainfall (mm): 1291
+    geology (parent material): Devonian - Laminated siltstone, sandstone, minor limestone
+      (Do)
+    precipitation, MAP (mm): 1291
   Copper Mine:
     longitude (deg): 142.585
     latitude (deg): -30.852
     elevation (m): 300
-    soil_total_P (ppm): 276
-    soil_total_N (ppm): 0.08
+    soil P, total (mg/kg): 276
+    soil N, total (ppm): 0.08
     description: shrubland
-    geology: Carpentarian - Phyllite, shale, chert, quartz muscovite schist (co)
-    rainfall (mm): 241
+    geology (parent material): Carpentarian - Phyllite, shale, chert, quartz muscovite
+      schist (co)
+    precipitation, MAP (mm): 241
   Cox's Gap:
     longitude (deg): 150.267
     latitude (deg): -32.45
     elevation (m): 300
-    soil_total_P (ppm): 247
-    soil_total_N (ppm): 0.15
+    soil P, total (mg/kg): 247
+    soil N, total (ppm): 0.15
     description: woodland
-    geology: Permian - Sandstone, shale, conglomerate, coal (Pus)
-    rainfall (mm): 575
+    geology (parent material): Permian - Sandstone, shale, conglomerate, coal (Pus)
+    precipitation, MAP (mm): 575
   Cumberland:
     longitude (deg): 151.039
     latitude (deg): -33.746
     elevation (m): 120
-    soil_total_P (ppm): 216
+    soil P, total (mg/kg): 216
     description: wet sclerophyll forest
-    geology: Triassic - Shale, lithic sandstone (Rw)
-    rainfall (mm): 1064
+    geology (parent material): Triassic - Shale, lithic sandstone (Rw)
+    precipitation, MAP (mm): 1064
   Danu:
     longitude (deg): 148.994
     latitude (deg): -31.317
     elevation (m): 600
-    soil_total_P (ppm): 179
-    soil_total_N (ppm): 0.32
+    soil P, total (mg/kg): 179
+    soil N, total (ppm): 0.32
     description: woodland
-    geology: Tertiary - Basaltic dolerite, minor trachyte, teschenite, phonolite,
-      andesite flows, plugs and sills,minor tuff, breccia, diatomite (Tb)
-    rainfall (mm): 639
+    geology (parent material): Tertiary - Basaltic dolerite, minor trachyte, teschenite,
+      phonolite, andesite flows, plugs and sills,minor tuff, breccia, diatomite (Tb)
+    precipitation, MAP (mm): 639
   Dolo Hills:
     longitude (deg): 142.674
     latitude (deg): -31.726
     elevation (m): 150
-    soil_total_P (ppm): 253
-    soil_total_N (ppm): 0.05
+    soil P, total (mg/kg): 253
+    soil N, total (ppm): 0.05
     description: tall shrubland
-    geology: Carpentarian - Phyllite, shale, chert, quartz muscovite schist (Co)
-    rainfall (mm): 222
+    geology (parent material): Carpentarian - Phyllite, shale, chert, quartz muscovite
+      schist (Co)
+    precipitation, MAP (mm): 222
   Emmdale:
     longitude (deg): 144.225
     latitude (deg): -31.682
     elevation (m): 123
-    soil_total_P (ppm): 123
-    soil_total_N (ppm): 0.04
+    soil P, total (mg/kg): 123
+    soil N, total (ppm): 0.04
     description: cypress pine
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 250
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 250
   Hermidale:
     longitude (deg): 146.504
     latitude (deg): -31.562
     elevation (m): 250
-    soil_total_P (ppm): 454
-    soil_total_N (ppm): 0.09
+    soil P, total (mg/kg): 454
+    soil N, total (ppm): 0.09
     description: woodland
-    geology: Ordovician - Schist, phyllite, quartz greywacke, quartzite, slate, minor
-      altered basic volcanics (yg)
-    rainfall (mm): 389
+    geology (parent material): Ordovician - Schist, phyllite, quartz greywacke, quartzite,
+      slate, minor altered basic volcanics (yg)
+    precipitation, MAP (mm): 389
   Honeysuckle:
     longitude (deg): 150.268
     latitude (deg): -32.399
     elevation (m): 230
-    soil_total_P (ppm): 246
-    soil_total_N (ppm): 0.32
+    soil P, total (mg/kg): 246
+    soil N, total (ppm): 0.32
     description: dry sclerophyll forest
-    geology: Triassic - Massive quartzose sandstone, flaggy sandstone, siltstone,
-      shale (Rs)
-    rainfall (mm): 552
+    geology (parent material): Triassic - Massive quartzose sandstone, flaggy sandstone,
+      siltstone, shale (Rs)
+    precipitation, MAP (mm): 552
   Kalyanka Creek:
     longitude (deg): 143.503
     latitude (deg): -31.46
     elevation (m): 80
-    soil_total_P (ppm): 212
-    soil_total_N (ppm): 0.03
+    soil P, total (mg/kg): 212
+    soil N, total (ppm): 0.03
     description: shrubland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 229
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 229
   Kayrunnera:
     longitude (deg): 142.539
     latitude (deg): -30.673
     elevation (m): 200
-    soil_total_P (ppm): 185
-    soil_total_N (ppm): 0.03
+    soil P, total (mg/kg): 185
+    soil N, total (ppm): 0.03
     description: shrubland
-    geology: Cambrian - Diorite, dolerite, basalt (Ezb)
-    rainfall (mm): 237
+    geology (parent material): Cambrian - Diorite, dolerite, basalt (Ezb)
+    precipitation, MAP (mm): 237
   Kuringai-Chase NP:
     longitude (deg): 151.284
     latitude (deg): -33.586
     elevation (m): 140
-    soil_total_P (ppm): 95
-    soil_total_N (ppm): 0.15
+    soil P, total (mg/kg): 95
+    soil N, total (ppm): 0.15
     description: heathland
-    geology: Triassic - Massive quartz sanstone, minor shale lenses (Rh)
-    rainfall (mm): 1231
+    geology (parent material): Triassic - Massive quartz sanstone, minor shale lenses
+      (Rh)
+    precipitation, MAP (mm): 1231
   Lake Mere:
     longitude (deg): 144.907
     latitude (deg): -30.271
     elevation (m): 100
-    soil_total_P (ppm): 228
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 228
+    soil N, total (ppm): 0.06
     description: tall shrubland
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 269
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 269
   Little Topar:
     longitude (deg): 142.161
     latitude (deg): -31.796
     elevation (m): 150
-    soil_total_P (ppm): 173
-    soil_total_N (ppm): 0.05
+    soil P, total (mg/kg): 173
+    soil N, total (ppm): 0.05
     description: shrubland
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 208
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 208
   Macquarie Pass:
     longitude (deg): 150.656
     latitude (deg): -34.567
     elevation (m): 265
-    soil_total_P (ppm): 754
-    soil_total_N (ppm): 0.46
+    soil P, total (mg/kg): 754
+    soil N, total (ppm): 0.46
     description: rainforest
-    geology: Permian - Lithic sandstone, shale, carbonaceous shale, coal conglomerate
-      tuff (Pui)
-    rainfall (mm): 1578
+    geology (parent material): Permian - Lithic sandstone, shale, carbonaceous shale,
+      coal conglomerate tuff (Pui)
+    precipitation, MAP (mm): 1578
   Matakana:
     longitude (deg): 146.032
     latitude (deg): -33.02
     elevation (m): 160
-    soil_total_P (ppm): 142
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 142
+    soil N, total (ppm): 0.06
     description: mallee
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 369
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 369
   Morton NP:
     longitude (deg): 150.336
     latitude (deg): -34.778
     elevation (m): 315
-    soil_total_P (ppm): 42
-    soil_total_N (ppm): 0.04
+    soil P, total (mg/kg): 42
+    soil N, total (ppm): 0.04
     description: heathland
-    geology: Permian - Lithic sandstone, feldspathic sandstone, sandy mudstone, shale,
-      quartz sandstone, conglomerate, pebbly siltstone, latite flows (Ps)
-    rainfall (mm): 1821
+    geology (parent material): Permian - Lithic sandstone, feldspathic sandstone,
+      sandy mudstone, shale, quartz sandstone, conglomerate, pebbly siltstone, latite
+      flows (Ps)
+    precipitation, MAP (mm): 1821
   Mt Keira:
     longitude (deg): 150.842
     latitude (deg): -34.405
     elevation (m): 330
-    soil_total_P (ppm): 725
-    soil_total_N (ppm): 0.37
+    soil P, total (mg/kg): 725
+    soil N, total (ppm): 0.37
     description: rainforest
-    geology: Permian - Lithic sandstone, shale, carbonaceous shale, coal conglomerate
-      tuff (Pui)
-    rainfall (mm): 1692
+    geology (parent material): Permian - Lithic sandstone, shale, carbonaceous shale,
+      coal conglomerate tuff (Pui)
+    precipitation, MAP (mm): 1692
   Mungo NP 1:
     longitude (deg): 143.086
     latitude (deg): -33.75
     elevation (m): 100
-    soil_total_P (ppm): 365
-    soil_total_N (ppm): 0.07
+    soil P, total (mg/kg): 365
+    soil N, total (ppm): 0.07
     description: shrubland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 271
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 271
   Mungo NP 3:
     longitude (deg): 143.128
     latitude (deg): -33.785
     elevation (m): 100
-    soil_total_P (ppm): 216
-    soil_total_N (ppm): 0.08
+    soil P, total (mg/kg): 216
+    soil N, total (ppm): 0.08
     description: cypress pine
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 272
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 272
   Mungo NP 4:
     longitude (deg): 143.175
     latitude (deg): -33.712
     elevation (m): 100
-    soil_total_P (ppm): 111
-    soil_total_N (ppm): 0.04
+    soil P, total (mg/kg): 111
+    soil N, total (ppm): 0.04
     description: mallee
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 270
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 270
   Myall Lakes:
     longitude (deg): 152.327
     latitude (deg): -32.514
     elevation (m): 15
-    soil_total_P (ppm): 22
-    soil_total_N (ppm): 0.07
+    soil P, total (mg/kg): 22
+    soil N, total (ppm): 0.07
     description: heathland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 1374
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 1374
   Nambucca Heads:
     longitude (deg): 153.002
     latitude (deg): -30.636
     elevation (m): 30
-    soil_total_P (ppm): 152
-    soil_total_N (ppm): 0.22
+    soil P, total (mg/kg): 152
+    soil N, total (ppm): 0.22
     description: wet sclerophyll forest
-    geology: Perminan - Slate, phyllite, schistose sandstone, schistose conglomerate
-      (Pls)
-    rainfall (mm): 1429
+    geology (parent material): Perminan - Slate, phyllite, schistose sandstone, schistose
+      conglomerate (Pls)
+    precipitation, MAP (mm): 1429
   Narriah Mountain:
     longitude (deg): 146.702
     latitude (deg): -33.882
     elevation (m): 350
-    soil_total_P (ppm): 401
-    soil_total_N (ppm): 0.12
+    soil P, total (mg/kg): 401
+    soil N, total (ppm): 0.12
     description: woodland
-    geology: Ordovician - Quartzose greywacke, siltstone, slate chert, quartzite,
-      phyllite, hornfels, schist, sanstone, mudstone, shale (yu)
-    rainfall (mm): 475
+    geology (parent material): Ordovician - Quartzose greywacke, siltstone, slate
+      chert, quartzite, phyllite, hornfels, schist, sanstone, mudstone, shale (yu)
+    precipitation, MAP (mm): 475
   Netallie Hill:
     longitude (deg): 143.26
     latitude (deg): -31.567
     elevation (m): 100
-    soil_total_P (ppm): 259
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 259
+    soil N, total (ppm): 0.06
     description: shrubland
-    geology: Devonian - Quartzite and sandstone, pebbly to conglomeratic in part,
-      shale ans siltstone (Dum)
-    rainfall (mm): 226
+    geology (parent material): Devonian - Quartzite and sandstone, pebbly to conglomeratic
+      in part, shale ans siltstone (Dum)
+    precipitation, MAP (mm): 226
   Nyngan:
     longitude (deg): 147.209
     latitude (deg): -31.521
     elevation (m): 170
-    soil_total_P (ppm): 488
-    soil_total_N (ppm): 0.06
+    soil P, total (mg/kg): 488
+    soil N, total (ppm): 0.06
     description: tall shrubland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 404
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 404
   Ourimbah:
     longitude (deg): 151.292
     latitude (deg): -33.264
     elevation (m): 290
-    soil_total_P (ppm): 40
-    soil_total_N (ppm): 0.05
+    soil P, total (mg/kg): 40
+    soil N, total (ppm): 0.05
     description: heathland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 1251
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 1251
   Purnawilla:
     longitude (deg): 143.467
     latitude (deg): -31.355
     elevation (m): 100
-    soil_total_P (ppm): 269
-    soil_total_N (ppm): 0.05
+    soil P, total (mg/kg): 269
+    soil N, total (ppm): 0.05
     description: shrubland
-    geology: Tertiary - Gravel, sand, clay, poorly consolidated conglomerate, sandstone
-      and siltstone (Ts)
-    rainfall (mm): 230
+    geology (parent material): Tertiary - Gravel, sand, clay, poorly consolidated
+      conglomerate, sandstone and siltstone (Ts)
+    precipitation, MAP (mm): 230
   Rosewood:
     longitude (deg): 146.28
     latitude (deg): -32.948
     elevation (m): 200
-    soil_total_P (ppm): 196
-    soil_total_N (ppm): 0.1
+    soil P, total (mg/kg): 196
+    soil N, total (ppm): 0.1
     description: woodland
-    geology: Silurian - Feldspathic and lithic greywacke, siltstone, mudstone, argillaceous
-      and quartzitic sandstone, basalt quartz pebble conglomerate (Slc)
-    rainfall (mm): 381
+    geology (parent material): Silurian - Feldspathic and lithic greywacke, siltstone,
+      mudstone, argillaceous and quartzitic sandstone, basalt quartz pebble conglomerate
+      (Slc)
+    precipitation, MAP (mm): 381
   South White Cliffs:
     longitude (deg): 143.089
     latitude (deg): -31.084
     elevation (m): 80
-    soil_total_P (ppm): 234
-    soil_total_N (ppm): 0.08
+    soil P, total (mg/kg): 234
+    soil N, total (ppm): 0.08
     description: shrubland
-    geology: Tertiary - Silcrete, ferricrete, porcellanite (Ti)
-    rainfall (mm): 216
+    geology (parent material): Tertiary - Silcrete, ferricrete, porcellanite (Ti)
+    precipitation, MAP (mm): 216
   Strickland:
     longitude (deg): 151.333
     latitude (deg): -33.373
     elevation (m): 120
-    soil_total_P (ppm): 278
+    soil P, total (mg/kg): 278
     description: rainforest
-    geology: Triassic - Massive quartz sanstone, minor shale lenses (Rh)
-    rainfall (mm): 1196
+    geology (parent material): Triassic - Massive quartz sanstone, minor shale lenses
+      (Rh)
+    precipitation, MAP (mm): 1196
   Stuart Point:
     longitude (deg): 152.988
     latitude (deg): -30.837
     elevation (m): 10
-    soil_total_P (ppm): 24
-    soil_total_N (ppm): 0.21
+    soil P, total (mg/kg): 24
+    soil N, total (ppm): 0.21
     description: heathland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 1327
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 1327
   Trangie:
     longitude (deg): 148.037
     latitude (deg): -31.973
     elevation (m): 220
-    soil_total_P (ppm): 408
-    soil_total_N (ppm): 0.14
+    soil P, total (mg/kg): 408
+    soil N, total (ppm): 0.14
     description: woodland
-    geology: Tertiary - Gravel, sand, clay, poorly consolidated conglomerate, sandstone
-      and siltstone (Ts)
-    rainfall (mm): 479
+    geology (parent material): Tertiary - Gravel, sand, clay, poorly consolidated
+      conglomerate, sandstone and siltstone (Ts)
+    precipitation, MAP (mm): 479
   Tundalya:
     longitude (deg): 144.834
     latitude (deg): -30.731
     elevation (m): 90
-    soil_total_P (ppm): 407
-    soil_total_N (ppm): 0.07
+    soil P, total (mg/kg): 407
+    soil N, total (ppm): 0.07
     description: woodland
-    geology: Quaternary - Alluvial and riverine plain deposits of gravel, sand, silt
-      and clay; claypans and outwash areas of black and red clayed silt and sand;
-      coastal sand dunes and beach deposits (Qa)
-    rainfall (mm): 262
+    geology (parent material): Quaternary - Alluvial and riverine plain deposits of
+      gravel, sand, silt and clay; claypans and outwash areas of black and red clayed
+      silt and sand; coastal sand dunes and beach deposits (Qa)
+    precipitation, MAP (mm): 262
   Weddin Mountains:
     longitude (deg): 148.001
     latitude (deg): -33.893
     elevation (m): 400
-    soil_total_P (ppm): 99
-    soil_total_N (ppm): 0.12
+    soil P, total (mg/kg): 99
+    soil N, total (ppm): 0.12
     description: cypress pine
-    geology: Devonian - Sandstone with siltstone, minor conglomerate (Duh)
-    rainfall (mm): 589
+    geology (parent material): Devonian - Sandstone with siltstone, minor conglomerate
+      (Duh)
+    precipitation, MAP (mm): 589
   West Copper Mine:
     longitude (deg): 142.579
     latitude (deg): -30.858
     elevation (m): 250
-    soil_total_P (ppm): 275
-    soil_total_N (ppm): 0.07
+    soil P, total (mg/kg): 275
+    soil N, total (ppm): 0.07
     description: shrubland
-    geology: Cambrian - Diorite, dolerite, basalt (Ezb)
-    rainfall (mm): 232
+    geology (parent material): Cambrian - Diorite, dolerite, basalt (Ezb)
+    precipitation, MAP (mm): 232
   White Cliffs:
     longitude (deg): 143.062
     latitude (deg): -30.907
     elevation (m): 150
-    soil_total_P (ppm): 382
-    soil_total_N (ppm): 0.05
+    soil P, total (mg/kg): 382
+    soil N, total (ppm): 0.05
     description: tall shrubland
-    geology: Cretaceous - Siltstone, sandy shale, minor sandstone, some thin coal
-      seams (Klr)
-    rainfall (mm): 228
+    geology (parent material): Cretaceous - Siltstone, sandy shale, minor sandstone,
+      some thin coal seams (Klr)
+    precipitation, MAP (mm): 228
   Yathong:
     longitude (deg): 145.44
     latitude (deg): -32.59
     elevation (m): 150
-    soil_total_P (ppm): 54
-    soil_total_N (ppm): 0.02
+    soil P, total (mg/kg): 54
+    soil N, total (ppm): 0.02
     description: mallee
-    geology: Quaternary - Flat to gently undulating plains and dunes of red and brown
-      clayed sand, loam and lateritic soils; largely aeolian (Qd)
-    rainfall (mm): 320
+    geology (parent material): Quaternary - Flat to gently undulating plains and dunes
+      of red and brown clayed sand, loam and lateritic soils; largely aeolian (Qd)
+    precipitation, MAP (mm): 320
 contexts: .na
 config:
   data_is_long_format: no
@@ -833,4 +844,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/French_2017/metadata.yml
+++ b/data/French_2017/metadata.yml
@@ -130,7 +130,7 @@ sites:
     latitude (deg): -43.18
     longitude (deg): 145.97
     precipitation, MAP (mm): 2142
-    lat/lon notes: A single approximate value is given for latitude and longitude
+    georeference remarks: A single approximate value is given for latitude and longitude
     description: complex mosaics of sedge-heathland, low sclerophyll scrublands, wet
       eucalypt forest and temperate rainforest
     geology (parent material): highly metamorphosed, nutrient-poor Precambrian basement

--- a/data/French_2017/metadata.yml
+++ b/data/French_2017/metadata.yml
@@ -10,7 +10,7 @@ source:
       wilderness
     volume: '64'
     number: '6'
-    pages: '513--525'
+    pages: 513--525
     doi: 10.1071/bt16087
 people:
 - name: Ben French
@@ -129,17 +129,17 @@ sites:
   Port Davey region:
     latitude (deg): -43.18
     longitude (deg): 145.97
-    MAP (mm): 2142
-    lat-lon notes: A single approximate value is given for latitude and longitude
+    precipitation, MAP (mm): 2142
+    lat/lon notes: A single approximate value is given for latitude and longitude
     description: complex mosaics of sedge-heathland, low sclerophyll scrublands, wet
       eucalypt forest and temperate rainforest
-    geology: highly metamorphosed, nutrient-poor Precambrian basement rocks
-    climate: climate is cool maritime and strongly influenced by elevation
-    soil description: Soils are characterised by an organic layer, typically 20-40
-      cm deep (Brown 2005; Wood et al. 2011) that is underlain by mineral soils, bedrock
-      or quartz gravels. The soils are highly acidic (pH 4.1-4.5) and most of their
-      small nutrient capital is derived from cyclic salts (Bowman et al. 1986; Brown
-      2005).
+    geology (parent material): highly metamorphosed, nutrient-poor Precambrian basement
+      rocks
+    climate description: climate is cool maritime and strongly influenced by elevation
+    soil type: Soils are characterised by an organic layer, typically 20-40 cm deep
+      (Brown 2005; Wood et al. 2011) that is underlain by mineral soils, bedrock or
+      quartz gravels. The soils are highly acidic (pH 4.1-4.5) and most of their small
+      nutrient capital is derived from cyclic salts (Bowman et al. 1986; Brown 2005).
 contexts: .na
 config:
   data_is_long_format: no
@@ -191,4 +191,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Funk_2016/metadata.yml
+++ b/data/Funk_2016/metadata.yml
@@ -44,24 +44,24 @@ sites:
     latitude (deg): -32.04667
     longitude (deg): 115.83639
     description: Banksia woodland
-    Fire frequency (year): '>20'
-    Grazing: Low
-    MAP (mm): 834.0
-    Soil: Bassendean sand
-    Soil N (g N/100g soil): 0.05
-    Soil pH: 5.38
-    Soil total P (mg P/kg soil): 47.7
+    fire frequency (years): '>20'
+    grazing severity: Low
+    precipitation, MAP (mm): 834.0
+    geology (stratigraphic map unit): Bassendean sand
+    soil N, total (g/100g): 0.05
+    soil pH: 5.38
+    soil P, total (mg/kg): 47.7
   Coastal banksia woodland:
     latitude (deg): -31.70778
     longitude (deg): 115.72194
     description: Coastal banksia woodland
-    Fire frequency (year): '>30'
-    Grazing: None
-    MAP (mm): 734.0
-    Soil: Spearwood sand
-    Soil N (g N/100g soil): 0.06
-    Soil pH: 5.74
-    Soil total P (mg P/kg soil): 150.9
+    fire frequency (years): '>30'
+    grazing severity: None
+    precipitation, MAP (mm): 734.0
+    geology (stratigraphic map unit): Spearwood sand
+    soil N, total (g/100g): 0.06
+    soil pH: 5.74
+    soil P, total (mg/kg): 150.9
 contexts: .na
 config:
   data_is_long_format: no
@@ -335,4 +335,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: root depth
-

--- a/data/Gallagher_2018/metadata.yml
+++ b/data/Gallagher_2018/metadata.yml
@@ -8,7 +8,8 @@ source:
       Karen Marais, Loren Pollitt, Luka Kovac, Martin Lambert, Sophia Amini, Tara
       Boreham, Thomas Pyne, Hannah MacPherson, Maurizio Rossetto, Marlien van der
       Merwe, Ian Wright, and Matthew Alfonzetti
-    title: 'Unpublished data: Trait campaign with the Royal Botanical Gardens, Macquarie University'
+    title: 'Unpublished data: Trait campaign with the Royal Botanical Gardens, Macquarie
+      University'
 people:
 - name: Rachael Gallagher
   institution: Department of Biological Sciences, Macquarie University
@@ -83,22 +84,22 @@ sites:
   MOUNT BANKS:
     latitude (deg): -33.57912
     longitude (deg): 150.36555
-    altitude (m): 818.0
+    elevation (m): 818.0
     description: dry sclerophyll vegetation on Triassic sandstone with basalt outcropping
   MOUNT WILSON:
     latitude (deg): -33.54299
     longitude (deg): 150.34431
-    altitude (m): 936.0
+    elevation (m): 936.0
     description: dry sclerophyll vegetation on sandstone substrate
   PATONGA:
     latitude (deg): -33.53835
     longitude (deg): 151.2827
-    altitude (m): 170.0
+    elevation (m): 170.0
     description: dry sclerophyll vegetation on sandstone substrate
   WEST HEAD:
     latitude (deg): -33.58846
     longitude (deg): 151.28337
-    altitude (m): 119.0
+    elevation (m): 119.0
     description: dry sclerophyll vegetation on sandstone substrate
 contexts: .na
 config:
@@ -153,4 +154,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Gardiner_2019/metadata.yml
+++ b/data/Gardiner_2019/metadata.yml
@@ -59,7 +59,7 @@ sites:
   Oxley Creek Common:
     latitude (deg): -27.537659
     longitude (deg): 152.990117
-    rainfall (mm): 1058
+    precipitation, MAP (mm): 1058
     description: The study site is in the inner southern suburbs of Brisbane, Queensland,
       Australia and is known locally as Oxley Creek Common (27 deg 32'S 152 deg 59'E,
       Fig. S1). It is situated on an alluvial floodplain along a section of Oxley
@@ -360,4 +360,3 @@ taxonomic_updates:
   reason: Species code replaced with species name by C. Baxter (2019-09-18)
 exclude_observations: .na
 questions: .na
-

--- a/data/Geange_2017/metadata.yml
+++ b/data/Geange_2017/metadata.yml
@@ -10,7 +10,7 @@ source:
       species along an elevation gradient'
     volume: '4'
     number: '1'
-    pages: '1--12'
+    pages: 1--12
     doi: 10.1186/s40665-017-0033-8
 people:
 - name: Sonya Geange
@@ -76,7 +76,7 @@ sites:
   Australian National University glasshouse:
     latitude (deg): -35.283
     longitude (deg): 149.1167
-    MAP (mm): 622
+    precipitation, MAP (mm): 622
     description: Australian National University glasshouses
 contexts:
   high elevation maternal lineage 10 grown under high water conditions:
@@ -625,4 +625,3 @@ questions:
   question2: Sites can be either the ANU glasshouses or the seed collection locations.
     Which would you prefer? If you want to link values to seed source location, do
     you have them? (For now I've put ANU as a place-holder)
-

--- a/data/Geange_2020/metadata.yml
+++ b/data/Geange_2020/metadata.yml
@@ -10,7 +10,7 @@ source:
       experiment'
     volume: '67'
     number: '8'
-    pages: '599--609'
+    pages: 599--609
     doi: 10.1071/bt19034
 people:
 - name: Sonya Geange
@@ -303,4 +303,3 @@ exclude_observations: .na
 questions:
   additional_traits: ice nucleation temperature (temperature at which ice forms in
     the leaves)
-

--- a/data/Gosper_2012/metadata.yml
+++ b/data/Gosper_2012/metadata.yml
@@ -86,7 +86,7 @@ sites:
     longitude (deg): 119.067
     description: mosaic of mallee, mallee-heath and woodland, with vegetation type
       determined by climate and especially edaphic factors
-    MAP (mm): 354
+    precipitation, MAP (mm): 354
 contexts: .na
 config:
   data_is_long_format: no
@@ -250,4 +250,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-26)
 exclude_observations: .na
 questions: .na
-

--- a/data/Groom_1997/metadata.yml
+++ b/data/Groom_1997/metadata.yml
@@ -242,4 +242,3 @@ exclude_observations: .na
 questions:
   additional_traits: seed wall thickness (all dimensions), fruit density, seed wing
     area, seed wing load ug mm-2
-

--- a/data/Groom_2010/metadata.yml
+++ b/data/Groom_2010/metadata.yml
@@ -49,20 +49,20 @@ dataset:
   collection_type: literature
   sample_age_class: adult
   sampling_strategy: 'Study compares seed P and seed P recycling in Proteaceae species
-    in southwestern Australia and South Africa to address the following exclude_observations: .na
-questions:
-    1. How much shoot and reproductive-structure P is allocated to seeds and what
-    affects the levels? 2. How much P is stored in individual seeds and how does seed
-    P vary with seed size, fire response, level of serotiny, and region? 3. What is
-    the form of P in seeds? 4. Do the data support the hypothesis that P is a limiting
-    resource in these regions? The study uses values from the literature to address
-    these questions. Values are used from: Denton et al. (2007) (data in AusTraits
-    under Denton_2007), Kuo et al. (1982) (data in AusTraits under Kuo_1982), Milberg
-    et al. (1998) (data in AusTraits under Milberg_1998), Stock et al. (1989) (doi.org/10.1111/j.1469-8137.1991.tb00950.x),
-    Hocking (1986) (data in AusTraits under Hocking_1986), Hocking (1982) (data in
-    AusTraits under Hocking_1982), Milberg and Lamont (1997) (data in AusTraits under
-    Milberg_1997), Groom and Lamont (2004), Lamont and Groom (2002) (doi.org/10.1111/nph.13465;
-    data in AusTraits under Lamont_2002), and Pate et al. (1986) (doi.org/10.1093/oxfordjournals.aob.a087159)'
+    in southwestern Australia and South Africa to address the following exclude_observations:
+    .na questions: 1. How much shoot and reproductive-structure P is allocated to
+    seeds and what affects the levels? 2. How much P is stored in individual seeds
+    and how does seed P vary with seed size, fire response, level of serotiny, and
+    region? 3. What is the form of P in seeds? 4. Do the data support the hypothesis
+    that P is a limiting resource in these regions? The study uses values from the
+    literature to address these questions. Values are used from: Denton et al. (2007)
+    (data in AusTraits under Denton_2007), Kuo et al. (1982) (data in AusTraits under
+    Kuo_1982), Milberg et al. (1998) (data in AusTraits under Milberg_1998), Stock
+    et al. (1989) (doi.org/10.1111/j.1469-8137.1991.tb00950.x), Hocking (1986) (data
+    in AusTraits under Hocking_1986), Hocking (1982) (data in AusTraits under Hocking_1982),
+    Milberg and Lamont (1997) (data in AusTraits under Milberg_1997), Groom and Lamont
+    (2004), Lamont and Groom (2002) (doi.org/10.1111/nph.13465; data in AusTraits
+    under Lamont_2002), and Pate et al. (1986) (doi.org/10.1093/oxfordjournals.aob.a087159)'
   original_file: none - extracted data from manuscript
   notes: Values derived from Denton_2007, Kuo_1982, Milberg_1998, Milberg_1997, Hocking_1986,
     and Hocking_1982 have been filtered out, since they are in AusTraits under their
@@ -131,4 +131,3 @@ substitutions:
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Grootemaat_2015/metadata.yml
+++ b/data/Grootemaat_2015/metadata.yml
@@ -82,51 +82,52 @@ sites:
   Kuring-gai NP hiP:
     longitude (deg): 151.2922222
     latitude (deg): -33.5788889
-    description: Kuring-gai National Park, high P site
-    vegetation: Closed forest
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 442.3
-    soil_total_N (%): 0.256
-    soil_total_C (%): 5.91
-    soil_cation_exchange_capacity (meq/kg): 55.6
-    geology: Red-brown clay (weathered volcanic dyke)
+    locality: Kuring-gai National Park, high P site
+    description: Closed forest
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 442.3
+    soil N, total (%): 0.256
+    soil C, total (%): 5.91
+    soil cation exchange capacity (meq/kg): 55.6
+    geology (stratigraphic map unit): Red-brown clay (weathered volcanic dyke)
   Kuring-gai NP lowP:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
-    description: Kuring-gai National Park, low P site
-    vegetation: Low open woodland
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 93.6
-    soil_total_N (%): 0.03
-    soil_total_C (%): 0.95
-    soil_cation_exchange_capacity (meq/kg): 9
-    geology: Yellow-grey sand (Hawkesbury sandstone)
+    locality: Kuring-gai National Park, low P site
+    description: Low open woodland
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 93.6
+    soil N, total (%): 0.03
+    soil C, total (%): 0.95
+    soil cation exchange capacity (meq/kg): 9
+    geology (stratigraphic map unit): Yellow-grey sand (Hawkesbury sandstone)
   Round Hill woodland:
     longitude (deg): 146.1547222
     latitude (deg): -32.9666667
-    description: Round Hill Nature Reserve, woodland site
-    vegetation: Open woodland
-    nutrient summary: loRhiP
-    MAP (mm): 387
-    soil_total_P (ppm): 250.4
-    soil_total_N (%): 0.071
-    soil_total_C (%): 1.2
-    soil_cation_exchange_capacity (meq/kg): 65.8
-    geology: Light red clay (residual deposits overlying Mt Hope volcanics)
+    locality: Round Hill Nature Reserve, woodland site
+    description: Open woodland
+    soil nutrient summary: loRhiP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
+    geology (stratigraphic map unit): Light red clay (residual deposits overlying
+      Mt Hope volcanics)
   Round Hill mallee:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
-    description: Round Hill Nature Reserve, mallee site
-    vegetation: Open shrub mallee
-    nutrient summary: loRloP
-    MAP (mm): 387
-    soil_total_P (ppm): 132.4
-    soil_total_N (%): 0.031
-    soil_total_C (%): 0.67
-    soil_cation_exchange_capacity (meq/kg): 38.7
-    geology: Loamy red sand (Quaternary dune systems)
+    locality: Round Hill Nature Reserve, mallee site
+    description: Open shrub mallee
+    soil nutrient summary: loRloP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
+    geology (stratigraphic map unit): Loamy red sand (Quaternary dune systems)
 contexts:
   DRIED:
     type: field
@@ -441,4 +442,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2021-02-09)
 exclude_observations: .na
 questions: .na
-

--- a/data/Grootemaat_2017_1/metadata.yml
+++ b/data/Grootemaat_2017_1/metadata.yml
@@ -67,32 +67,32 @@ sites:
     latitude (deg): -33.5072222
     longitude (deg): 151.3333
     description: dry sclerophyll forest
-    soils: infertile sandy soil at the interface between Hawkesbury and Narrabeen
-      Sandstones
-    soil_P (mg/kg): 30-80
-    MAT (C): 17
-    MAP (mm): 1332
+    geology (parent material): infertile sandy soil at the interface between Hawkesbury
+      and Narrabeen Sandstones
+    soil P, total (mg/kg): 30-80
+    temperature, MAT (C): 17
+    precipitation, MAP (mm): 1332
     notes: .na
   Bobbin Head:
     latitude (deg): -33.661582
     longitude (deg): 151.149208
     description: dry sclerophyll forest
-    soils: sandy, derived from Hawkesbury sandstone
-    soil_P (mg/kg): 30-80
-    MAT (C): 17
-    MAP (mm): 1332
+    geology (parent material): sandy, derived from Hawkesbury sandstone
+    soil P, total (mg/kg): 30-80
+    temperature, MAT (C): 17
+    precipitation, MAP (mm): 1332
     notes: .na
   West Head:
     latitude (deg): -33.578781
     longitude (deg): 151.304784
     description: dry sclerophyll forest
-    soil_P (mg/kg): 30-80
-    MAT (C): 17
-    MAP (mm): 1332
-    notes: Note, lat/lon values is just one of the sites sampled in the West Head area; the
-      actual sampling occurred at three sites at, -33.578781, 151.304784; -33.619800,
-      151.267429; and -33.651660;, 151.255547.
-    soils: sandy, derived from Hawkesbury sandstone
+    soil P, total (mg/kg): 30-80
+    temperature, MAT (C): 17
+    precipitation, MAP (mm): 1332
+    notes: Note, lat/lon values is just one of the sites sampled in the West Head
+      area; the actual sampling occurred at three sites at, -33.578781, 151.304784;
+      -33.619800, 151.267429; and -33.651660;, 151.255547.
+    geology (parent material): sandy, derived from Hawkesbury sandstone
 contexts:
   BARK:
     type: field
@@ -835,13 +835,14 @@ traits:
   trait_name: .na
   value_type: raw_value
   replicates: '1'
-  methods: leaf_water_content_per_dry_mass - not included because the water content of senesced leaves; Standard protocols were followed for measuring leaf length (mm), effective
-    leaf width (mm), thickness (mm) and mass (g) (Perez-Harguindeguy et al. 2013).
-    Subsamples for fuel moisture content (FMC) were held apart; leaves were measured
-    at their actual weight and remeasured after 24 h of drying at 105 deg C, when
-    equilibrium was reached (Matthews 2010). Fuel moisture content, as a percentage
-    of oven dried weight, was then defined as follows, (leaf mass - leaf dry mass)/(leaf
-    dry mass)*100
+  methods: leaf_water_content_per_dry_mass - not included because the water content
+    of senesced leaves; Standard protocols were followed for measuring leaf length
+    (mm), effective leaf width (mm), thickness (mm) and mass (g) (Perez-Harguindeguy
+    et al. 2013). Subsamples for fuel moisture content (FMC) were held apart; leaves
+    were measured at their actual weight and remeasured after 24 h of drying at 105
+    deg C, when equilibrium was reached (Matthews 2010). Fuel moisture content, as
+    a percentage of oven dried weight, was then defined as follows, (leaf mass - leaf
+    dry mass)/(leaf dry mass)*100
 - var_in: Leaf dry mass (g)
   unit_in: g
   trait_name: leaf_dry_mass
@@ -970,4 +971,3 @@ questions:
     traits measuring bark strength (MaxFlexLoad and MFLperTHICKN), bark flammability,
     energy content (leaf and bark) and mass loss (decomposition data) that are not
     yet traits in AusTraits
-

--- a/data/Grootemaat_2017_2/metadata.yml
+++ b/data/Grootemaat_2017_2/metadata.yml
@@ -73,51 +73,52 @@ sites:
   Kuring-gai NP hiP:
     longitude (deg): 151.2922222
     latitude (deg): -33.5788889
-    description: Kuring-gai National Park, high P site
-    vegetation: Closed forest
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 442.3
-    soil_total_N (%): 0.256
-    soil_total_C (%): 5.91
-    soil_cation_exchange_capacity (meq/kg): 55.6
-    geology: Red-brown clay (weathered volcanic dyke)
+    locality: Kuring-gai National Park, high P site
+    description: Closed forest
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 442.3
+    soil N, total (%): 0.256
+    soil C, total (%): 5.91
+    soil cation exchange capacity (meq/kg): 55.6
+    geology (stratigraphic map unit): Red-brown clay (weathered volcanic dyke)
   Kuring-gai NP lowP:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
-    description: Kuring-gai National Park, low P site
-    vegetation: Low open woodland
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 93.6
-    soil_total_N (%): 0.03
-    soil_total_C (%): 0.95
-    soil_cation_exchange_capacity (meq/kg): 9
-    geology: Yellow-grey sand (Hawkesbury sandstone)
+    locality: Kuring-gai National Park, low P site
+    description: Low open woodland
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 93.6
+    soil N, total (%): 0.03
+    soil C, total (%): 0.95
+    soil cation exchange capacity (meq/kg): 9
+    geology (stratigraphic map unit): Yellow-grey sand (Hawkesbury sandstone)
   Round Hill woodland:
     longitude (deg): 146.1547222
     latitude (deg): -32.9666667
-    description: Round Hill Nature Reserve, woodland site
-    vegetation: Open woodland
-    nutrient summary: loRhiP
-    MAP (mm): 387
-    soil_total_P (ppm): 250.4
-    soil_total_N (%): 0.071
-    soil_total_C (%): 1.2
-    soil_cation_exchange_capacity (meq/kg): 65.8
-    geology: Light red clay (residual deposits overlying Mt Hope volcanics)
+    locality: Round Hill Nature Reserve, woodland site
+    description: Open woodland
+    soil nutrient summary: loRhiP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
+    geology (stratigraphic map unit): Light red clay (residual deposits overlying
+      Mt Hope volcanics)
   Round Hill mallee:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
-    description: Round Hill Nature Reserve, mallee site
-    vegetation: Open shrub mallee
-    nutrient summary: loRloP
-    MAP (mm): 387
-    soil_total_P (ppm): 132.4
-    soil_total_N (%): 0.031
-    soil_total_C (%): 0.67
-    soil_cation_exchange_capacity (meq/kg): 38.7
-    geology: Loamy red sand (Quaternary dune systems)
+    locality: Round Hill Nature Reserve, mallee site
+    description: Open shrub mallee
+    soil nutrient summary: loRloP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
+    geology (stratigraphic map unit): Loamy red sand (Quaternary dune systems)
 contexts:
   dried:
     type: field
@@ -434,4 +435,3 @@ questions:
     bed properties that are not yet in AusTraits, the rate of spread, the fuel bed
     density, the fuel bed packing ratio, and the point burning time. (Note to AusTraits
     data processors)
-

--- a/data/Grubb_2008/metadata.yml
+++ b/data/Grubb_2008/metadata.yml
@@ -41,13 +41,13 @@ sites:
     longitude (deg): 145.4333333
     latitude (deg): -17.3
     elevation (m): 750
-    rainfall (mm): 1400
+    precipitation, MAP (mm): 1400
     description: tropical lowland rainforest
   Wooroonooran National Park:
     longitude (deg): 145.7166667
     latitude (deg): -17.3833333
     elevation (m): 800
-    rainfall (mm): 3500
+    precipitation, MAP (mm): 3500
     description: tropical lowland rainforest
 contexts: .na
 config:
@@ -116,4 +116,3 @@ exclude_observations:
   find: Ptychanthus racemiger
   reason: moss (E Wenk, 2020.06.18)
 questions: .na
-

--- a/data/Guilherme_Pereira_2018/metadata.yml
+++ b/data/Guilherme_Pereira_2018/metadata.yml
@@ -56,41 +56,41 @@ dataset:
   notes: none
 sites:
   Quindalup Old:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.1911676
     longitude (deg): 115.0593393
-    total P (mg/kg): 286.0
+    soil P, total (mg/kg): 286.0
     resin P (mg/mg): 1.22
-    Ca (mg/kg): 2332.0
-    Al (mg/kg): 1.2
-    CEC (cmol/kg): 12.6
-    pH (H2O): 8.6
-    geological formation: Safety Bay Sand
-    parent material: Calcareous sand
+    soil Ca (mg/kg): 2332.0
+    soil Al (mg/kg): 1.2
+    soil cation exchange capacity (cmol/kg): 12.6
+    soil pH (H2O): 8.6
+    geology (stratigraphic map unit): Safety Bay Sand
+    geology (parent material): Calcareous sand
   Quindalup Young:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.407139
     longitude (deg): 115.081852
-    total P (mg/kg): 350.0
+    soil P, total (mg/kg): 350.0
     resin P (mg/mg): 1.42
-    Ca (mg/kg): 4617.0
-    Al (mg/kg): 0.0
-    CEC (cmol/kg): 24.9
-    pH (H2O): 9.3
-    geological formation: Safety Bay Sand
-    parent material: Calcareous sand
+    soil Ca (mg/kg): 4617.0
+    soil Al (mg/kg): 0.0
+    soil cation exchange capacity (cmol/kg): 24.9
+    soil pH (H2O): 9.3
+    geology (stratigraphic map unit): Safety Bay Sand
+    geology (parent material): Calcareous sand
   Spearwood West:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.1920924
     longitude (deg): 115.0630152
-    total P (mg/kg): 22.0
+    soil P, total (mg/kg): 22.0
     resin P (mg/mg): 1.07
-    Ca (mg/kg): 738.0
-    Al (mg/kg): 0.9
-    CEC (cmol/kg): 4.3
-    pH (H2O): 6.6
-    geological formation: Tamala Limestone
-    parent material: Calcareous sand
+    soil Ca (mg/kg): 738.0
+    soil Al (mg/kg): 0.9
+    soil cation exchange capacity (cmol/kg): 4.3
+    soil pH (H2O): 6.6
+    geology (stratigraphic map unit): Tamala Limestone
+    geology (parent material): Calcareous sand
 contexts: .na
 config:
   data_is_long_format: no
@@ -156,4 +156,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Guilherme_Pereira_2019/metadata.yml
+++ b/data/Guilherme_Pereira_2019/metadata.yml
@@ -56,48 +56,48 @@ dataset:
   notes: .na
 sites:
   Quindalup Old:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.1911676
     longitude (deg): 115.0593393
-    total P (mg/kg): 286.0
+    soil P, total (mg/kg): 286.0
     resin P (mg/mg): 1.22
-    Ca (mg/kg): 2332.0
-    Al (mg/kg): 1.2
-    CEC (cmol/kg): 12.6
-    pH (H2O): 8.6
-    geological formation: Safety Bay Sand
-    parent material: Calcareous sand
-    stage: stage 3
+    soil Ca (mg/kg): 2332.0
+    soil Al (mg/kg): 1.2
+    soil cation exchange capacity (cmol/kg): 12.6
+    soil pH (H2O): 8.6
+    geology (stratigraphic map unit): Safety Bay Sand
+    geology (parent material): Calcareous sand
+    choronosequence stage: stage 3
     notes: measurements made at a site designated as "Quindalup Old" from Laliberte_2012,
       but the coordinates used as approximate
   Quindalup Young:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.407139
     longitude (deg): 115.081852
-    total P (mg/kg): 350.0
+    soil P, total (mg/kg): 350.0
     resin P (mg/mg): 1.42
-    Ca (mg/kg): 4617.0
-    Al (mg/kg): 0.0
-    CEC (cmol/kg): 24.9
-    pH (H2O): 9.3
-    geological formation: Safety Bay Sand
-    parent material: Calcareous sand
-    stage: stage 1
+    soil Ca (mg/kg): 4617.0
+    soil Al (mg/kg): 0.0
+    soil cation exchange capacity (cmol/kg): 24.9
+    soil pH (H2O): 9.3
+    geology (stratigraphic map unit): Safety Bay Sand
+    geology (parent material): Calcareous sand
+    choronosequence stage: stage 1
     notes: measurements made at a site designated as "Quindalup Young" from Laliberte_2012,
       but the coordinates used as approximate
   Spearwood West:
-    Vegetation: Kwongan
+    description: Kwongan
     latitude (deg): -30.1920924
     longitude (deg): 115.0630152
-    total P (mg/kg): 22.0
+    soil P, total (mg/kg): 22.0
     resin P (mg/mg): 1.07
-    Ca (mg/kg): 738.0
-    Al (mg/kg): 0.9
-    CEC (cmol/kg): 4.3
-    pH (H2O): 6.6
-    geological formation: Tamala Limestone
-    parent material: Calcareous sand
-    stage: stage 4
+    soil Ca (mg/kg): 738.0
+    soil Al (mg/kg): 0.9
+    soil cation exchange capacity (cmol/kg): 4.3
+    soil pH (H2O): 6.6
+    geology (stratigraphic map unit): Tamala Limestone
+    geology (parent material): Calcareous sand
+    choronosequence stage: stage 4
     notes: measurements made at a site designated as "Spearwood West" from Laliberte_2012,
       but the coordinates used as approximate
 contexts: .na
@@ -1054,4 +1054,3 @@ taxonomic_updates:
   reason: Change spelling to align with known species in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Hall_1981/metadata.yml
+++ b/data/Hall_1981/metadata.yml
@@ -9,7 +9,7 @@ source:
       Dichanthium-Eulalia Grasslands of North-West Queensland.
     volume: '3'
     number: '1'
-    pages: '67--73'
+    pages: 67--73
     doi: 10.1071/rj9810067
 people:
 - name: TJ Hall
@@ -45,10 +45,10 @@ sites:
     latitude (deg): -18.85
     longitude (deg): 140.9
     description: open grassland
-    soil: grey silty clay
-    soil_pH: 7.3
-    available P (ppm): 3-6
-    total nitrogen (%): 0.029
+    soil type: grey silty clay
+    soil pH: 7.3
+    soil P, available (ppm): 3-6
+    soil N, total (%): 0.029
 contexts:
   January:
     description: samples collected in January, during the wet (growing) season
@@ -134,4 +134,3 @@ taxonomic_updates:
   reason: Change spelling to Align to APC accepted name (E. Wenk, 2020-05-26)
 exclude_observations: .na
 questions: .na
-

--- a/data/Hayes_2014/metadata.yml
+++ b/data/Hayes_2014/metadata.yml
@@ -107,7 +107,7 @@ dataset:
 sites:
   B.HR.2:
     dune: Bassendean
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0154143
     soil P, total (mg/kg): 9.0007857
@@ -142,7 +142,7 @@ sites:
     soil organic carbon (%): 0.605
   B.HR.5:
     dune: Bassendean
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0204571
     soil P, total (mg/kg): 8.0209571
@@ -177,7 +177,7 @@ sites:
     soil organic carbon (%): 0.556
   B.L.10:
     dune: Bassendean
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0292429
     soil P, total (mg/kg): 7.9833429
@@ -212,7 +212,7 @@ sites:
     soil organic carbon (%): 0.729
   B.L.14:
     dune: Bassendean
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0406571
     soil P, total (mg/kg): 4.6392
@@ -247,7 +247,7 @@ sites:
     soil organic carbon (%): 0.535
   B.L.4:
     dune: Bassendean
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0348571
     soil P, total (mg/kg): 7.8295286
@@ -282,7 +282,7 @@ sites:
     soil organic carbon (%): 0.837
   B.L.5:
     dune: Bassendean
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0338571
     soil P, total (mg/kg): 6.5937714
@@ -317,7 +317,7 @@ sites:
     soil organic carbon (%): 0.828
   B.L.6:
     dune: Bassendean
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0226143
     soil P, total (mg/kg): 6.6636143
@@ -352,7 +352,7 @@ sites:
     soil organic carbon (%): 0.677
   B.L.9:
     dune: Bassendean
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0267571
     soil P, total (mg/kg): 6.9141429
@@ -387,7 +387,7 @@ sites:
     soil organic carbon (%): 0.902
   B.NL.1:
     dune: Bassendean
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0150857
     soil P, total (mg/kg): 5.5671714
@@ -422,7 +422,7 @@ sites:
     soil organic carbon (%): 0.347
   B.NL.3:
     dune: Bassendean
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0095286
     soil P, total (mg/kg): 3.8973857
@@ -457,7 +457,7 @@ sites:
     soil organic carbon (%): 0.291
   Q.M.18:
     dune: Quindalup - medium
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0922571
     soil P, total (mg/kg): 372.8478714
@@ -492,7 +492,7 @@ sites:
     soil organic carbon (%): 0.57
   Q.M.23:
     dune: Quindalup - medium
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.1231
     soil P, total (mg/kg): 451.5028571
@@ -527,7 +527,7 @@ sites:
     soil organic carbon (%): 2.548
   Q.M.25:
     dune: Quindalup - medium
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.133
     soil P, total (mg/kg): 405.9889429
@@ -562,7 +562,7 @@ sites:
     soil organic carbon (%): 3.123
   Q.M.26:
     dune: Quindalup - medium
-    data sampled: 11/6/12
+    date sampled: 11/6/12
     plot type: subplot
     soil N, total (%): 0.0944429
     soil P, total (mg/kg): 423.1210143
@@ -597,7 +597,7 @@ sites:
     soil organic carbon (%): 1.147
   Q.M.30:
     dune: Quindalup - medium
-    data sampled: 11/6/12
+    date sampled: 11/6/12
     plot type: subplot
     soil N, total (%): 0.1210143
     soil P, total (mg/kg): 522.9865286
@@ -632,7 +632,7 @@ sites:
     soil organic carbon (%): 1.728
   Q.M.31:
     dune: Quindalup - medium
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.1255857
     soil P, total (mg/kg): 451.1819429
@@ -667,7 +667,7 @@ sites:
     soil organic carbon (%): 1.661
   Q.M.32:
     dune: Quindalup - medium
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.1250714
     soil P, total (mg/kg): 412.1763286
@@ -702,7 +702,7 @@ sites:
     soil organic carbon (%): 2.24
   Q.M.33:
     dune: Quindalup - medium
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.1313
     soil P, total (mg/kg): 489.7578286
@@ -737,7 +737,7 @@ sites:
     soil organic carbon (%): 2.429
   Q.M.7:
     dune: Quindalup - medium
-    data sampled: 11/6/12
+    date sampled: 11/6/12
     plot type: subplot
     soil N, total (%): 0.1147286
     soil P, total (mg/kg): 428.1163
@@ -772,7 +772,7 @@ sites:
     soil organic carbon (%): 1.634
   Q.M.8:
     dune: Quindalup - medium
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.1096286
     soil P, total (mg/kg): 374.8017857
@@ -807,7 +807,7 @@ sites:
     soil organic carbon (%): 1.728
   Q.O.11:
     dune: Quindalup - old
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0597286
     soil P, total (mg/kg): 98.8946714
@@ -842,7 +842,7 @@ sites:
     soil organic carbon (%): 0.931
   Q.O.14:
     dune: Quindalup - old
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0657429
     soil P, total (mg/kg): 168.3803
@@ -877,7 +877,7 @@ sites:
     soil organic carbon (%): 0.999
   Q.O.15:
     dune: Quindalup - old
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0854571
     soil P, total (mg/kg): 269.7260857
@@ -912,7 +912,7 @@ sites:
     soil organic carbon (%): 1.008
   Q.O.17:
     dune: Quindalup - old
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0715571
     soil P, total (mg/kg): 169.5353286
@@ -947,7 +947,7 @@ sites:
     soil organic carbon (%): 1.348
   Q.O.20:
     dune: Quindalup - old
-    data sampled: 11/6/12
+    date sampled: 11/6/12
     plot type: subplot
     soil N, total (%): 0.1586143
     soil P, total (mg/kg): 480.1539
@@ -982,7 +982,7 @@ sites:
     soil organic carbon (%): 2.195
   Q.O.22:
     dune: Quindalup - old
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.1238429
     soil P, total (mg/kg): 373.9444286
@@ -1017,7 +1017,7 @@ sites:
     soil organic carbon (%): 2.1
   Q.O.24:
     dune: Quindalup - old
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0748
     soil P, total (mg/kg): 214.5303429
@@ -1052,7 +1052,7 @@ sites:
     soil organic carbon (%): 1.463
   Q.O.3:
     dune: Quindalup - old
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.1981
     soil P, total (mg/kg): 448.3340286
@@ -1087,7 +1087,7 @@ sites:
     soil organic carbon (%): 2.776
   Q.O.4:
     dune: Quindalup - old
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0633571
     soil P, total (mg/kg): 431.6737286
@@ -1122,7 +1122,7 @@ sites:
     soil organic carbon (%): 0.331
   Q.O.5:
     dune: Quindalup - old
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0624143
     soil P, total (mg/kg): 206.4214714
@@ -1157,7 +1157,7 @@ sites:
     soil organic carbon (%): 1.497
   Q.Y.1:
     dune: Quindalup - young
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0359
     soil P, total (mg/kg): 318.6621714
@@ -1192,7 +1192,7 @@ sites:
     soil organic carbon (%): 0.751
   Q.Y.12:
     dune: Quindalup - young
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0520286
     soil P, total (mg/kg): 370.0116429
@@ -1227,7 +1227,7 @@ sites:
     soil organic carbon (%): 1.962
   Q.Y.15:
     dune: Quindalup - young
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0415143
     soil P, total (mg/kg): 350.0687714
@@ -1262,7 +1262,7 @@ sites:
     soil organic carbon (%): 0.942
   Q.Y.16:
     dune: Quindalup - young
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0483429
     soil P, total (mg/kg): 355.1827286
@@ -1297,7 +1297,7 @@ sites:
     soil organic carbon (%): 1.227
   Q.Y.17:
     dune: Quindalup - young
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0568286
     soil P, total (mg/kg): 329.5503286
@@ -1332,7 +1332,7 @@ sites:
     soil organic carbon (%): 1.095
   Q.Y.18:
     dune: Quindalup - young
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0474
     soil P, total (mg/kg): 401.6401857
@@ -1367,7 +1367,7 @@ sites:
     soil organic carbon (%): 1.729
   Q.Y.20:
     dune: Quindalup - young
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0490143
     soil P, total (mg/kg): 335.7599429
@@ -1402,7 +1402,7 @@ sites:
     soil organic carbon (%): 1.473
   Q.Y.3:
     dune: Quindalup - young
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0531429
     soil P, total (mg/kg): 327.3090571
@@ -1437,7 +1437,7 @@ sites:
     soil organic carbon (%): 2.101
   Q.Y.7:
     dune: Quindalup - young
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.061
     soil P, total (mg/kg): 368.2940857
@@ -1472,7 +1472,7 @@ sites:
     soil organic carbon (%): 1.983
   Q.Y.8:
     dune: Quindalup - young
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0616857
     soil P, total (mg/kg): 344.5576714
@@ -1507,7 +1507,7 @@ sites:
     soil organic carbon (%): 0.76
   S.W.11:
     dune: Spearwood - west
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0432429
     soil P, total (mg/kg): 26.4606429
@@ -1542,7 +1542,7 @@ sites:
     soil organic carbon (%): 0.862
   S.W.14:
     dune: Spearwood - west
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0171571
     soil P, total (mg/kg): 20.4435857
@@ -1577,7 +1577,7 @@ sites:
     soil organic carbon (%): 0.391
   S.W.17:
     dune: Spearwood - west
-    data sampled: 15/6/12
+    date sampled: 15/6/12
     plot type: subplot
     soil N, total (%): 0.0222143
     soil P, total (mg/kg): 17.7429571
@@ -1612,7 +1612,7 @@ sites:
     soil organic carbon (%): 0.577
   S.W.26:
     dune: Spearwood - west
-    data sampled: 12/6/12
+    date sampled: 12/6/12
     plot type: subplot
     soil N, total (%): 0.0341429
     soil P, total (mg/kg): 21.1981286
@@ -1647,7 +1647,7 @@ sites:
     soil organic carbon (%): 0.927
   S.W.3:
     dune: Spearwood - west
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0642857
     soil P, total (mg/kg): 37.1840143
@@ -1682,7 +1682,7 @@ sites:
     soil organic carbon (%): 1.049
   S.W.34:
     dune: Spearwood - west
-    data sampled: 16/6/12
+    date sampled: 16/6/12
     plot type: subplot
     soil N, total (%): 0.0146857
     soil P, total (mg/kg): 12.8282
@@ -1717,7 +1717,7 @@ sites:
     soil organic carbon (%): 0.36
   S.W.35:
     dune: Spearwood - west
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0222571
     soil P, total (mg/kg): 15.5478857
@@ -1752,7 +1752,7 @@ sites:
     soil organic carbon (%): 0.628
   S.W.36:
     dune: Spearwood - west
-    data sampled: 14/6/12
+    date sampled: 14/6/12
     plot type: subplot
     soil N, total (%): 0.0272857
     soil P, total (mg/kg): 21.6309286
@@ -1787,7 +1787,7 @@ sites:
     soil organic carbon (%): 0.629
   S.W.6:
     dune: Spearwood - west
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0325571
     soil P, total (mg/kg): 26.9575571
@@ -1822,7 +1822,7 @@ sites:
     soil organic carbon (%): 0.689
   S.W.8:
     dune: Spearwood - west
-    data sampled: 13/6/12
+    date sampled: 13/6/12
     plot type: subplot
     soil N, total (%): 0.0249
     soil P, total (mg/kg): 14.7581286

--- a/data/Hayes_2014/metadata.yml
+++ b/data/Hayes_2014/metadata.yml
@@ -107,1754 +107,1754 @@ dataset:
 sites:
   B.HR.2:
     dune: Bassendean
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0154143
-    totalP_mgkg: 9.0007857
-    NP: 17.1584143
-    pHwater: 5.9985714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 534.9537286
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 12.4759857
-    exchMg_mgkg: 54.2574286
-    exchMn_mgkg: 0.7044714
-    exchNa_mgkg: 18.2440286
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 2.6694286
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0319143
-    exchMg_cmolkg: 0.4463857
-    exchMn_cmolkg: 0.0025571
-    exchNa_cmolkg: 0.0793429
-    TEB_cmolkg: 3.2270571
-    ECEC_cmolkg: 3.2296429
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0154143
+    soil P, total (mg/kg): 9.0007857
+    soil N:P: 17.1584143
+    soil pH (H2O): 5.9985714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 534.9537286
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 12.4759857
+    soil exchangeable Mg (mg/kg): 54.2574286
+    soil exchangeable Mn (mg/kg): 0.7044714
+    soil exchangeable Na (mg/kg): 18.2440286
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.6694286
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0319143
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.4463857
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0025571
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0793429
+    soil TEB (cmol/kg): 3.2270571
+    soil cation exchange capacity (cmol/kg): 3.2296429
     latitude (deg): -30.2950876
     longitude (deg): 115.1876421
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 8.07
-    nh4: 3.258
-    no3: 0.609
-    nh4incub: -0.407
-    orgC: 0.605
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 8.07
+    soil NH4 content (mg/kg): 3.258
+    soil NO3 content: 0.609
+    incubated soil NH4 content (mg/kg): -0.407
+    soil organic carbon (%): 0.605
   B.HR.5:
     dune: Bassendean
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0204571
-    totalP_mgkg: 8.0209571
-    NP: 25.4924714
-    pHwater: 6.1242857
-    exchAl_mgkg: 1.1189286
-    exchCa_mgkg: 263.9227143
-    exchFe_mgkg: 0.4191714
-    exchK_mgkg: 1.8314571
-    exchMg_mgkg: 35.7199714
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 11.5193571
-    exchAl_cmolkg: 0.0124429
-    exchCa_cmolkg: 1.3169571
-    exchFe_cmolkg: 0.0022571
-    exchK_cmolkg: 0.0046857
-    exchMg_cmolkg: 0.2938714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0501
-    TEB_cmolkg: 1.6656143
-    ECEC_cmolkg: 1.6803143
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0204571
+    soil P, total (mg/kg): 8.0209571
+    soil N:P: 25.4924714
+    soil pH (H2O): 6.1242857
+    soil exchangeable Al (mg/kg): 1.1189286
+    soil exchangeable Ca (mg/kg): 263.9227143
+    soil exchangeable Fe (mg/kg): 0.4191714
+    soil exchangeable K (mg/kg): 1.8314571
+    soil exchangeable Mg (mg/kg): 35.7199714
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 11.5193571
+    soil exchangeable Al (cmol/kg): 0.0124429
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.3169571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0022571
+    soil exchangeable K (cmol/kg, meq/100g): 0.0046857
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.2938714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0501
+    soil TEB (cmol/kg): 1.6656143
+    soil cation exchange capacity (cmol/kg): 1.6803143
     latitude (deg): -30.2942394
     longitude (deg): 115.1849383
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 12.353
-    nh4: 3.443
-    no3: 0.476
-    nh4incub: -0.162
-    orgC: 0.556
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 12.353
+    soil NH4 content (mg/kg): 3.443
+    soil NO3 content: 0.476
+    incubated soil NH4 content (mg/kg): -0.162
+    soil organic carbon (%): 0.556
   B.L.10:
     dune: Bassendean
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0292429
-    totalP_mgkg: 7.9833429
-    NP: 36.9731429
-    pHwater: 6.1228571
-    exchAl_mgkg: 0.7277143
-    exchCa_mgkg: 415.9009143
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 3.7037143
-    exchMg_mgkg: 45.5132286
-    exchMn_mgkg: 0.5997286
-    exchNa_mgkg: 3.1690857
-    exchAl_cmolkg: 0.0080857
-    exchCa_cmolkg: 2.0753429
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0094714
-    exchMg_cmolkg: 0.3744286
-    exchMn_cmolkg: 0.0022
-    exchNa_cmolkg: 0.0137857
-    TEB_cmolkg: 2.4730429
-    ECEC_cmolkg: 2.4833143
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0292429
+    soil P, total (mg/kg): 7.9833429
+    soil N:P: 36.9731429
+    soil pH (H2O): 6.1228571
+    soil exchangeable Al (mg/kg): 0.7277143
+    soil exchangeable Ca (mg/kg): 415.9009143
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 3.7037143
+    soil exchangeable Mg (mg/kg): 45.5132286
+    soil exchangeable Mn (mg/kg): 0.5997286
+    soil exchangeable Na (mg/kg): 3.1690857
+    soil exchangeable Al (cmol/kg): 0.0080857
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.0753429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0094714
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3744286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0022
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0137857
+    soil TEB (cmol/kg): 2.4730429
+    soil cation exchange capacity (cmol/kg): 2.4833143
     latitude (deg): -30.1600016
     longitude (deg): 115.1205556
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 9.794
-    nh4: 1.426
-    no3: 1.372
-    nh4incub: 0.03
-    orgC: 0.729
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 9.794
+    soil NH4 content (mg/kg): 1.426
+    soil NO3 content: 1.372
+    incubated soil NH4 content (mg/kg): 0.03
+    soil organic carbon (%): 0.729
   B.L.14:
     dune: Bassendean
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0406571
-    totalP_mgkg: 4.6392
-    NP: 85.8034571
-    pHwater: 5.48
-    exchAl_mgkg: 0.7721
-    exchCa_mgkg: 389.2601143
-    exchFe_mgkg: 0.7122143
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 42.6555429
-    exchMn_mgkg: 0.2816571
-    exchNa_mgkg: 3.5425857
-    exchAl_cmolkg: 0.0085857
-    exchCa_cmolkg: 1.9424286
-    exchFe_cmolkg: 0.0038143
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.3509286
-    exchMn_cmolkg: 0.0010143
-    exchNa_cmolkg: 0.0154143
-    TEB_cmolkg: 2.3087429
-    ECEC_cmolkg: 2.3222
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0406571
+    soil P, total (mg/kg): 4.6392
+    soil N:P: 85.8034571
+    soil pH (H2O): 5.48
+    soil exchangeable Al (mg/kg): 0.7721
+    soil exchangeable Ca (mg/kg): 389.2601143
+    soil exchangeable Fe (mg/kg): 0.7122143
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 42.6555429
+    soil exchangeable Mn (mg/kg): 0.2816571
+    soil exchangeable Na (mg/kg): 3.5425857
+    soil exchangeable Al (cmol/kg): 0.0085857
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.9424286
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0038143
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3509286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0010143
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0154143
+    soil TEB (cmol/kg): 2.3087429
+    soil cation exchange capacity (cmol/kg): 2.3222
     latitude (deg): -30.1809
     longitude (deg): 115.1288
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 7.983
-    nh4: 2.889
-    no3: 2.479
-    nh4incub: 0.069
-    orgC: 0.535
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 7.983
+    soil NH4 content (mg/kg): 2.889
+    soil NO3 content: 2.479
+    incubated soil NH4 content (mg/kg): 0.069
+    soil organic carbon (%): 0.535
   B.L.4:
     dune: Bassendean
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0348571
-    totalP_mgkg: 7.8295286
-    NP: 42.3658714
-    pHwater: 5.6328571
-    exchAl_mgkg: 6.1609
-    exchCa_mgkg: 353.2571571
-    exchFe_mgkg: 1.0526857
-    exchK_mgkg: 18.1633714
-    exchMg_mgkg: 38.4008571
-    exchMn_mgkg: 0.4712
-    exchNa_mgkg: 4.7013286
-    exchAl_cmolkg: 0.0685143
-    exchCa_cmolkg: 1.7627571
-    exchFe_cmolkg: 0.0056714
-    exchK_cmolkg: 0.0464286
-    exchMg_cmolkg: 0.3159
-    exchMn_cmolkg: 0.0017143
-    exchNa_cmolkg: 0.0204571
-    TEB_cmolkg: 2.1455857
-    ECEC_cmolkg: 2.2214857
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0348571
+    soil P, total (mg/kg): 7.8295286
+    soil N:P: 42.3658714
+    soil pH (H2O): 5.6328571
+    soil exchangeable Al (mg/kg): 6.1609
+    soil exchangeable Ca (mg/kg): 353.2571571
+    soil exchangeable Fe (mg/kg): 1.0526857
+    soil exchangeable K (mg/kg): 18.1633714
+    soil exchangeable Mg (mg/kg): 38.4008571
+    soil exchangeable Mn (mg/kg): 0.4712
+    soil exchangeable Na (mg/kg): 4.7013286
+    soil exchangeable Al (cmol/kg): 0.0685143
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.7627571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0056714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0464286
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3159
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0017143
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0204571
+    soil TEB (cmol/kg): 2.1455857
+    soil cation exchange capacity (cmol/kg): 2.2214857
     latitude (deg): -30.1867482
     longitude (deg): 115.109051
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 7.538
-    nh4: 1.469
-    no3: 1.843
-    nh4incub: 0.051
-    orgC: 0.837
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 7.538
+    soil NH4 content (mg/kg): 1.469
+    soil NO3 content: 1.843
+    incubated soil NH4 content (mg/kg): 0.051
+    soil organic carbon (%): 0.837
   B.L.5:
     dune: Bassendean
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0338571
-    totalP_mgkg: 6.5937714
-    NP: 56.4882857
-    pHwater: 5.54
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 477.4507286
-    exchFe_mgkg: 0.4457429
-    exchK_mgkg: 19.8023286
-    exchMg_mgkg: 59.3893857
-    exchMn_mgkg: 2.2615143
-    exchNa_mgkg: 7.0854714
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 2.3825
-    exchFe_cmolkg: 0.0024
-    exchK_cmolkg: 0.0506571
-    exchMg_cmolkg: 0.4886
-    exchMn_cmolkg: 0.0082429
-    exchNa_cmolkg: 0.0308143
-    TEB_cmolkg: 2.9525571
-    ECEC_cmolkg: 2.9631857
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0338571
+    soil P, total (mg/kg): 6.5937714
+    soil N:P: 56.4882857
+    soil pH (H2O): 5.54
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 477.4507286
+    soil exchangeable Fe (mg/kg): 0.4457429
+    soil exchangeable K (mg/kg): 19.8023286
+    soil exchangeable Mg (mg/kg): 59.3893857
+    soil exchangeable Mn (mg/kg): 2.2615143
+    soil exchangeable Na (mg/kg): 7.0854714
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.3825
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0024
+    soil exchangeable K (cmol/kg, meq/100g): 0.0506571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.4886
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0082429
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0308143
+    soil TEB (cmol/kg): 2.9525571
+    soil cation exchange capacity (cmol/kg): 2.9631857
     latitude (deg): -30.1643263
     longitude (deg): 115.122627
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 9.459
-    nh4: 3.23
-    no3: 1.18
-    nh4incub: 0.028
-    orgC: 0.828
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 9.459
+    soil NH4 content (mg/kg): 3.23
+    soil NO3 content: 1.18
+    incubated soil NH4 content (mg/kg): 0.028
+    soil organic carbon (%): 0.828
   B.L.6:
     dune: Bassendean
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0226143
-    totalP_mgkg: 6.6636143
-    NP: 34.0105571
-    pHwater: 5.8842857
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 451.2585143
-    exchFe_mgkg: 1.0751429
-    exchK_mgkg: 10.0478286
-    exchMg_mgkg: 41.1179
-    exchMn_mgkg: 1.1227143
-    exchNa_mgkg: 3.6616286
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 2.2518
-    exchFe_cmolkg: 0.0057714
-    exchK_cmolkg: 0.0256857
-    exchMg_cmolkg: 0.3383
-    exchMn_cmolkg: 0.0041
-    exchNa_cmolkg: 0.0159286
-    TEB_cmolkg: 2.6317
-    ECEC_cmolkg: 2.6415571
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0226143
+    soil P, total (mg/kg): 6.6636143
+    soil N:P: 34.0105571
+    soil pH (H2O): 5.8842857
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 451.2585143
+    soil exchangeable Fe (mg/kg): 1.0751429
+    soil exchangeable K (mg/kg): 10.0478286
+    soil exchangeable Mg (mg/kg): 41.1179
+    soil exchangeable Mn (mg/kg): 1.1227143
+    soil exchangeable Na (mg/kg): 3.6616286
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.2518
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0057714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0256857
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3383
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0041
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0159286
+    soil TEB (cmol/kg): 2.6317
+    soil cation exchange capacity (cmol/kg): 2.6415571
     latitude (deg): -30.1714053
     longitude (deg): 115.1090639
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 9.731
-    nh4: 3.596
-    no3: 3.204
-    nh4incub: -0.069
-    orgC: 0.677
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 9.731
+    soil NH4 content (mg/kg): 3.596
+    soil NO3 content: 3.204
+    incubated soil NH4 content (mg/kg): -0.069
+    soil organic carbon (%): 0.677
   B.L.9:
     dune: Bassendean
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0267571
-    totalP_mgkg: 6.9141429
-    NP: 40.8930571
-    pHwater: 5.5814286
-    exchAl_mgkg: 0.8021286
-    exchCa_mgkg: 299.9741143
-    exchFe_mgkg: 2.2621
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 38.5957571
-    exchMn_mgkg: 5.2767571
-    exchNa_mgkg: 2.9018
-    exchAl_cmolkg: 0.0089143
-    exchCa_cmolkg: 1.4969
-    exchFe_cmolkg: 0.0121714
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.3175429
-    exchMn_cmolkg: 0.0192143
-    exchNa_cmolkg: 0.0126143
-    TEB_cmolkg: 1.8270143
-    ECEC_cmolkg: 1.8673286
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0267571
+    soil P, total (mg/kg): 6.9141429
+    soil N:P: 40.8930571
+    soil pH (H2O): 5.5814286
+    soil exchangeable Al (mg/kg): 0.8021286
+    soil exchangeable Ca (mg/kg): 299.9741143
+    soil exchangeable Fe (mg/kg): 2.2621
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 38.5957571
+    soil exchangeable Mn (mg/kg): 5.2767571
+    soil exchangeable Na (mg/kg): 2.9018
+    soil exchangeable Al (cmol/kg): 0.0089143
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.4969
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0121714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3175429
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0192143
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0126143
+    soil TEB (cmol/kg): 1.8270143
+    soil cation exchange capacity (cmol/kg): 1.8673286
     latitude (deg): -30.1681836
     longitude (deg): 115.1057057
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 8.487
-    nh4: 2.786
-    no3: 0.681
-    nh4incub: 0.166
-    orgC: 0.902
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 8.487
+    soil NH4 content (mg/kg): 2.786
+    soil NO3 content: 0.681
+    incubated soil NH4 content (mg/kg): 0.166
+    soil organic carbon (%): 0.902
   B.NL.1:
     dune: Bassendean
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0150857
-    totalP_mgkg: 5.5671714
-    NP: 26.7433
-    pHwater: 6.1628571
-    exchAl_mgkg: 1.2438857
-    exchCa_mgkg: 339.1802429
-    exchFe_mgkg: 0.3977571
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 39.6048571
-    exchMn_mgkg: 0.3641571
-    exchNa_mgkg: 1.1043286
-    exchAl_cmolkg: 0.0138286
-    exchCa_cmolkg: 1.6925143
-    exchFe_cmolkg: 0.0021429
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.3258286
-    exchMn_cmolkg: 0.0013286
-    exchNa_cmolkg: 0.0048
-    TEB_cmolkg: 2.0231429
-    ECEC_cmolkg: 2.0404429
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0150857
+    soil P, total (mg/kg): 5.5671714
+    soil N:P: 26.7433
+    soil pH (H2O): 6.1628571
+    soil exchangeable Al (mg/kg): 1.2438857
+    soil exchangeable Ca (mg/kg): 339.1802429
+    soil exchangeable Fe (mg/kg): 0.3977571
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 39.6048571
+    soil exchangeable Mn (mg/kg): 0.3641571
+    soil exchangeable Na (mg/kg): 1.1043286
+    soil exchangeable Al (cmol/kg): 0.0138286
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.6925143
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0021429
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3258286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0013286
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0048
+    soil TEB (cmol/kg): 2.0231429
+    soil cation exchange capacity (cmol/kg): 2.0404429
     latitude (deg): -30.12959
     longitude (deg): 115.1074556
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 7.465
-    nh4: 2.089
-    no3: 0.368
-    nh4incub: -0.124
-    orgC: 0.347
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 7.465
+    soil NH4 content (mg/kg): 2.089
+    soil NO3 content: 0.368
+    incubated soil NH4 content (mg/kg): -0.124
+    soil organic carbon (%): 0.347
   B.NL.3:
     dune: Bassendean
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0095286
-    totalP_mgkg: 3.8973857
-    NP: 26.3582857
-    pHwater: 5.9814286
-    exchAl_mgkg: 0.8497714
-    exchCa_mgkg: 448.7867857
-    exchFe_mgkg: 1.2259
-    exchK_mgkg: 2.1334714
-    exchMg_mgkg: 47.2342143
-    exchMn_mgkg: 0.2081143
-    exchNa_mgkg: 2.4462857
-    exchAl_cmolkg: 0.0094429
-    exchCa_cmolkg: 2.2394429
-    exchFe_cmolkg: 0.0065857
-    exchK_cmolkg: 0.0054571
-    exchMg_cmolkg: 0.3886
-    exchMn_cmolkg: 0.0007571
-    exchNa_cmolkg: 0.0106429
-    TEB_cmolkg: 2.6441571
-    ECEC_cmolkg: 2.6609571
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0095286
+    soil P, total (mg/kg): 3.8973857
+    soil N:P: 26.3582857
+    soil pH (H2O): 5.9814286
+    soil exchangeable Al (mg/kg): 0.8497714
+    soil exchangeable Ca (mg/kg): 448.7867857
+    soil exchangeable Fe (mg/kg): 1.2259
+    soil exchangeable K (mg/kg): 2.1334714
+    soil exchangeable Mg (mg/kg): 47.2342143
+    soil exchangeable Mn (mg/kg): 0.2081143
+    soil exchangeable Na (mg/kg): 2.4462857
+    soil exchangeable Al (cmol/kg): 0.0094429
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.2394429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0065857
+    soil exchangeable K (cmol/kg, meq/100g): 0.0054571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3886
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0007571
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0106429
+    soil TEB (cmol/kg): 2.6441571
+    soil cation exchange capacity (cmol/kg): 2.6609571
     latitude (deg): -30.12666
     longitude (deg): 115.10631
-    stage: 6.0
+    choronosequence stage: 6.0
     epoch: Early Pleistocene
-    age: 2000000.0
-    geology: Bassendean Sand
-    don: 8.657
-    nh4: 2.993
-    no3: 0.937
-    nh4incub: -0.017
-    orgC: 0.291
+    soil age: 2000000.0
+    geology (stratigraphic map unit): Bassendean Sand
+    soil disolved organic nitrogen: 8.657
+    soil NH4 content (mg/kg): 2.993
+    soil NO3 content: 0.937
+    incubated soil NH4 content (mg/kg): -0.017
+    soil organic carbon (%): 0.291
   Q.M.18:
     dune: Quindalup - medium
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0922571
-    totalP_mgkg: 372.8478714
-    NP: 2.4189143
-    pHwater: 8.6671429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1768.9212714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 76.8200143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 19.3159286
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 8.8269571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.632
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0840143
-    TEB_cmolkg: 9.5429714
-    ECEC_cmolkg: 9.5429714
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0922571
+    soil P, total (mg/kg): 372.8478714
+    soil N:P: 2.4189143
+    soil pH (H2O): 8.6671429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1768.9212714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 76.8200143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 19.3159286
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 8.8269571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.632
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0840143
+    soil TEB (cmol/kg): 9.5429714
+    soil cation exchange capacity (cmol/kg): 9.5429714
     latitude (deg): -30.059799
     longitude (deg): 114.983038
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 15.314
-    nh4: 7.786
-    no3: 5.838
-    nh4incub: -0.667
-    orgC: 0.57
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 15.314
+    soil NH4 content (mg/kg): 7.786
+    soil NO3 content: 5.838
+    incubated soil NH4 content (mg/kg): -0.667
+    soil organic carbon (%): 0.57
   Q.M.23:
     dune: Quindalup - medium
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.1231
-    totalP_mgkg: 451.5028571
-    NP: 2.7255
-    pHwater: 8.5228571
-    exchAl_mgkg: 1.3517
-    exchCa_mgkg: 2426.7652714
-    exchFe_mgkg: 0.6098571
-    exchK_mgkg: 1.4634429
-    exchMg_mgkg: 112.9028143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 33.4632
-    exchAl_cmolkg: 0.0150286
-    exchCa_cmolkg: 12.1096143
-    exchFe_cmolkg: 0.0032714
-    exchK_cmolkg: 0.0037429
-    exchMg_cmolkg: 0.9288714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1455571
-    TEB_cmolkg: 13.1877571
-    ECEC_cmolkg: 13.2060714
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.1231
+    soil P, total (mg/kg): 451.5028571
+    soil N:P: 2.7255
+    soil pH (H2O): 8.5228571
+    soil exchangeable Al (mg/kg): 1.3517
+    soil exchangeable Ca (mg/kg): 2426.7652714
+    soil exchangeable Fe (mg/kg): 0.6098571
+    soil exchangeable K (mg/kg): 1.4634429
+    soil exchangeable Mg (mg/kg): 112.9028143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 33.4632
+    soil exchangeable Al (cmol/kg): 0.0150286
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.1096143
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0032714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0037429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.9288714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1455571
+    soil TEB (cmol/kg): 13.1877571
+    soil cation exchange capacity (cmol/kg): 13.2060714
     latitude (deg): -30.1703198
     longitude (deg): 115.0119435
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 22.189
-    nh4: 6.62
-    no3: 5.537
-    nh4incub: -0.5
-    orgC: 2.548
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 22.189
+    soil NH4 content (mg/kg): 6.62
+    soil NO3 content: 5.537
+    incubated soil NH4 content (mg/kg): -0.5
+    soil organic carbon (%): 2.548
   Q.M.25:
     dune: Quindalup - medium
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.133
-    totalP_mgkg: 405.9889429
-    NP: 3.2725714
-    pHwater: 8.4657143
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2467.5707714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 15.1763714
-    exchMg_mgkg: 131.9193429
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 20.7030714
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 12.3132286
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0388286
-    exchMg_cmolkg: 1.0853143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0900571
-    TEB_cmolkg: 13.5274143
-    ECEC_cmolkg: 13.5274143
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.133
+    soil P, total (mg/kg): 405.9889429
+    soil N:P: 3.2725714
+    soil pH (H2O): 8.4657143
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2467.5707714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 15.1763714
+    soil exchangeable Mg (mg/kg): 131.9193429
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 20.7030714
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.3132286
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0388286
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.0853143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0900571
+    soil TEB (cmol/kg): 13.5274143
+    soil cation exchange capacity (cmol/kg): 13.5274143
     latitude (deg): -30.22424
     longitude (deg): 115.010676
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 21.676
-    nh4: 8.124
-    no3: 5.221
-    nh4incub: -0.691
-    orgC: 3.123
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 21.676
+    soil NH4 content (mg/kg): 8.124
+    soil NO3 content: 5.221
+    incubated soil NH4 content (mg/kg): -0.691
+    soil organic carbon (%): 3.123
   Q.M.26:
     dune: Quindalup - medium
-    date: 11/6/12
-    type: subplot
-    totalN_perc: 0.0944429
-    totalP_mgkg: 423.1210143
-    NP: 2.2260429
-    pHwater: 8.6242857
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1302.2209143
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 29.3438857
-    exchMg_mgkg: 82.8682143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 30.7882429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 6.4981143
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0750429
-    exchMg_cmolkg: 0.6817571
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1339143
-    TEB_cmolkg: 7.3888571
-    ECEC_cmolkg: 7.3888571
+    data sampled: 11/6/12
+    plot type: subplot
+    soil N, total (%): 0.0944429
+    soil P, total (mg/kg): 423.1210143
+    soil N:P: 2.2260429
+    soil pH (H2O): 8.6242857
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1302.2209143
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 29.3438857
+    soil exchangeable Mg (mg/kg): 82.8682143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 30.7882429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 6.4981143
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0750429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.6817571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1339143
+    soil TEB (cmol/kg): 7.3888571
+    soil cation exchange capacity (cmol/kg): 7.3888571
     latitude (deg): -30.2140527
     longitude (deg): 115.010374
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 21.417
-    nh4: 9.427
-    no3: 5.707
-    nh4incub: -0.959
-    orgC: 1.147
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 21.417
+    soil NH4 content (mg/kg): 9.427
+    soil NO3 content: 5.707
+    incubated soil NH4 content (mg/kg): -0.959
+    soil organic carbon (%): 1.147
   Q.M.30:
     dune: Quindalup - medium
-    date: 11/6/12
-    type: subplot
-    totalN_perc: 0.1210143
-    totalP_mgkg: 522.9865286
-    NP: 2.3104571
-    pHwater: 8.63
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1792.8818857
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 36.1499
-    exchMg_mgkg: 118.7547143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 29.5951571
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 8.9465429
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0924571
-    exchMg_cmolkg: 0.977
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1287286
-    TEB_cmolkg: 10.1447
-    ECEC_cmolkg: 10.1447
+    data sampled: 11/6/12
+    plot type: subplot
+    soil N, total (%): 0.1210143
+    soil P, total (mg/kg): 522.9865286
+    soil N:P: 2.3104571
+    soil pH (H2O): 8.63
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1792.8818857
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 36.1499
+    soil exchangeable Mg (mg/kg): 118.7547143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 29.5951571
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 8.9465429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0924571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.977
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1287286
+    soil TEB (cmol/kg): 10.1447
+    soil cation exchange capacity (cmol/kg): 10.1447
     latitude (deg): -30.27663
     longitude (deg): 115.045336
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 28.945
-    nh4: 12.775
-    no3: 4.323
-    nh4incub: -1.258
-    orgC: 1.728
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 28.945
+    soil NH4 content (mg/kg): 12.775
+    soil NO3 content: 4.323
+    incubated soil NH4 content (mg/kg): -1.258
+    soil organic carbon (%): 1.728
   Q.M.31:
     dune: Quindalup - medium
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.1255857
-    totalP_mgkg: 451.1819429
-    NP: 2.7887571
-    pHwater: 8.5185714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1545.4235429
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 26.5780143
-    exchMg_mgkg: 104.9089
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 36.4634
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 7.7116857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0679571
-    exchMg_cmolkg: 0.8631143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1586
-    TEB_cmolkg: 8.8013571
-    ECEC_cmolkg: 8.8013571
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.1255857
+    soil P, total (mg/kg): 451.1819429
+    soil N:P: 2.7887571
+    soil pH (H2O): 8.5185714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1545.4235429
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 26.5780143
+    soil exchangeable Mg (mg/kg): 104.9089
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 36.4634
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 7.7116857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0679571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.8631143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1586
+    soil TEB (cmol/kg): 8.8013571
+    soil cation exchange capacity (cmol/kg): 8.8013571
     latitude (deg): -30.07305
     longitude (deg): 114.98254
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 38.198
-    nh4: 4.367
-    no3: 8.81
-    nh4incub: -0.409
-    orgC: 1.661
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 38.198
+    soil NH4 content (mg/kg): 4.367
+    soil NO3 content: 8.81
+    incubated soil NH4 content (mg/kg): -0.409
+    soil organic carbon (%): 1.661
   Q.M.32:
     dune: Quindalup - medium
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.1250714
-    totalP_mgkg: 412.1763286
-    NP: 3.0265714
-    pHwater: 8.5328571
-    exchAl_mgkg: 0.6939714
-    exchCa_mgkg: 4480.1158857
-    exchFe_mgkg: 0.6026857
-    exchK_mgkg: 20.5022143
-    exchMg_mgkg: 281.3346571
-    exchMn_mgkg: 0.1408429
-    exchNa_mgkg: 55.7989429
-    exchAl_cmolkg: 0.0077143
-    exchCa_cmolkg: 22.3558714
-    exchFe_cmolkg: 0.0032429
-    exchK_cmolkg: 0.0524286
-    exchMg_cmolkg: 2.3145429
-    exchMn_cmolkg: 0.0005143
-    exchNa_cmolkg: 0.2427143
-    TEB_cmolkg: 24.9655714
-    ECEC_cmolkg: 24.9770286
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.1250714
+    soil P, total (mg/kg): 412.1763286
+    soil N:P: 3.0265714
+    soil pH (H2O): 8.5328571
+    soil exchangeable Al (mg/kg): 0.6939714
+    soil exchangeable Ca (mg/kg): 4480.1158857
+    soil exchangeable Fe (mg/kg): 0.6026857
+    soil exchangeable K (mg/kg): 20.5022143
+    soil exchangeable Mg (mg/kg): 281.3346571
+    soil exchangeable Mn (mg/kg): 0.1408429
+    soil exchangeable Na (mg/kg): 55.7989429
+    soil exchangeable Al (cmol/kg): 0.0077143
+    soil exchangeable Ca (cmol/kg, meq/100g): 22.3558714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0032429
+    soil exchangeable K (cmol/kg, meq/100g): 0.0524286
+    soil exchangeable Mg (cmol/kg, meq/100g): 2.3145429
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0005143
+    soil exchangeable Na (cmol/kg, meq/100g): 0.2427143
+    soil TEB (cmol/kg): 24.9655714
+    soil cation exchange capacity (cmol/kg): 24.9770286
     latitude (deg): -30.1646328
     longitude (deg): 115.0074926
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 24.844
-    nh4: 4.56
-    no3: 15.823
-    nh4incub: -0.44
-    orgC: 2.24
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 24.844
+    soil NH4 content (mg/kg): 4.56
+    soil NO3 content: 15.823
+    incubated soil NH4 content (mg/kg): -0.44
+    soil organic carbon (%): 2.24
   Q.M.33:
     dune: Quindalup - medium
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.1313
-    totalP_mgkg: 489.7578286
-    NP: 2.6572857
-    pHwater: 8.5528571
-    exchAl_mgkg: 1.0777857
-    exchCa_mgkg: 2538.6398
-    exchFe_mgkg: 0.5669
-    exchK_mgkg: 21.6055143
-    exchMg_mgkg: 112.2614143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 26.1693429
-    exchAl_cmolkg: 0.0119857
-    exchCa_cmolkg: 12.6678714
-    exchFe_cmolkg: 0.0030429
-    exchK_cmolkg: 0.0552571
-    exchMg_cmolkg: 0.9235857
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1138286
-    TEB_cmolkg: 13.7605143
-    ECEC_cmolkg: 13.7755571
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.1313
+    soil P, total (mg/kg): 489.7578286
+    soil N:P: 2.6572857
+    soil pH (H2O): 8.5528571
+    soil exchangeable Al (mg/kg): 1.0777857
+    soil exchangeable Ca (mg/kg): 2538.6398
+    soil exchangeable Fe (mg/kg): 0.5669
+    soil exchangeable K (mg/kg): 21.6055143
+    soil exchangeable Mg (mg/kg): 112.2614143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 26.1693429
+    soil exchangeable Al (cmol/kg): 0.0119857
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.6678714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0030429
+    soil exchangeable K (cmol/kg, meq/100g): 0.0552571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.9235857
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1138286
+    soil TEB (cmol/kg): 13.7605143
+    soil cation exchange capacity (cmol/kg): 13.7755571
     latitude (deg): -30.09049
     longitude (deg): 114.9986206
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 19.012
-    nh4: 4.63
-    no3: 4.22
-    nh4incub: -0.18
-    orgC: 2.429
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 19.012
+    soil NH4 content (mg/kg): 4.63
+    soil NO3 content: 4.22
+    incubated soil NH4 content (mg/kg): -0.18
+    soil organic carbon (%): 2.429
   Q.M.7:
     dune: Quindalup - medium
-    date: 11/6/12
-    type: subplot
-    totalN_perc: 0.1147286
-    totalP_mgkg: 428.1163
-    NP: 2.6657286
-    pHwater: 8.6785714
-    exchAl_mgkg: 0.9804857
-    exchCa_mgkg: 2258.7838429
-    exchFe_mgkg: 0.4717286
-    exchK_mgkg: 23.1323429
-    exchMg_mgkg: 151.0931429
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 41.0606143
-    exchAl_cmolkg: 0.0109
-    exchCa_cmolkg: 11.2713714
-    exchFe_cmolkg: 0.0025286
-    exchK_cmolkg: 0.0591571
-    exchMg_cmolkg: 1.2430571
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1786286
-    TEB_cmolkg: 12.7522
-    ECEC_cmolkg: 12.7656286
+    data sampled: 11/6/12
+    plot type: subplot
+    soil N, total (%): 0.1147286
+    soil P, total (mg/kg): 428.1163
+    soil N:P: 2.6657286
+    soil pH (H2O): 8.6785714
+    soil exchangeable Al (mg/kg): 0.9804857
+    soil exchangeable Ca (mg/kg): 2258.7838429
+    soil exchangeable Fe (mg/kg): 0.4717286
+    soil exchangeable K (mg/kg): 23.1323429
+    soil exchangeable Mg (mg/kg): 151.0931429
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 41.0606143
+    soil exchangeable Al (cmol/kg): 0.0109
+    soil exchangeable Ca (cmol/kg, meq/100g): 11.2713714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0025286
+    soil exchangeable K (cmol/kg, meq/100g): 0.0591571
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.2430571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1786286
+    soil TEB (cmol/kg): 12.7522
+    soil cation exchange capacity (cmol/kg): 12.7656286
     latitude (deg): -30.2743268
     longitude (deg): 115.0469911
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 27.78
-    nh4: 8.652
-    no3: 4.226
-    nh4incub: -0.926
-    orgC: 1.634
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 27.78
+    soil NH4 content (mg/kg): 8.652
+    soil NO3 content: 4.226
+    incubated soil NH4 content (mg/kg): -0.926
+    soil organic carbon (%): 1.634
   Q.M.8:
     dune: Quindalup - medium
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.1096286
-    totalP_mgkg: 374.8017857
-    NP: 2.9188
-    pHwater: 8.5228571
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2471.5421
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 19.1539857
-    exchMg_mgkg: 102.8163143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 38.0675429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 12.3330571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0489857
-    exchMg_cmolkg: 0.8458571
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1655714
-    TEB_cmolkg: 13.3934857
-    ECEC_cmolkg: 13.3934857
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.1096286
+    soil P, total (mg/kg): 374.8017857
+    soil N:P: 2.9188
+    soil pH (H2O): 8.5228571
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2471.5421
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 19.1539857
+    soil exchangeable Mg (mg/kg): 102.8163143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 38.0675429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.3330571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0489857
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.8458571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1655714
+    soil TEB (cmol/kg): 13.3934857
+    soil cation exchange capacity (cmol/kg): 13.3934857
     latitude (deg): -30.226345
     longitude (deg): 115.0183784
-    stage: 2.0
+    choronosequence stage: 2.0
     epoch: Holocene
-    age: 1000.0
-    geology: Safety Bay Sand
-    don: 18.234
-    nh4: 3.466
-    no3: 1.9
-    nh4incub: -0.366
-    orgC: 1.728
+    soil age: 1000.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 18.234
+    soil NH4 content (mg/kg): 3.466
+    soil NO3 content: 1.9
+    incubated soil NH4 content (mg/kg): -0.366
+    soil organic carbon (%): 1.728
   Q.O.11:
     dune: Quindalup - old
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0597286
-    totalP_mgkg: 98.8946714
-    NP: 6.3075429
-    pHwater: 8.5171429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1827.6712286
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 18.0269429
-    exchMg_mgkg: 62.3353286
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 11.4521143
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 9.1200857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0460857
-    exchMg_cmolkg: 0.5128429
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0498
-    TEB_cmolkg: 9.7288714
-    ECEC_cmolkg: 9.7288714
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0597286
+    soil P, total (mg/kg): 98.8946714
+    soil N:P: 6.3075429
+    soil pH (H2O): 8.5171429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1827.6712286
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 18.0269429
+    soil exchangeable Mg (mg/kg): 62.3353286
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 11.4521143
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 9.1200857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0460857
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5128429
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0498
+    soil TEB (cmol/kg): 9.7288714
+    soil cation exchange capacity (cmol/kg): 9.7288714
     latitude (deg): -30.1911676
     longitude (deg): 115.0593393
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 15.663
-    nh4: 2.895
-    no3: 3.41
-    nh4incub: 0.171
-    orgC: 0.931
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 15.663
+    soil NH4 content (mg/kg): 2.895
+    soil NO3 content: 3.41
+    incubated soil NH4 content (mg/kg): 0.171
+    soil organic carbon (%): 0.931
   Q.O.14:
     dune: Quindalup - old
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0657429
-    totalP_mgkg: 168.3803
-    NP: 3.9626857
-    pHwater: 8.6057143
-    exchAl_mgkg: 2.2655429
-    exchCa_mgkg: 2127.4413571
-    exchFe_mgkg: 0.3389
-    exchK_mgkg: 20.5797
-    exchMg_mgkg: 74.5079
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 12.1702857
-    exchAl_cmolkg: 0.0251857
-    exchCa_cmolkg: 10.6159714
-    exchFe_cmolkg: 0.0018143
-    exchK_cmolkg: 0.0526143
-    exchMg_cmolkg: 0.6129714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0529429
-    TEB_cmolkg: 11.3345429
-    ECEC_cmolkg: 11.3615571
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0657429
+    soil P, total (mg/kg): 168.3803
+    soil N:P: 3.9626857
+    soil pH (H2O): 8.6057143
+    soil exchangeable Al (mg/kg): 2.2655429
+    soil exchangeable Ca (mg/kg): 2127.4413571
+    soil exchangeable Fe (mg/kg): 0.3389
+    soil exchangeable K (mg/kg): 20.5797
+    soil exchangeable Mg (mg/kg): 74.5079
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 12.1702857
+    soil exchangeable Al (cmol/kg): 0.0251857
+    soil exchangeable Ca (cmol/kg, meq/100g): 10.6159714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0018143
+    soil exchangeable K (cmol/kg, meq/100g): 0.0526143
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.6129714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0529429
+    soil TEB (cmol/kg): 11.3345429
+    soil cation exchange capacity (cmol/kg): 11.3615571
     latitude (deg): -30.2406149
     longitude (deg): 115.066927
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 16.459
-    nh4: 3.682
-    no3: 3.853
-    nh4incub: -0.023
-    orgC: 0.999
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 16.459
+    soil NH4 content (mg/kg): 3.682
+    soil NO3 content: 3.853
+    incubated soil NH4 content (mg/kg): -0.023
+    soil organic carbon (%): 0.999
   Q.O.15:
     dune: Quindalup - old
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0854571
-    totalP_mgkg: 269.7260857
-    NP: 3.1878143
-    pHwater: 8.6
-    exchAl_mgkg: 5.6623857
-    exchCa_mgkg: 2405.0782571
-    exchFe_mgkg: 0.5239714
-    exchK_mgkg: 19.208
-    exchMg_mgkg: 70.8274143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 24.6883429
-    exchAl_cmolkg: 0.0629571
-    exchCa_cmolkg: 12.0014
-    exchFe_cmolkg: 0.0028143
-    exchK_cmolkg: 0.0491286
-    exchMg_cmolkg: 0.5826857
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1074
-    TEB_cmolkg: 12.7406143
-    ECEC_cmolkg: 12.8063857
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0854571
+    soil P, total (mg/kg): 269.7260857
+    soil N:P: 3.1878143
+    soil pH (H2O): 8.6
+    soil exchangeable Al (mg/kg): 5.6623857
+    soil exchangeable Ca (mg/kg): 2405.0782571
+    soil exchangeable Fe (mg/kg): 0.5239714
+    soil exchangeable K (mg/kg): 19.208
+    soil exchangeable Mg (mg/kg): 70.8274143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 24.6883429
+    soil exchangeable Al (cmol/kg): 0.0629571
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.0014
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0028143
+    soil exchangeable K (cmol/kg, meq/100g): 0.0491286
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5826857
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1074
+    soil TEB (cmol/kg): 12.7406143
+    soil cation exchange capacity (cmol/kg): 12.8063857
     latitude (deg): -30.2406081
     longitude (deg): 115.0642989
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 15.864
-    nh4: 3.599
-    no3: 0.668
-    nh4incub: -0.068
-    orgC: 1.008
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 15.864
+    soil NH4 content (mg/kg): 3.599
+    soil NO3 content: 0.668
+    incubated soil NH4 content (mg/kg): -0.068
+    soil organic carbon (%): 1.008
   Q.O.17:
     dune: Quindalup - old
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0715571
-    totalP_mgkg: 169.5353286
-    NP: 4.2257857
-    pHwater: 8.6142857
-    exchAl_mgkg: 2.5670714
-    exchCa_mgkg: 1872.1074429
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 19.0138857
-    exchMg_mgkg: 73.538
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 15.4750857
-    exchAl_cmolkg: 0.0285429
-    exchCa_cmolkg: 9.3418857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0486429
-    exchMg_cmolkg: 0.605
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0673143
-    TEB_cmolkg: 10.0628
-    ECEC_cmolkg: 10.0913429
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0715571
+    soil P, total (mg/kg): 169.5353286
+    soil N:P: 4.2257857
+    soil pH (H2O): 8.6142857
+    soil exchangeable Al (mg/kg): 2.5670714
+    soil exchangeable Ca (mg/kg): 1872.1074429
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 19.0138857
+    soil exchangeable Mg (mg/kg): 73.538
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 15.4750857
+    soil exchangeable Al (cmol/kg): 0.0285429
+    soil exchangeable Ca (cmol/kg, meq/100g): 9.3418857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0486429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.605
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0673143
+    soil TEB (cmol/kg): 10.0628
+    soil cation exchange capacity (cmol/kg): 10.0913429
     latitude (deg): -30.2136657
     longitude (deg): 115.063878
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 20.754
-    nh4: 2.88
-    no3: 4.01
-    nh4incub: 0.249
-    orgC: 1.348
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 20.754
+    soil NH4 content (mg/kg): 2.88
+    soil NO3 content: 4.01
+    incubated soil NH4 content (mg/kg): 0.249
+    soil organic carbon (%): 1.348
   Q.O.20:
     dune: Quindalup - old
-    date: 11/6/12
-    type: subplot
-    totalN_perc: 0.1586143
-    totalP_mgkg: 480.1539
-    NP: 3.2973571
-    pHwater: 8.4471429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 3259.3950857
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 29.5622
-    exchMg_mgkg: 143.3977143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 45.9837429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 16.2644571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0756
-    exchMg_cmolkg: 1.1797571
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.2000429
-    TEB_cmolkg: 17.7198143
-    ECEC_cmolkg: 17.7198143
+    data sampled: 11/6/12
+    plot type: subplot
+    soil N, total (%): 0.1586143
+    soil P, total (mg/kg): 480.1539
+    soil N:P: 3.2973571
+    soil pH (H2O): 8.4471429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 3259.3950857
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 29.5622
+    soil exchangeable Mg (mg/kg): 143.3977143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 45.9837429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 16.2644571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0756
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.1797571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.2000429
+    soil TEB (cmol/kg): 17.7198143
+    soil cation exchange capacity (cmol/kg): 17.7198143
     latitude (deg): -30.3157197
     longitude (deg): 115.0665914
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 26.74
-    nh4: 6.837
-    no3: 10.886
-    nh4incub: -0.659
-    orgC: 2.195
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 26.74
+    soil NH4 content (mg/kg): 6.837
+    soil NO3 content: 10.886
+    incubated soil NH4 content (mg/kg): -0.659
+    soil organic carbon (%): 2.195
   Q.O.22:
     dune: Quindalup - old
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.1238429
-    totalP_mgkg: 373.9444286
-    NP: 3.3111571
-    pHwater: 8.4857143
-    exchAl_mgkg: 0.8864429
-    exchCa_mgkg: 2309.2230571
-    exchFe_mgkg: 0.4103571
-    exchK_mgkg: 22.8733143
-    exchMg_mgkg: 87.9318714
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 26.576
-    exchAl_cmolkg: 0.0098571
-    exchCa_cmolkg: 11.5230714
-    exchFe_cmolkg: 0.0022
-    exchK_cmolkg: 0.0585
-    exchMg_cmolkg: 0.7234143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1156
-    TEB_cmolkg: 12.4205857
-    ECEC_cmolkg: 12.4326429
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.1238429
+    soil P, total (mg/kg): 373.9444286
+    soil N:P: 3.3111571
+    soil pH (H2O): 8.4857143
+    soil exchangeable Al (mg/kg): 0.8864429
+    soil exchangeable Ca (mg/kg): 2309.2230571
+    soil exchangeable Fe (mg/kg): 0.4103571
+    soil exchangeable K (mg/kg): 22.8733143
+    soil exchangeable Mg (mg/kg): 87.9318714
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 26.576
+    soil exchangeable Al (cmol/kg): 0.0098571
+    soil exchangeable Ca (cmol/kg, meq/100g): 11.5230714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0022
+    soil exchangeable K (cmol/kg, meq/100g): 0.0585
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.7234143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1156
+    soil TEB (cmol/kg): 12.4205857
+    soil cation exchange capacity (cmol/kg): 12.4326429
     latitude (deg): -30.27658
     longitude (deg): 115.061847
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 18.25
-    nh4: 5.172
-    no3: 7.12
-    nh4incub: -0.461
-    orgC: 2.1
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 18.25
+    soil NH4 content (mg/kg): 5.172
+    soil NO3 content: 7.12
+    incubated soil NH4 content (mg/kg): -0.461
+    soil organic carbon (%): 2.1
   Q.O.24:
     dune: Quindalup - old
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0748
-    totalP_mgkg: 214.5303429
-    NP: 3.4957714
-    pHwater: 8.5185714
-    exchAl_mgkg: 0.8725857
-    exchCa_mgkg: 2226.8598857
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 5.7098143
-    exchMg_mgkg: 71.4011286
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 11.7838286
-    exchAl_cmolkg: 0.0097
-    exchCa_cmolkg: 11.1120857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0146
-    exchMg_cmolkg: 0.5874286
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0512571
-    TEB_cmolkg: 11.7653429
-    ECEC_cmolkg: 11.7750429
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0748
+    soil P, total (mg/kg): 214.5303429
+    soil N:P: 3.4957714
+    soil pH (H2O): 8.5185714
+    soil exchangeable Al (mg/kg): 0.8725857
+    soil exchangeable Ca (mg/kg): 2226.8598857
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 5.7098143
+    soil exchangeable Mg (mg/kg): 71.4011286
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 11.7838286
+    soil exchangeable Al (cmol/kg): 0.0097
+    soil exchangeable Ca (cmol/kg, meq/100g): 11.1120857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0146
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5874286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0512571
+    soil TEB (cmol/kg): 11.7653429
+    soil cation exchange capacity (cmol/kg): 11.7750429
     latitude (deg): -30.27088
     longitude (deg): 115.0708
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 18.414
-    nh4: 4.825
-    no3: 3.915
-    nh4incub: -0.362
-    orgC: 1.463
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 18.414
+    soil NH4 content (mg/kg): 4.825
+    soil NO3 content: 3.915
+    incubated soil NH4 content (mg/kg): -0.362
+    soil organic carbon (%): 1.463
   Q.O.3:
     dune: Quindalup - old
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.1981
-    totalP_mgkg: 448.3340286
-    NP: 4.3907429
-    pHwater: 8.3442857
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 4258.9289714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 26.1822714
-    exchMg_mgkg: 209.9434571
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 156.4017571
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 21.2521571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0669714
-    exchMg_cmolkg: 1.7272286
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.6802857
-    TEB_cmolkg: 23.7266286
-    ECEC_cmolkg: 23.7266286
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.1981
+    soil P, total (mg/kg): 448.3340286
+    soil N:P: 4.3907429
+    soil pH (H2O): 8.3442857
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 4258.9289714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 26.1822714
+    soil exchangeable Mg (mg/kg): 209.9434571
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 156.4017571
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 21.2521571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0669714
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.7272286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.6802857
+    soil TEB (cmol/kg): 23.7266286
+    soil cation exchange capacity (cmol/kg): 23.7266286
     latitude (deg): -30.0629937
     longitude (deg): 115.0120484
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 25.342
-    nh4: 4.133
-    no3: 12.36
-    nh4incub: -0.422
-    orgC: 2.776
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 25.342
+    soil NH4 content (mg/kg): 4.133
+    soil NO3 content: 12.36
+    incubated soil NH4 content (mg/kg): -0.422
+    soil organic carbon (%): 2.776
   Q.O.4:
     dune: Quindalup - old
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0633571
-    totalP_mgkg: 431.6737286
-    NP: 1.4607857
-    pHwater: 8.7328571
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1478.7538
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 72.3526143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 15.2661143
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 7.379
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.5952714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0664
-    TEB_cmolkg: 8.0406571
-    ECEC_cmolkg: 8.0406571
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0633571
+    soil P, total (mg/kg): 431.6737286
+    soil N:P: 1.4607857
+    soil pH (H2O): 8.7328571
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1478.7538
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 72.3526143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 15.2661143
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 7.379
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5952714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0664
+    soil TEB (cmol/kg): 8.0406571
+    soil cation exchange capacity (cmol/kg): 8.0406571
     latitude (deg): -30.0354182
     longitude (deg): 115.0055205
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 19.345
-    nh4: 2.772
-    no3: 5.311
-    nh4incub: -0.289
-    orgC: 0.331
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 19.345
+    soil NH4 content (mg/kg): 2.772
+    soil NO3 content: 5.311
+    incubated soil NH4 content (mg/kg): -0.289
+    soil organic carbon (%): 0.331
   Q.O.5:
     dune: Quindalup - old
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0624143
-    totalP_mgkg: 206.4214714
-    NP: 3.0390571
-    pHwater: 8.7585714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1554.5374714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 61.7869
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 13.3954857
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 7.7571571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.5083143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0582714
-    TEB_cmolkg: 8.3237714
-    ECEC_cmolkg: 8.3237714
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0624143
+    soil P, total (mg/kg): 206.4214714
+    soil N:P: 3.0390571
+    soil pH (H2O): 8.7585714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1554.5374714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 61.7869
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 13.3954857
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 7.7571571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5083143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0582714
+    soil TEB (cmol/kg): 8.3237714
+    soil cation exchange capacity (cmol/kg): 8.3237714
     latitude (deg): -30.2256609
     longitude (deg): 115.0648947
-    stage: 3.0
+    choronosequence stage: 3.0
     epoch: Holocene
-    age: 6500.0
-    geology: Safety Bay Sand
-    don: 15.3
-    nh4: 3.105
-    no3: 1.395
-    nh4incub: 0.093
-    orgC: 1.497
+    soil age: 6500.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 15.3
+    soil NH4 content (mg/kg): 3.105
+    soil NO3 content: 1.395
+    incubated soil NH4 content (mg/kg): 0.093
+    soil organic carbon (%): 1.497
   Q.Y.1:
     dune: Quindalup - young
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0359
-    totalP_mgkg: 318.6621714
-    NP: 1.1446714
-    pHwater: 9.1328571
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 4832.2622143
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 5.3126
-    exchMg_mgkg: 161.3668857
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 6.2602
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 24.1130714
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0135714
-    exchMg_cmolkg: 1.3275714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0272286
-    TEB_cmolkg: 25.4814571
-    ECEC_cmolkg: 25.4814571
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0359
+    soil P, total (mg/kg): 318.6621714
+    soil N:P: 1.1446714
+    soil pH (H2O): 9.1328571
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 4832.2622143
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 5.3126
+    soil exchangeable Mg (mg/kg): 161.3668857
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 6.2602
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 24.1130714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0135714
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.3275714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0272286
+    soil TEB (cmol/kg): 25.4814571
+    soil cation exchange capacity (cmol/kg): 25.4814571
     latitude (deg): -30.405829
     longitude (deg): 115.094783
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 8.657
-    nh4: 2.291
-    no3: 0.085
-    nh4incub: -0.128
-    orgC: 0.751
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 8.657
+    soil NH4 content (mg/kg): 2.291
+    soil NO3 content: 0.085
+    incubated soil NH4 content (mg/kg): -0.128
+    soil organic carbon (%): 0.751
   Q.Y.12:
     dune: Quindalup - young
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0520286
-    totalP_mgkg: 370.0116429
-    NP: 1.4099571
-    pHwater: 9.2171429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2130.1502571
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 101.8668286
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 6.8336
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 10.6294714
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.8380714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0297143
-    TEB_cmolkg: 11.4972857
-    ECEC_cmolkg: 11.4972857
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0520286
+    soil P, total (mg/kg): 370.0116429
+    soil N:P: 1.4099571
+    soil pH (H2O): 9.2171429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2130.1502571
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 101.8668286
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 6.8336
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 10.6294714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.8380714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0297143
+    soil TEB (cmol/kg): 11.4972857
+    soil cation exchange capacity (cmol/kg): 11.4972857
     latitude (deg): -30.181027
     longitude (deg): 115.003786
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 9.921
-    nh4: 0.587
-    no3: 0.163
-    nh4incub: -0.07
-    orgC: 1.962
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 9.921
+    soil NH4 content (mg/kg): 0.587
+    soil NO3 content: 0.163
+    incubated soil NH4 content (mg/kg): -0.07
+    soil organic carbon (%): 1.962
   Q.Y.15:
     dune: Quindalup - young
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0415143
-    totalP_mgkg: 350.0687714
-    NP: 1.1854286
-    pHwater: 9.3957143
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 8073.3750571
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 338.9134
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 17.4138
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 40.2863
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 2.7882571
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0757429
-    TEB_cmolkg: 43.1503143
-    ECEC_cmolkg: 43.1503143
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0415143
+    soil P, total (mg/kg): 350.0687714
+    soil N:P: 1.1854286
+    soil pH (H2O): 9.3957143
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 8073.3750571
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 338.9134
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 17.4138
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 40.2863
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 2.7882571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0757429
+    soil TEB (cmol/kg): 43.1503143
+    soil cation exchange capacity (cmol/kg): 43.1503143
     latitude (deg): -30.407139
     longitude (deg): 115.081852
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 8.561
-    nh4: 2.25
-    no3: 0.016
-    nh4incub: -0.102
-    orgC: 0.942
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 8.561
+    soil NH4 content (mg/kg): 2.25
+    soil NO3 content: 0.016
+    incubated soil NH4 content (mg/kg): -0.102
+    soil organic carbon (%): 0.942
   Q.Y.16:
     dune: Quindalup - young
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0483429
-    totalP_mgkg: 355.1827286
-    NP: 1.3598
-    pHwater: 9.2485714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 4049.8318714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 1.7272571
-    exchMg_mgkg: 165.9673429
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 10.9374571
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 20.2087571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0044143
-    exchMg_cmolkg: 1.3654143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0475857
-    TEB_cmolkg: 21.6261286
-    ECEC_cmolkg: 21.6261286
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0483429
+    soil P, total (mg/kg): 355.1827286
+    soil N:P: 1.3598
+    soil pH (H2O): 9.2485714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 4049.8318714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 1.7272571
+    soil exchangeable Mg (mg/kg): 165.9673429
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 10.9374571
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 20.2087571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0044143
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.3654143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0475857
+    soil TEB (cmol/kg): 21.6261286
+    soil cation exchange capacity (cmol/kg): 21.6261286
     latitude (deg): -30.115121
     longitude (deg): 115.006458
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 9.478
-    nh4: 0.579
-    no3: 0.054
-    nh4incub: -0.051
-    orgC: 1.227
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 9.478
+    soil NH4 content (mg/kg): 0.579
+    soil NO3 content: 0.054
+    incubated soil NH4 content (mg/kg): -0.051
+    soil organic carbon (%): 1.227
   Q.Y.17:
     dune: Quindalup - young
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0568286
-    totalP_mgkg: 329.5503286
-    NP: 1.7289
-    pHwater: 9.3257143
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2771.7096429
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 164.9427
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 19.0045429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 13.8308857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 1.3570143
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0826714
-    TEB_cmolkg: 15.2705429
-    ECEC_cmolkg: 15.2705429
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0568286
+    soil P, total (mg/kg): 329.5503286
+    soil N:P: 1.7289
+    soil pH (H2O): 9.3257143
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2771.7096429
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 164.9427
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 19.0045429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 13.8308857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.3570143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0826714
+    soil TEB (cmol/kg): 15.2705429
+    soil cation exchange capacity (cmol/kg): 15.2705429
     latitude (deg): -30.045269
     longitude (deg): 114.962754
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 9.944
-    nh4: 0.945
-    no3: 0.071
-    nh4incub: -0.072
-    orgC: 1.095
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 9.944
+    soil NH4 content (mg/kg): 0.945
+    soil NO3 content: 0.071
+    incubated soil NH4 content (mg/kg): -0.072
+    soil organic carbon (%): 1.095
   Q.Y.18:
     dune: Quindalup - young
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0474
-    totalP_mgkg: 401.6401857
-    NP: 1.1888429
-    pHwater: 9.42
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 8578.1928143
-    exchFe_mgkg: 1.2391714
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 481.2246571
-    exchMn_mgkg: 0.1167714
-    exchNa_mgkg: 44.2639
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 42.8053429
-    exchFe_cmolkg: 0.0066571
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 3.9590714
-    exchMn_cmolkg: 0.0004286
-    exchNa_cmolkg: 0.1925429
-    TEB_cmolkg: 46.9569571
-    ECEC_cmolkg: 46.9640429
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0474
+    soil P, total (mg/kg): 401.6401857
+    soil N:P: 1.1888429
+    soil pH (H2O): 9.42
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 8578.1928143
+    soil exchangeable Fe (mg/kg): 1.2391714
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 481.2246571
+    soil exchangeable Mn (mg/kg): 0.1167714
+    soil exchangeable Na (mg/kg): 44.2639
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 42.8053429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0066571
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 3.9590714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0004286
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1925429
+    soil TEB (cmol/kg): 46.9569571
+    soil cation exchange capacity (cmol/kg): 46.9640429
     latitude (deg): -30.22362
     longitude (deg): 115.00817
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 6.737
-    nh4: 0.0
-    no3: 0.011
-    nh4incub: 0.0
-    orgC: 1.729
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 6.737
+    soil NH4 content (mg/kg): 0.0
+    soil NO3 content: 0.011
+    incubated soil NH4 content (mg/kg): 0.0
+    soil organic carbon (%): 1.729
   Q.Y.20:
     dune: Quindalup - young
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0490143
-    totalP_mgkg: 335.7599429
-    NP: 1.4632714
-    pHwater: 9.3871429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 9422.5423143
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 510.6096429
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 45.7270429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 47.0186714
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 4.2008
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.1989
-    TEB_cmolkg: 51.4183714
-    ECEC_cmolkg: 51.4183714
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0490143
+    soil P, total (mg/kg): 335.7599429
+    soil N:P: 1.4632714
+    soil pH (H2O): 9.3871429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 9422.5423143
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 510.6096429
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 45.7270429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 47.0186714
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 4.2008
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.1989
+    soil TEB (cmol/kg): 51.4183714
+    soil cation exchange capacity (cmol/kg): 51.4183714
     latitude (deg): -30.24837
     longitude (deg): 115.0482869
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 8.915
-    nh4: 2.342
-    no3: 0.135
-    nh4incub: -0.293
-    orgC: 1.473
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 8.915
+    soil NH4 content (mg/kg): 2.342
+    soil NO3 content: 0.135
+    incubated soil NH4 content (mg/kg): -0.293
+    soil organic carbon (%): 1.473
   Q.Y.3:
     dune: Quindalup - young
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0531429
-    totalP_mgkg: 327.3090571
-    NP: 1.6033714
-    pHwater: 9.0414286
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2975.5721
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 5.0817143
-    exchMg_mgkg: 120.7612571
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 14.3905857
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 14.8481571
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.013
-    exchMg_cmolkg: 0.9935
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0626143
-    TEB_cmolkg: 15.9172714
-    ECEC_cmolkg: 15.9172714
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0531429
+    soil P, total (mg/kg): 327.3090571
+    soil N:P: 1.6033714
+    soil pH (H2O): 9.0414286
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2975.5721
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 5.0817143
+    soil exchangeable Mg (mg/kg): 120.7612571
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 14.3905857
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 14.8481571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.013
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.9935
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0626143
+    soil TEB (cmol/kg): 15.9172714
+    soil cation exchange capacity (cmol/kg): 15.9172714
     latitude (deg): -30.253199
     longitude (deg): 115.039634
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 9.203
-    nh4: 1.449
-    no3: 0.821
-    nh4incub: -0.181
-    orgC: 2.101
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 9.203
+    soil NH4 content (mg/kg): 1.449
+    soil NO3 content: 0.821
+    incubated soil NH4 content (mg/kg): -0.181
+    soil organic carbon (%): 2.101
   Q.Y.7:
     dune: Quindalup - young
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.061
-    totalP_mgkg: 368.2940857
-    NP: 1.6680143
-    pHwater: 9.2171429
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 804.5453286
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 4.3577571
-    exchMg_mgkg: 41.7953
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 21.0173286
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 4.0147
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0111429
-    exchMg_cmolkg: 0.3438714
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0914286
-    TEB_cmolkg: 4.4611143
-    ECEC_cmolkg: 4.4611143
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.061
+    soil P, total (mg/kg): 368.2940857
+    soil N:P: 1.6680143
+    soil pH (H2O): 9.2171429
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 804.5453286
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 4.3577571
+    soil exchangeable Mg (mg/kg): 41.7953
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 21.0173286
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 4.0147
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0111429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3438714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0914286
+    soil TEB (cmol/kg): 4.4611143
+    soil cation exchange capacity (cmol/kg): 4.4611143
     latitude (deg): -30.093851
     longitude (deg): 114.990058
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 10.959
-    nh4: 1.048
-    no3: 0.037
-    nh4incub: -0.067
-    orgC: 1.983
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 10.959
+    soil NH4 content (mg/kg): 1.048
+    soil NO3 content: 0.037
+    incubated soil NH4 content (mg/kg): -0.067
+    soil organic carbon (%): 1.983
   Q.Y.8:
     dune: Quindalup - young
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0616857
-    totalP_mgkg: 344.5576714
-    NP: 1.7840143
-    pHwater: 9.2085714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 2531.1773571
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 0.0
-    exchMg_mgkg: 116.7854286
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 22.0233857
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 12.6306429
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0
-    exchMg_cmolkg: 0.9608
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0957857
-    TEB_cmolkg: 13.6872143
-    ECEC_cmolkg: 13.6872143
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0616857
+    soil P, total (mg/kg): 344.5576714
+    soil N:P: 1.7840143
+    soil pH (H2O): 9.2085714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 2531.1773571
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 0.0
+    soil exchangeable Mg (mg/kg): 116.7854286
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 22.0233857
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 12.6306429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.9608
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0957857
+    soil TEB (cmol/kg): 13.6872143
+    soil cation exchange capacity (cmol/kg): 13.6872143
     latitude (deg): -30.106683
     longitude (deg): 114.996559
-    stage: 1.0
+    choronosequence stage: 1.0
     epoch: Holocene
-    age: 50.0
-    geology: Safety Bay Sand
-    don: 9.57
-    nh4: 1.748
-    no3: 0.015
-    nh4incub: -0.116
-    orgC: 0.76
+    soil age: 50.0
+    geology (stratigraphic map unit): Safety Bay Sand
+    soil disolved organic nitrogen: 9.57
+    soil NH4 content (mg/kg): 1.748
+    soil NO3 content: 0.015
+    incubated soil NH4 content (mg/kg): -0.116
+    soil organic carbon (%): 0.76
   S.W.11:
     dune: Spearwood - west
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0432429
-    totalP_mgkg: 26.4606429
-    NP: 16.1539143
-    pHwater: 6.6185714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 949.4217714
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 30.9956286
-    exchMg_mgkg: 65.6845429
-    exchMn_mgkg: 0.4358857
-    exchNa_mgkg: 15.2215429
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 4.7376286
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0792857
-    exchMg_cmolkg: 0.5403857
-    exchMn_cmolkg: 0.0015857
-    exchNa_cmolkg: 0.0662143
-    TEB_cmolkg: 5.4235
-    ECEC_cmolkg: 5.4250857
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0432429
+    soil P, total (mg/kg): 26.4606429
+    soil N:P: 16.1539143
+    soil pH (H2O): 6.6185714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 949.4217714
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 30.9956286
+    soil exchangeable Mg (mg/kg): 65.6845429
+    soil exchangeable Mn (mg/kg): 0.4358857
+    soil exchangeable Na (mg/kg): 15.2215429
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 4.7376286
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0792857
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5403857
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0015857
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0662143
+    soil TEB (cmol/kg): 5.4235
+    soil cation exchange capacity (cmol/kg): 5.4250857
     latitude (deg): -30.1920924
     longitude (deg): 115.0630152
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 12.18
-    nh4: 1.727
-    no3: 2.166
-    nh4incub: -0.216
-    orgC: 0.862
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 12.18
+    soil NH4 content (mg/kg): 1.727
+    soil NO3 content: 2.166
+    incubated soil NH4 content (mg/kg): -0.216
+    soil organic carbon (%): 0.862
   S.W.14:
     dune: Spearwood - west
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0171571
-    totalP_mgkg: 20.4435857
-    NP: 8.5697857
-    pHwater: 6.5385714
-    exchAl_mgkg: 0.8630429
-    exchCa_mgkg: 508.0107286
-    exchFe_mgkg: 0.6744143
-    exchK_mgkg: 25.5933143
-    exchMg_mgkg: 48.6982429
-    exchMn_mgkg: 0.3905286
-    exchNa_mgkg: 5.6784857
-    exchAl_cmolkg: 0.0096
-    exchCa_cmolkg: 2.535
-    exchFe_cmolkg: 0.0036286
-    exchK_cmolkg: 0.0654429
-    exchMg_cmolkg: 0.4006286
-    exchMn_cmolkg: 0.0014286
-    exchNa_cmolkg: 0.0247
-    TEB_cmolkg: 3.0257857
-    ECEC_cmolkg: 3.0404143
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0171571
+    soil P, total (mg/kg): 20.4435857
+    soil N:P: 8.5697857
+    soil pH (H2O): 6.5385714
+    soil exchangeable Al (mg/kg): 0.8630429
+    soil exchangeable Ca (mg/kg): 508.0107286
+    soil exchangeable Fe (mg/kg): 0.6744143
+    soil exchangeable K (mg/kg): 25.5933143
+    soil exchangeable Mg (mg/kg): 48.6982429
+    soil exchangeable Mn (mg/kg): 0.3905286
+    soil exchangeable Na (mg/kg): 5.6784857
+    soil exchangeable Al (cmol/kg): 0.0096
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.535
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0036286
+    soil exchangeable K (cmol/kg, meq/100g): 0.0654429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.4006286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0014286
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0247
+    soil TEB (cmol/kg): 3.0257857
+    soil cation exchange capacity (cmol/kg): 3.0404143
     latitude (deg): -30.0826445
     longitude (deg): 115.0524686
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 9.879
-    nh4: 2.654
-    no3: 0.75
-    nh4incub: -0.332
-    orgC: 0.391
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 9.879
+    soil NH4 content (mg/kg): 2.654
+    soil NO3 content: 0.75
+    incubated soil NH4 content (mg/kg): -0.332
+    soil organic carbon (%): 0.391
   S.W.17:
     dune: Spearwood - west
-    date: 15/6/12
-    type: subplot
-    totalN_perc: 0.0222143
-    totalP_mgkg: 17.7429571
-    NP: 12.3514143
-    pHwater: 6.47
-    exchAl_mgkg: 1.851
-    exchCa_mgkg: 497.6907714
-    exchFe_mgkg: 0.9806
-    exchK_mgkg: 20.5517714
-    exchMg_mgkg: 47.1544286
-    exchMn_mgkg: 0.1384714
-    exchNa_mgkg: 8.9197857
-    exchAl_cmolkg: 0.0205857
-    exchCa_cmolkg: 2.4835
-    exchFe_cmolkg: 0.0052571
-    exchK_cmolkg: 0.0525571
-    exchMg_cmolkg: 0.3879571
-    exchMn_cmolkg: 0.0005
-    exchNa_cmolkg: 0.0388143
-    TEB_cmolkg: 2.9627857
-    ECEC_cmolkg: 2.9891571
+    data sampled: 15/6/12
+    plot type: subplot
+    soil N, total (%): 0.0222143
+    soil P, total (mg/kg): 17.7429571
+    soil N:P: 12.3514143
+    soil pH (H2O): 6.47
+    soil exchangeable Al (mg/kg): 1.851
+    soil exchangeable Ca (mg/kg): 497.6907714
+    soil exchangeable Fe (mg/kg): 0.9806
+    soil exchangeable K (mg/kg): 20.5517714
+    soil exchangeable Mg (mg/kg): 47.1544286
+    soil exchangeable Mn (mg/kg): 0.1384714
+    soil exchangeable Na (mg/kg): 8.9197857
+    soil exchangeable Al (cmol/kg): 0.0205857
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.4835
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0052571
+    soil exchangeable K (cmol/kg, meq/100g): 0.0525571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3879571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0005
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0388143
+    soil TEB (cmol/kg): 2.9627857
+    soil cation exchange capacity (cmol/kg): 2.9891571
     latitude (deg): -30.2286499
     longitude (deg): 115.0685099
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 6.67
-    nh4: 1.913
-    no3: 0.473
-    nh4incub: -0.127
-    orgC: 0.577
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 6.67
+    soil NH4 content (mg/kg): 1.913
+    soil NO3 content: 0.473
+    incubated soil NH4 content (mg/kg): -0.127
+    soil organic carbon (%): 0.577
   S.W.26:
     dune: Spearwood - west
-    date: 12/6/12
-    type: subplot
-    totalN_perc: 0.0341429
-    totalP_mgkg: 21.1981286
-    NP: 16.1133571
-    pHwater: 6.2814286
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 577.0061143
-    exchFe_mgkg: 0.0
-    exchK_mgkg: 26.3255
-    exchMg_mgkg: 62.289
-    exchMn_mgkg: 0.3588429
-    exchNa_mgkg: 15.4284286
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 2.8792857
-    exchFe_cmolkg: 0.0
-    exchK_cmolkg: 0.0673429
-    exchMg_cmolkg: 0.5124429
-    exchMn_cmolkg: 0.0013143
-    exchNa_cmolkg: 0.0671143
-    TEB_cmolkg: 3.5261714
-    ECEC_cmolkg: 3.5274857
+    data sampled: 12/6/12
+    plot type: subplot
+    soil N, total (%): 0.0341429
+    soil P, total (mg/kg): 21.1981286
+    soil N:P: 16.1133571
+    soil pH (H2O): 6.2814286
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 577.0061143
+    soil exchangeable Fe (mg/kg): 0.0
+    soil exchangeable K (mg/kg): 26.3255
+    soil exchangeable Mg (mg/kg): 62.289
+    soil exchangeable Mn (mg/kg): 0.3588429
+    soil exchangeable Na (mg/kg): 15.4284286
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.8792857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.0673429
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5124429
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0013143
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0671143
+    soil TEB (cmol/kg): 3.5261714
+    soil cation exchange capacity (cmol/kg): 3.5274857
     latitude (deg): -30.2403976
     longitude (deg): 115.0693132
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 12.059
-    nh4: 3.424
-    no3: 0.455
-    nh4incub: -0.149
-    orgC: 0.927
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 12.059
+    soil NH4 content (mg/kg): 3.424
+    soil NO3 content: 0.455
+    incubated soil NH4 content (mg/kg): -0.149
+    soil organic carbon (%): 0.927
   S.W.3:
     dune: Spearwood - west
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0642857
-    totalP_mgkg: 37.1840143
-    NP: 17.0782714
-    pHwater: 7.3585714
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 1812.3820286
-    exchFe_mgkg: 2.5611429
-    exchK_mgkg: 71.6150286
-    exchMg_mgkg: 63.2150429
-    exchMn_mgkg: 0.1100857
-    exchNa_mgkg: 9.6647143
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 9.0438286
-    exchFe_cmolkg: 0.0137571
-    exchK_cmolkg: 0.1831714
-    exchMg_cmolkg: 0.5200714
-    exchMn_cmolkg: 0.0004
-    exchNa_cmolkg: 0.0420286
-    TEB_cmolkg: 9.7891
-    ECEC_cmolkg: 9.8032571
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0642857
+    soil P, total (mg/kg): 37.1840143
+    soil N:P: 17.0782714
+    soil pH (H2O): 7.3585714
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 1812.3820286
+    soil exchangeable Fe (mg/kg): 2.5611429
+    soil exchangeable K (mg/kg): 71.6150286
+    soil exchangeable Mg (mg/kg): 63.2150429
+    soil exchangeable Mn (mg/kg): 0.1100857
+    soil exchangeable Na (mg/kg): 9.6647143
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 9.0438286
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0137571
+    soil exchangeable K (cmol/kg, meq/100g): 0.1831714
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5200714
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0004
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0420286
+    soil TEB (cmol/kg): 9.7891
+    soil cation exchange capacity (cmol/kg): 9.8032571
     latitude (deg): -30.14323
     longitude (deg): 115.0621127
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 15.192
-    nh4: 2.651
-    no3: 1.786
-    nh4incub: -0.257
-    orgC: 1.049
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 15.192
+    soil NH4 content (mg/kg): 2.651
+    soil NO3 content: 1.786
+    incubated soil NH4 content (mg/kg): -0.257
+    soil organic carbon (%): 1.049
   S.W.34:
     dune: Spearwood - west
-    date: 16/6/12
-    type: subplot
-    totalN_perc: 0.0146857
-    totalP_mgkg: 12.8282
-    NP: 11.5731
-    pHwater: 6.6957143
-    exchAl_mgkg: 0.7782143
-    exchCa_mgkg: 699.2670429
-    exchFe_mgkg: 0.9175286
-    exchK_mgkg: 28.7284429
-    exchMg_mgkg: 70.1160286
-    exchMn_mgkg: 0.1537143
-    exchNa_mgkg: 12.0986286
-    exchAl_cmolkg: 0.0086571
-    exchCa_cmolkg: 3.4893571
-    exchFe_cmolkg: 0.0049286
-    exchK_cmolkg: 0.0734714
-    exchMg_cmolkg: 0.5768571
-    exchMn_cmolkg: 0.0005571
-    exchNa_cmolkg: 0.0526286
-    TEB_cmolkg: 4.1923
-    ECEC_cmolkg: 4.2064429
+    data sampled: 16/6/12
+    plot type: subplot
+    soil N, total (%): 0.0146857
+    soil P, total (mg/kg): 12.8282
+    soil N:P: 11.5731
+    soil pH (H2O): 6.6957143
+    soil exchangeable Al (mg/kg): 0.7782143
+    soil exchangeable Ca (mg/kg): 699.2670429
+    soil exchangeable Fe (mg/kg): 0.9175286
+    soil exchangeable K (mg/kg): 28.7284429
+    soil exchangeable Mg (mg/kg): 70.1160286
+    soil exchangeable Mn (mg/kg): 0.1537143
+    soil exchangeable Na (mg/kg): 12.0986286
+    soil exchangeable Al (cmol/kg): 0.0086571
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.4893571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0049286
+    soil exchangeable K (cmol/kg, meq/100g): 0.0734714
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5768571
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0005571
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0526286
+    soil TEB (cmol/kg): 4.1923
+    soil cation exchange capacity (cmol/kg): 4.2064429
     latitude (deg): -30.02759
     longitude (deg): 115.038893
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 10.045
-    nh4: 3.238
-    no3: 1.754
-    nh4incub: -0.142
-    orgC: 0.36
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 10.045
+    soil NH4 content (mg/kg): 3.238
+    soil NO3 content: 1.754
+    incubated soil NH4 content (mg/kg): -0.142
+    soil organic carbon (%): 0.36
   S.W.35:
     dune: Spearwood - west
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0222571
-    totalP_mgkg: 15.5478857
-    NP: 14.2767
-    pHwater: 6.4542857
-    exchAl_mgkg: 0.9593714
-    exchCa_mgkg: 489.0666571
-    exchFe_mgkg: 0.7594286
-    exchK_mgkg: 26.7521714
-    exchMg_mgkg: 40.9275
-    exchMn_mgkg: 0.1304857
-    exchNa_mgkg: 16.4776857
-    exchAl_cmolkg: 0.0106714
-    exchCa_cmolkg: 2.4404429
-    exchFe_cmolkg: 0.0040714
-    exchK_cmolkg: 0.0684143
-    exchMg_cmolkg: 0.3367143
-    exchMn_cmolkg: 0.0004714
-    exchNa_cmolkg: 0.0716857
-    TEB_cmolkg: 2.9172571
-    ECEC_cmolkg: 2.9324857
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0222571
+    soil P, total (mg/kg): 15.5478857
+    soil N:P: 14.2767
+    soil pH (H2O): 6.4542857
+    soil exchangeable Al (mg/kg): 0.9593714
+    soil exchangeable Ca (mg/kg): 489.0666571
+    soil exchangeable Fe (mg/kg): 0.7594286
+    soil exchangeable K (mg/kg): 26.7521714
+    soil exchangeable Mg (mg/kg): 40.9275
+    soil exchangeable Mn (mg/kg): 0.1304857
+    soil exchangeable Na (mg/kg): 16.4776857
+    soil exchangeable Al (cmol/kg): 0.0106714
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.4404429
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0040714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0684143
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3367143
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0004714
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0716857
+    soil TEB (cmol/kg): 2.9172571
+    soil cation exchange capacity (cmol/kg): 2.9324857
     latitude (deg): -30.1978913
     longitude (deg): 115.073864
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 6.911
-    nh4: 3.144
-    no3: 1.221
-    nh4incub: 0.054
-    orgC: 0.628
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 6.911
+    soil NH4 content (mg/kg): 3.144
+    soil NO3 content: 1.221
+    incubated soil NH4 content (mg/kg): 0.054
+    soil organic carbon (%): 0.628
   S.W.36:
     dune: Spearwood - west
-    date: 14/6/12
-    type: subplot
-    totalN_perc: 0.0272857
-    totalP_mgkg: 21.6309286
-    NP: 12.8605857
-    pHwater: 6.5528571
-    exchAl_mgkg: 0.0
-    exchCa_mgkg: 570.0574571
-    exchFe_mgkg: 0.3337571
-    exchK_mgkg: 20.7419429
-    exchMg_mgkg: 47.1843143
-    exchMn_mgkg: 0.0
-    exchNa_mgkg: 6.8177714
-    exchAl_cmolkg: 0.0
-    exchCa_cmolkg: 2.8445857
-    exchFe_cmolkg: 0.0018
-    exchK_cmolkg: 0.0530571
-    exchMg_cmolkg: 0.3882
-    exchMn_cmolkg: 0.0
-    exchNa_cmolkg: 0.0296571
-    TEB_cmolkg: 3.3154714
-    ECEC_cmolkg: 3.3172714
+    data sampled: 14/6/12
+    plot type: subplot
+    soil N, total (%): 0.0272857
+    soil P, total (mg/kg): 21.6309286
+    soil N:P: 12.8605857
+    soil pH (H2O): 6.5528571
+    soil exchangeable Al (mg/kg): 0.0
+    soil exchangeable Ca (mg/kg): 570.0574571
+    soil exchangeable Fe (mg/kg): 0.3337571
+    soil exchangeable K (mg/kg): 20.7419429
+    soil exchangeable Mg (mg/kg): 47.1843143
+    soil exchangeable Mn (mg/kg): 0.0
+    soil exchangeable Na (mg/kg): 6.8177714
+    soil exchangeable Al (cmol/kg): 0.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 2.8445857
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0018
+    soil exchangeable K (cmol/kg, meq/100g): 0.0530571
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.3882
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0296571
+    soil TEB (cmol/kg): 3.3154714
+    soil cation exchange capacity (cmol/kg): 3.3172714
     latitude (deg): -30.1914824
     longitude (deg): 115.0742914
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 6.926
-    nh4: 2.462
-    no3: 1.232
-    nh4incub: 0.056
-    orgC: 0.629
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 6.926
+    soil NH4 content (mg/kg): 2.462
+    soil NO3 content: 1.232
+    incubated soil NH4 content (mg/kg): 0.056
+    soil organic carbon (%): 0.629
   S.W.6:
     dune: Spearwood - west
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0325571
-    totalP_mgkg: 26.9575571
-    NP: 11.9487571
-    pHwater: 6.5414286
-    exchAl_mgkg: 2.5001714
-    exchCa_mgkg: 653.0768143
-    exchFe_mgkg: 12.9788429
-    exchK_mgkg: 38.9690429
-    exchMg_mgkg: 61.0090143
-    exchMn_mgkg: 3.3326571
-    exchNa_mgkg: 11.9402714
-    exchAl_cmolkg: 0.0278
-    exchCa_cmolkg: 3.2588571
-    exchFe_cmolkg: 0.0697429
-    exchK_cmolkg: 0.0996714
-    exchMg_cmolkg: 0.5019286
-    exchMn_cmolkg: 0.0121286
-    exchNa_cmolkg: 0.0519286
-    TEB_cmolkg: 3.9124
-    ECEC_cmolkg: 4.0220714
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0325571
+    soil P, total (mg/kg): 26.9575571
+    soil N:P: 11.9487571
+    soil pH (H2O): 6.5414286
+    soil exchangeable Al (mg/kg): 2.5001714
+    soil exchangeable Ca (mg/kg): 653.0768143
+    soil exchangeable Fe (mg/kg): 12.9788429
+    soil exchangeable K (mg/kg): 38.9690429
+    soil exchangeable Mg (mg/kg): 61.0090143
+    soil exchangeable Mn (mg/kg): 3.3326571
+    soil exchangeable Na (mg/kg): 11.9402714
+    soil exchangeable Al (cmol/kg): 0.0278
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.2588571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0697429
+    soil exchangeable K (cmol/kg, meq/100g): 0.0996714
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5019286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0121286
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0519286
+    soil TEB (cmol/kg): 3.9124
+    soil cation exchange capacity (cmol/kg): 4.0220714
     latitude (deg): -30.0980282
     longitude (deg): 115.0579672
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 7.633
-    nh4: 3.518
-    no3: 2.015
-    nh4incub: -0.332
-    orgC: 0.689
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 7.633
+    soil NH4 content (mg/kg): 3.518
+    soil NO3 content: 2.015
+    incubated soil NH4 content (mg/kg): -0.332
+    soil organic carbon (%): 0.689
   S.W.8:
     dune: Spearwood - west
-    date: 13/6/12
-    type: subplot
-    totalN_perc: 0.0249
-    totalP_mgkg: 14.7581286
-    NP: 16.8333429
-    pHwater: 6.26
-    exchAl_mgkg: 1.9932857
-    exchCa_mgkg: 622.6570857
-    exchFe_mgkg: 1.297
-    exchK_mgkg: 21.3052857
-    exchMg_mgkg: 61.1321286
-    exchMn_mgkg: 0.4025714
-    exchNa_mgkg: 16.9883143
-    exchAl_cmolkg: 0.0221714
-    exchCa_cmolkg: 3.1070571
-    exchFe_cmolkg: 0.0069714
-    exchK_cmolkg: 0.0545
-    exchMg_cmolkg: 0.5029286
-    exchMn_cmolkg: 0.0014571
-    exchNa_cmolkg: 0.0738857
-    TEB_cmolkg: 3.7384
-    ECEC_cmolkg: 3.7690143
+    data sampled: 13/6/12
+    plot type: subplot
+    soil N, total (%): 0.0249
+    soil P, total (mg/kg): 14.7581286
+    soil N:P: 16.8333429
+    soil pH (H2O): 6.26
+    soil exchangeable Al (mg/kg): 1.9932857
+    soil exchangeable Ca (mg/kg): 622.6570857
+    soil exchangeable Fe (mg/kg): 1.297
+    soil exchangeable K (mg/kg): 21.3052857
+    soil exchangeable Mg (mg/kg): 61.1321286
+    soil exchangeable Mn (mg/kg): 0.4025714
+    soil exchangeable Na (mg/kg): 16.9883143
+    soil exchangeable Al (cmol/kg): 0.0221714
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.1070571
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.0069714
+    soil exchangeable K (cmol/kg, meq/100g): 0.0545
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.5029286
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0014571
+    soil exchangeable Na (cmol/kg, meq/100g): 0.0738857
+    soil TEB (cmol/kg): 3.7384
+    soil cation exchange capacity (cmol/kg): 3.7690143
     latitude (deg): -30.2352837
     longitude (deg): 115.0706568
-    stage: 4.0
+    choronosequence stage: 4.0
     epoch: Late Pleistocene
-    age: 120000.0
-    geology: Tamala Limestone
-    don: 14.416
-    nh4: 4.031
-    no3: 0.959
-    nh4incub: -0.266
-    orgC: 0.695
+    soil age: 120000.0
+    geology (stratigraphic map unit): Tamala Limestone
+    soil disolved organic nitrogen: 14.416
+    soil NH4 content (mg/kg): 4.031
+    soil NO3 content: 0.959
+    incubated soil NH4 content (mg/kg): -0.266
+    soil organic carbon (%): 0.695
 contexts: .na
 config:
   data_is_long_format: no
@@ -2733,4 +2733,3 @@ taxonomic_updates:
   reason: Change spelling to align with known species in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Hayes_2018/metadata.yml
+++ b/data/Hayes_2018/metadata.yml
@@ -46,75 +46,75 @@ dataset:
   notes: none
 sites:
   M.Lesueur:
-    pH (water): 5.9133333
-    pH (CaCl2): 4.57
-    Total P (mg/kg): 11.3333333
-    Olsen P (mg/kg): 0.1833333
-    Resin P (mg/kg): 0.7533333
-    Total N (%): 0.0203333
-    organic matter (%): 1.6633333
-    Ca (mg/kg): 265.31
-    Fe (mg/kg): 0.9833333
-    K (mg/kg): 8.3533333
-    Mg (mg/kg): 34.6866667
-    Mn (mg/kg): 0.8966667
-    Ca cmol/kg: 1.3233333
-    Fe cmol/kg: 0.01
-    K cmol/kg: 0.02
-    Mg cmol/kg: 0.2866667
-    Mn cmol/kg: 0.005
-    ECEC: 1.7133333
-    date: 6/17/2015
-    location detail: Peron slopes
+    soil pH (H2O): 5.9133333
+    soil pH (CaCl2): 4.57
+    soil P, total (mg/kg): 11.3333333
+    soil P, Olsen (mg/kg): 0.1833333
+    soil P, Resin (mg/kg): 0.7533333
+    soil N, total (%): 0.0203333
+    soil organic content (%): 1.6633333
+    soil Ca (mg/kg): 265.31
+    soil Fe (mg/kg): 0.9833333
+    soil K (mg/kg): 8.3533333
+    soil Mg (mg/kg): 34.6866667
+    soil Mn (mg/kg): 0.8966667
+    soil Ca (cmol/kg): 1.3233333
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.01
+    soil exchangeable K (cmol/kg, meq/100g): 0.02
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.2866667
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.005
+    soil cation exchange capacity (cmol/kg): 1.7133333
+    data sampled: 6/17/2015
+    dune: Peron slopes
     latitude (deg): -30.1664
     longitude (deg): 115.201
     description: site on the older laterite gravel of the Peron slopes
   N.Lesueur:
-    pH (water): 6.1066667
-    pH (CaCl2): 4.8633333
-    Total P (mg/kg): 9.2
-    Olsen P (mg/kg): 0.2266667
-    Resin P (mg/kg): 0.3533333
-    Total N (%): 0.0073333
-    organic matter (%): 0.98
-    Ca (mg/kg): 169.0666667
-    Fe (mg/kg): 1.62
-    K (mg/kg): 10.0933333
-    Mg (mg/kg): 21.65
-    Mn (mg/kg): 0.1433333
-    Ca cmol/kg: 0.8433333
-    Fe cmol/kg: 0.01
-    K cmol/kg: 0.0266667
-    Mg cmol/kg: 0.18
-    Mn cmol/kg: 0.0003333
-    ECEC: 1.1266667
-    date: 6/17/2015
-    location detail: Bassendean
+    soil pH (H2O): 6.1066667
+    soil pH (CaCl2): 4.8633333
+    soil P, total (mg/kg): 9.2
+    soil P, Olsen (mg/kg): 0.2266667
+    soil P, Resin (mg/kg): 0.3533333
+    soil N, total (%): 0.0073333
+    soil organic content (%): 0.98
+    soil Ca (mg/kg): 169.0666667
+    soil Fe (mg/kg): 1.62
+    soil K (mg/kg): 10.0933333
+    soil Mg (mg/kg): 21.65
+    soil Mn (mg/kg): 0.1433333
+    soil Ca (cmol/kg): 0.8433333
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.01
+    soil exchangeable K (cmol/kg, meq/100g): 0.0266667
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.18
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.0003333
+    soil cation exchange capacity (cmol/kg): 1.1266667
+    data sampled: 6/17/2015
+    dune: Bassendean
     latitude (deg): -30.1369
     longitude (deg): 115.1059
     description: site on the ~2-million-year old Bassendean stage of the Jurien Bay
       dune chronosequence
   P.Line:
-    pH (water): 6.3166667
-    pH (CaCl2): 5.2466667
-    Total P (mg/kg): 11.1
-    Olsen P (mg/kg): 0.1233333
-    Resin P (mg/kg): 0.49
-    Total N (%): 0.0156667
-    organic matter (%): 1.0933333
-    Ca (mg/kg): 114.7433333
-    Fe (mg/kg): 0.7433333
-    K (mg/kg): 10.2166667
-    Mg (mg/kg): 22.3166667
-    Mn (mg/kg): 0.4333333
-    Ca cmol/kg: 0.5733333
-    Fe cmol/kg: 0.01
-    K cmol/kg: 0.0266667
-    Mg cmol/kg: 0.18
-    Mn cmol/kg: 0.007
-    ECEC: 0.8333333
-    date: 6/17/2015
-    location detail: Bassendean
+    soil pH (H2O): 6.3166667
+    soil pH (CaCl2): 5.2466667
+    soil P, total (mg/kg): 11.1
+    soil P, Olsen (mg/kg): 0.1233333
+    soil P, Resin (mg/kg): 0.49
+    soil N, total (%): 0.0156667
+    soil organic matter (%): 1.0933333
+    soil Ca (mg/kg): 114.7433333
+    soil Fe (mg/kg): 0.7433333
+    soil K (mg/kg): 10.2166667
+    soil Mg (mg/kg): 22.3166667
+    soil Mn (mg/kg): 0.4333333
+    soil Ca (cmol/kg): 0.5733333
+    soil exchangeable Fe (cmol/kg, meq/100g): 0.01
+    soil exchangeable K (cmol/kg, meq/100g): 0.0266667
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.18
+    soil exchangeable Mn (cmol/kg, meq/100g): 0.007
+    soil cation exchange capacity (cmol/kg): 0.8333333
+    data sampled: 6/17/2015
+    dune: Bassendean
     latitude (deg): -30.1579
     longitude (deg): 115.116
     description: site on the ~2-million-year old Bassendean stage of the Jurien Bay
@@ -1063,4 +1063,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Hayes_2018/metadata.yml
+++ b/data/Hayes_2018/metadata.yml
@@ -64,7 +64,7 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.2866667
     soil exchangeable Mn (cmol/kg, meq/100g): 0.005
     soil cation exchange capacity (cmol/kg): 1.7133333
-    data sampled: 6/17/2015
+    date sampled: 6/17/2015
     dune: Peron slopes
     latitude (deg): -30.1664
     longitude (deg): 115.201
@@ -88,7 +88,7 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.18
     soil exchangeable Mn (cmol/kg, meq/100g): 0.0003333
     soil cation exchange capacity (cmol/kg): 1.1266667
-    data sampled: 6/17/2015
+    date sampled: 6/17/2015
     dune: Bassendean
     latitude (deg): -30.1369
     longitude (deg): 115.1059
@@ -113,7 +113,7 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.18
     soil exchangeable Mn (cmol/kg, meq/100g): 0.007
     soil cation exchange capacity (cmol/kg): 0.8333333
-    data sampled: 6/17/2015
+    date sampled: 6/17/2015
     dune: Bassendean
     latitude (deg): -30.1579
     longitude (deg): 115.116

--- a/data/Henery_2001/metadata.yml
+++ b/data/Henery_2001/metadata.yml
@@ -39,7 +39,7 @@ sites:
   Kuringgai_NP:
     longitude (deg): 151.13
     latitude (deg): -33.69
-    lat/lon notes: 'Data were collected from six sites in Kuringgai National Park:
+    georeference remarks: 'Data were collected from six sites in Kuringgai National Park:
       Perimeter Track, 33deg 39min 40secS, 151deg 11min 26sec S; Murrua Track (Woodland),
       33deg 40min 53sec S, 151deg 8min 50secS; Chase Trail (Woodland), 33deg 41min
       7sec S, 151deg 7 min 51sec S; Long Track, 33deg 38min 25secS, 151deg 10min 58secS;

--- a/data/Henery_2001/metadata.yml
+++ b/data/Henery_2001/metadata.yml
@@ -39,15 +39,15 @@ sites:
   Kuringgai_NP:
     longitude (deg): 151.13
     latitude (deg): -33.69
-    coordinate details: 'Data were collected from six sites in Kuringgai National
-      Park: Perimeter Track, 33deg 39min 40secS, 151deg 11min 26sec S; Murrua Track
-      (Woodland), 33deg 40min 53sec S, 151deg 8min 50secS; Chase Trail (Woodland),
-      33deg 41min 7sec S, 151deg 7 min 51sec S; Long Track, 33deg 38min 25secS, 151deg
-      10min 58secS; Chase Trail (Heath), 33 deg 41min45secS, 151 deg 6min 38secS;
-      Murrua Track (Heath), 33 deg 40min58secS, 151 deg 8min 38sec S. The coordinates
-      for the Chase Trail are given as an approximate location. All values reported
-      are multi-site means across sites. Which species were sampled at which sites
-      is recorded in the file location_data.csv within the raw folder'
+    lat/lon notes: 'Data were collected from six sites in Kuringgai National Park:
+      Perimeter Track, 33deg 39min 40secS, 151deg 11min 26sec S; Murrua Track (Woodland),
+      33deg 40min 53sec S, 151deg 8min 50secS; Chase Trail (Woodland), 33deg 41min
+      7sec S, 151deg 7 min 51sec S; Long Track, 33deg 38min 25secS, 151deg 10min 58secS;
+      Chase Trail (Heath), 33 deg 41min45secS, 151 deg 6min 38secS; Murrua Track (Heath),
+      33 deg 40min58secS, 151 deg 8min 38sec S. The coordinates for the Chase Trail
+      are given as an approximate location. All values reported are multi-site means
+      across sites. Which species were sampled at which sites is recorded in the file
+      location_data.csv within the raw folder'
     description: Sites were widely separated level surfaces with similar (9-11 yr)
       elapsed time since the last fire and with a common soil type derived from a
       geology of underlying Hawkesbury sandstone. These soils are depauperate in nutrients,
@@ -123,4 +123,3 @@ taxonomic_updates:
   reason: Align to existing species (E. Wenk, 2020-05-23)
 exclude_observations: .na
 questions: .na
-

--- a/data/Hocking_1982/metadata.yml
+++ b/data/Hocking_1982/metadata.yml
@@ -9,7 +9,7 @@ source:
       Hakea undulata, from south-western Australia
     volume: '30'
     number: '2'
-    pages: '219--230'
+    pages: 219--230
     doi: 10.1071/bt9820219
 people:
 - name: Peter Hocking
@@ -51,9 +51,9 @@ sites:
     latitude (deg): -31.74
     longitude (deg): 116.07
     description: jarrah woodland
-    precipitation: area lies within the 850-1000 mm rainfall isohyets
-    soil: ironstone gravel with a sandy matrix that had been derived from weathered
-      lateritic duricrust (Beard 1979)
+    precipitation, MAP (mm): area lies within the 850-1000 mm rainfall isohyets
+    geology (parent material): ironstone gravel with a sandy matrix that had been
+      derived from weathered lateritic duricrust (Beard 1979)
 contexts: .na
 config:
   data_is_long_format: no
@@ -366,4 +366,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Hughes_2005/metadata.yml
+++ b/data/Hughes_2005/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: Kate Hughes
     year: 2005
-    title: 'Unpublished data: Wood and stem density data for Australian plant species, Macquarie University'
+    title: 'Unpublished data: Wood and stem density data for Australian plant species,
+      Macquarie University'
 people:
 - name: Kate Hughes
   institution: unknown
@@ -43,33 +44,33 @@ sites:
     latitude (deg): -32.9666667
     description: woodland site near Round Hill; same location sampled extensively
       by Ian Wright
-    soil_total_P (ppm): 250.4
-    soil_total_N (%): 0.071
-    soil_total_C (%): 1.2
-    soil_cation_exchange_capacity (meq/kg): 65.8
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
   RHM:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
     description: mallee site near Round Hill; same location sampled extensively by
       Ian Wright
-    soil_total_P (ppm): 132.4
-    soil_total_N (%): 0.031
-    soil_total_C (%): 0.67
-    soil_cation_exchange_capacity (meq/kg): 38.7
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
   ghp:
     longitude (deg): 151.3166667
     latitude (deg): -33.3833333
-    rainfall (mm): 1300
-    MAT (deg): 17.5
+    precipitation, MAP (mm): 1300
+    temperature, MAT (C): 17.5
     description: Closed forest near Gosford with high P concentration
-    soil_total_P (ppm): 335
+    soil P, total (mg/kg): 335
   glp:
     longitude (deg): 151.3166667
     latitude (deg): -33.3667
-    rainfall (mm): 1300
-    MAT (deg): 17.5
+    precipitation, MAP (mm): 1300
+    temperature, MAT (C): 17.5
     description: Open woodland near Gosford with low P concentration
-    soil_total_P (ppm): 98
+    soil P, total (mg/kg): 98
 contexts: .na
 config:
   data_is_long_format: no
@@ -528,4 +529,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: additional vessel, lumen traits
-

--- a/data/Islam_1999_1/metadata.yml
+++ b/data/Islam_1999_1/metadata.yml
@@ -56,13 +56,13 @@ sites:
   Hamersley station Pilbara:
     longitude (deg): 117.6166667
     latitude (deg): -22.33
-    soil_pH (mol/l): 7.1
-    OMC (%): 1.21
-    soil_total_N (mg/g): 0.99
-    soil_total_P (ug/g): 4.7
-    rainfall (mm): 354
-    min_monthly_temp: 6
-    max_monthly_temp: 36
+    soil pH (H2O): 7.1
+    soil organic content (%): 1.21
+    soil N, total (mg/g): 0.99
+    soil P, total (mg/kg): 4.7
+    precipitation, MAP (mm): 354
+    temperature, monthly min (C): 6
+    temperature, monthly max (C): 36
     description: The soil type at the study sites is a silty clay loam of high P-fixation
       capacity and is rich in iron and aluminium oxides and poor in available N and
       P (Bennett and Adams 1999). Long-term annual rainfall at Hamersley Station is
@@ -196,4 +196,3 @@ taxonomic_updates:
   reason: Change spelling to Align to APC or ALA species lists (Sam Andrew, 2018-02-07)
 exclude_observations: .na
 questions: .na
-

--- a/data/Islam_1999_2/metadata.yml
+++ b/data/Islam_1999_2/metadata.yml
@@ -42,13 +42,13 @@ sites:
   Hamersley station Pilbara:
     longitude (deg): 117.6166667
     latitude (deg): -22.33
-    soil_pH (mol/l): 7.1
-    OMC (%): 1.21
-    soil_total_N (mg/g): 0.99
-    soil_total_P (ug/g): 4.7
-    rainfall (mm): 354
-    min_monthly_temp: 6
-    max_monthly_temp: 36
+    soil pH (H2O): 7.1
+    soil organic content (%): 1.21
+    soil N, total (mg/g): 0.99
+    soil P, total (mg/kg): 4.7
+    precipitation, MAP (mm): 354
+    temperature, monthly min (C): 6
+    temperature, monthly max (C): 36
     description: The experiment was conducted at Hamersley Station, 40 km north-west
       of Tom Price, Western Australia, Australia (22 deg 20 'S, 117 deg 37 'E) during
       1996-97. The site has a semi-arid, subtropical climate, with hot summers and
@@ -170,4 +170,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: non-structural carbohydrates, dry matter digestibility
-

--- a/data/Jagdish_2020/metadata.yml
+++ b/data/Jagdish_2020/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     year: 2020
     author: Ashika Jagdish
-    title: "Unpublished data: Germination photoperiod sensitivity of Australian Plants, University of New South Wales"
+    title: 'Unpublished data: Germination photoperiod sensitivity of Australian Plants,
+      University of New South Wales'
 people:
 - name: Ashika Jagdish
   institution: University of New South Wales
@@ -35,296 +36,296 @@ sites:
   Bald Rock National Park (site_at_-28.8527_S_and_152.0401_E):
     latitude (deg): -28.8527
     longitude (deg): 152.0401
-    LAI: 1.533318
-    Site abbreviation: B.Rock
+    leaf area index: 1.533318
+    site code: B.Rock
     description: .na.character
   Border Ranges National Park (site_at_-28.3827_S_and_153.0607_E):
     latitude (deg): -28.3827
     longitude (deg): 153.0607
-    LAI: 4.9999499
-    Site abbreviation: B.R.N.P
+    leaf area index: 4.9999499
+    site code: B.R.N.P
     description: .na.character
   Chambigne Nature Reserve (site_at_-29.8068_S_and_152.7778_E):
     latitude (deg): -29.8068
     longitude (deg): 152.7778
-    LAI: 2.66664
-    Site abbreviation: C.N.R
+    leaf area index: 2.66664
+    site code: C.N.R
     description: .na.character
   Dorrigo National Park (site_at_-30.3658_S_and_152.7304_E):
     latitude (deg): -30.3658
     longitude (deg): 152.7304
-    LAI: 4.4332891
-    Site abbreviation: D.N.P
+    leaf area index: 4.4332891
+    site code: D.N.P
     description: .na.character
   Kosciuszko National Park (site_at_-36.3440_S_and_148.5382_E):
     latitude (deg): -36.344
     longitude (deg): 148.5382
-    LAI: 2.4666419
-    Site abbreviation: K.N.P
+    leaf area index: 2.4666419
+    site code: K.N.P
     description: <=1500m Above Sea Level
   Kosciuszko National Park (site_at_-36.3471_S_and_148.5270_E):
     latitude (deg): -36.3471
     longitude (deg): 148.527
-    LAI: 2.033313
-    Site abbreviation: K.N.P
+    leaf area index: 2.033313
+    site code: K.N.P
     description: <=1500m Above Sea Level
   Kosciuszko National Park (site_at_-36.3503_S_and_148.5202_E):
     latitude (deg): -36.3503
     longitude (deg): 148.5202
-    LAI: 2.2333109
-    Site abbreviation: K.N.P
+    leaf area index: 2.2333109
+    site code: K.N.P
     description: <=1500m Above Sea Level
   Kosciuszko National Park (site_at_-36.3513_S_and_148.5181_E):
     latitude (deg): -36.3513
     longitude (deg): 148.5181
-    LAI: 2.2333109
-    Site abbreviation: K.N.P
+    leaf area index: 2.2333109
+    site code: K.N.P
     description: <=1500m Above Sea Level
   Kosciuszko National Park (site_at_-36.4351_S_and_148.5184_E):
     latitude (deg): -36.4351
     longitude (deg): 148.5184
-    LAI: 1.899981
-    Site abbreviation: K.N.P
+    leaf area index: 1.899981
+    site code: K.N.P
     description: <=1500m Above Sea Level
   Kosciuszko National Park Alpine area (site_at_-36.4376_S_and_148.3198_E):
     latitude (deg): -36.4376
     longitude (deg): 148.3198
-    LAI: 2.133312
-    Site abbreviation: K.N.P.A
+    leaf area index: 2.133312
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4377_S_and_148.3198_E):
     latitude (deg): -36.4377
     longitude (deg): 148.3198
-    LAI: 2.133312
-    Site abbreviation: K.N.P.A
+    leaf area index: 2.133312
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4378_S_and_148.3197_E):
     latitude (deg): -36.4378
     longitude (deg): 148.3197
-    LAI: 2.133312
-    Site abbreviation: K.N.P.A
+    leaf area index: 2.133312
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4382_S_and_148.3228_E):
     latitude (deg): -36.4382
     longitude (deg): 148.3228
-    LAI: 1.799982
-    Site abbreviation: K.N.P.A
+    leaf area index: 1.799982
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4389_S_and_148.3187_E):
     latitude (deg): -36.4389
     longitude (deg): 148.3187
-    LAI: 2.133312
-    Site abbreviation: K.N.P.A
+    leaf area index: 2.133312
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4539_S_and_148.2656_E):
     latitude (deg): -36.4539
     longitude (deg): 148.2656
-    LAI: 0.833325
-    Site abbreviation: K.N.P.A
+    leaf area index: 0.833325
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4556_S_and_148.2624_E):
     latitude (deg): -36.4556
     longitude (deg): 148.2624
-    LAI: 0.499995
-    Site abbreviation: K.N.P.A
+    leaf area index: 0.499995
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4568_S_and_148.2680_E):
     latitude (deg): -36.4568
     longitude (deg): 148.268
-    LAI: 1.133322
-    Site abbreviation: K.N.P.A
+    leaf area index: 1.133322
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4661_S_and_148.2700_E):
     latitude (deg): -36.4661
     longitude (deg): 148.27
-    LAI: 0.899991
-    Site abbreviation: K.N.P.A
+    leaf area index: 0.899991
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Kosciuszko National Park Alpine area (site_at_-36.4916_S_and_148.2852_E):
     latitude (deg): -36.4916
     longitude (deg): 148.2852
-    LAI: 1.566651
-    Site abbreviation: K.N.P.A
+    leaf area index: 1.566651
+    site code: K.N.P.A
     description: alpine (>=1500m Above Sea Level)
   Mallanganee National Park (site_at_-28.8988_S_and_152.7401_E):
     latitude (deg): -28.8988
     longitude (deg): 152.7401
-    LAI: 4.9999499
-    Site abbreviation: M.N.P
+    leaf area index: 4.9999499
+    site code: M.N.P
     description: .na.character
   Mallanganee National Park (site_at_-28.8988_S_and_152.7406_E):
     latitude (deg): -28.8988
     longitude (deg): 152.7406
-    LAI: 4.9999499
-    Site abbreviation: M.N.P
+    leaf area index: 4.9999499
+    site code: M.N.P
     description: .na.character
   Mallanganee National Park (site_at_-29.8988_S_and_152.7406_E):
     latitude (deg): -29.8988
     longitude (deg): 152.7406
-    LAI: 2.266644
-    Site abbreviation: M.N.P
+    leaf area index: 2.266644
+    site code: M.N.P
     description: .na.character
   Queensland Rainforest (site_at_-16.6235_S_and_145.3102_E):
     latitude (deg): -16.6235
     longitude (deg): 145.3102
-    LAI: 5.4666119
-    Site abbreviation: Q.L.D
+    leaf area index: 5.4666119
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-16.6251_S_and_145.3118_E):
     latitude (deg): -16.6251
     longitude (deg): 145.3118
-    LAI: 5.3999457
-    Site abbreviation: Q.L.D
+    leaf area index: 5.3999457
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.3378_S_and_145.5811_E):
     latitude (deg): -17.3378
     longitude (deg): 145.5811
-    LAI: 4.4999552
-    Site abbreviation: Q.L.D
+    leaf area index: 4.4999552
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4122_S_and_145.7005_E):
     latitude (deg): -17.4122
     longitude (deg): 145.7005
-    LAI: 5.266614
-    Site abbreviation: Q.L.D
+    leaf area index: 5.266614
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4123_S_and_145.7006_E):
     latitude (deg): -17.4123
     longitude (deg): 145.7006
-    LAI: 5.3666129
-    Site abbreviation: Q.L.D
+    leaf area index: 5.3666129
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4160_S_and_145.7000_E):
     latitude (deg): -17.416
     longitude (deg): 145.7
-    LAI: 5.1332822
-    Site abbreviation: Q.L.D
+    leaf area index: 5.1332822
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4467_S_and_145.4763_E):
     latitude (deg): -17.4467
     longitude (deg): 145.4763
-    LAI: 5.266614
-    Site abbreviation: Q.L.D
+    leaf area index: 5.266614
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4583_S_and_145.4697_E):
     latitude (deg): -17.4583
     longitude (deg): 145.4697
-    LAI: 5.3332801
-    Site abbreviation: Q.L.D
+    leaf area index: 5.3332801
+    site code: Q.L.D
     description: rainforest
   Queensland Rainforest (site_at_-17.4640_S_and_145.4787_E):
     latitude (deg): -17.464
     longitude (deg): 145.4787
-    LAI: 5.2332811
-    Site abbreviation: Q.L.D
+    leaf area index: 5.2332811
+    site code: Q.L.D
     description: rainforest
   Queensland Wet Sclerophyll Forest (site_at_-17.3922_S_and_145.3873_E):
     latitude (deg): -17.3922
     longitude (deg): 145.3873
-    LAI: 1.833315
-    Site abbreviation: Q.L.D.S
+    leaf area index: 1.833315
+    site code: Q.L.D.S
     description: wet sclerophyll forest
   Queensland Wet Sclerophyll Forest (site_at_-17.4300_S_and_145.4027_E):
     latitude (deg): -17.43
     longitude (deg): 145.4027
-    LAI: 3.033303
-    Site abbreviation: Q.L.D.S
+    leaf area index: 3.033303
+    site code: Q.L.D.S
     description: wet sclerophyll forest
   Queensland Wet Sclerophyll Forest (site_at_-17.4553_S_and_145.4643_E):
     latitude (deg): -17.4553
     longitude (deg): 145.4643
-    LAI: 5.1332822
-    Site abbreviation: Q.L.D.S
+    leaf area index: 5.1332822
+    site code: Q.L.D.S
     description: wet sclerophyll forest
   Queensland Wet Sclerophyll Forest (site_at_-17.4583_S_and_145.4697_E):
     latitude (deg): -17.4583
     longitude (deg): 145.4697
-    LAI: 5.3332801
-    Site abbreviation: Q.L.D.S
+    leaf area index: 5.3332801
+    site code: Q.L.D.S
     description: wet sclerophyll forest
   Queensland Woodland (site_at_-17.3683_S_and_145.3128_E):
     latitude (deg): -17.3683
     longitude (deg): 145.3128
-    LAI: 1.633317
-    Site abbreviation: Q.L.D.W
+    leaf area index: 1.633317
+    site code: Q.L.D.W
     description: woodland
   Queensland Woodland (site_at_-17.3782_S_and_145.2530_E):
     latitude (deg): -17.3782
     longitude (deg): 145.253
-    LAI: 1.533318
-    Site abbreviation: Q.L.D.W
+    leaf area index: 1.533318
+    site code: Q.L.D.W
     description: woodland
   Queensland Woodland (site_at_-17.3820_S_and_145.2577_E):
     latitude (deg): -17.382
     longitude (deg): 145.2577
-    LAI: 1.299987
-    Site abbreviation: Q.L.D.W
+    leaf area index: 1.299987
+    site code: Q.L.D.W
     description: woodland
   Queensland Woodland (site_at_-17.3830_S_and_145.3787_E):
     latitude (deg): -17.383
     longitude (deg): 145.3787
-    LAI: 1.499985
-    Site abbreviation: Q.L.D.W
+    leaf area index: 1.499985
+    site code: Q.L.D.W
     description: woodland
   Queensland Woodland (site_at_-17.3913_S_and_145.3758_E):
     latitude (deg): -17.3913
     longitude (deg): 145.3758
-    LAI: 1.366653
-    Site abbreviation: Q.L.D.W
+    leaf area index: 1.366653
+    site code: Q.L.D.W
     description: woodland
   Rocky Creek at Fortis Creek National Park (site_at_-29.4718_S_and_152.8611_E):
     latitude (deg): -29.4718
     longitude (deg): 152.8611
-    LAI: 2.499975
-    Site abbreviation: R.C
+    leaf area index: 2.499975
+    site code: R.C
     description: .na.character
   Royal National Park (Coast Walk) (site_at_-34.0954_S_and_151.1601_E):
     latitude (deg): -34.0954
     longitude (deg): 151.1601
-    LAI: 1.366653
-    Site abbreviation: C.W
+    leaf area index: 1.366653
+    site code: C.W
     description: heathland
   Royal National Park (Flat Rock Creek) (site_at_-34.1138_S_and_151.0664_E):
     latitude (deg): -34.1138
     longitude (deg): 151.0664
-    LAI: 3.3666329
-    Site abbreviation: R.N.P
+    leaf area index: 3.3666329
+    site code: R.N.P
     description: .na.character
   The Australian Botanic Garden (site_at_-34.0659_S_and_150.7690_E):
     latitude (deg): -34.0659
     longitude (deg): 150.769
-    LAI: 1.466652
-    Site abbreviation: A.B.G
+    leaf area index: 1.466652
+    site code: A.B.G
     description: Cumberland Plain Woodland
   The Australian Botanic Garden (site_at_-34.0659_S_and_150.7691_E):
     latitude (deg): -34.0659
     longitude (deg): 150.7691
-    LAI: 1.466652
-    Site abbreviation: A.B.G
+    leaf area index: 1.466652
+    site code: A.B.G
     description: Cumberland Plain Woodland
   Thungutti Swamp (site_at_-28.5207_S_and_152.7479_E):
     latitude (deg): -28.5207
     longitude (deg): 152.7479
-    LAI: 5.4999452
-    Site abbreviation: T.S
+    leaf area index: 5.4999452
+    site code: T.S
     description: .na.character
   Thungutti Swamp (site_at_-30.5013_S_and_152.3859_E):
     latitude (deg): -30.5013
     longitude (deg): 152.3859
-    LAI: 4.1332922
-    Site abbreviation: T.S
+    leaf area index: 4.1332922
+    site code: T.S
     description: .na.character
   Thungutti Swamp (site_at_-30.6017_S_and_152.3854_E):
     latitude (deg): -30.6017
     longitude (deg): 152.3854
-    LAI: 5.2999468
-    Site abbreviation: T.S
+    leaf area index: 5.2999468
+    site code: T.S
     description: .na.character
   Toonumber National Park (site_at_-28.5207_S_and_152.7479_E):
     latitude (deg): -28.5207
     longitude (deg): 152.7479
-    LAI: 5.4999452
-    Site abbreviation: T.N.P
+    leaf area index: 5.4999452
+    site code: T.N.P
     description: .na.character
 contexts:
   control:
@@ -418,4 +419,3 @@ taxonomic_updates:
   reason: Alignment with known name in APC names (Elizabeth Wenk, 2020-08-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Jordan_2007/metadata.yml
+++ b/data/Jordan_2007/metadata.yml
@@ -25,20 +25,20 @@ sites:
   Frodshams Pass:
     longitude (deg): 146.4
     latitude (deg): -42.8
-    MAP (mm): 1780
-    MAT (C): 8.5
+    precipitation, MAP (mm): 1780
+    temperature, MAT (C): 8.5
     description: All woody species growing in community; cool temperate rainforest
   Mt_Read:
     longitude (deg): 145.6
     latitude (deg): -41.8
-    MAP (mm): 3710
-    MAT (C): 6.5
+    precipitation, MAP (mm): 3710
+    temperature, MAT (C): 6.5
     description: All woody species growing in community; montane  cool temperate rainforest
   wet_scler_UTAS:
     longitude (deg): 147.3
     latitude (deg): -42.9
-    MAP (mm): 620
-    MAT (C): 12.1
+    precipitation, MAP (mm): 620
+    temperature, MAT (C): 12.1
     description: All woody species growing in community; lowland wet sclerophyll forest
 contexts: .na
 config:
@@ -200,4 +200,3 @@ taxonomic_updates:
   reason: Change spelling to align with APC or ALA species lists (Sam Andrew, 2018-02-07)
 exclude_observations: .na
 questions: .na
-

--- a/data/Jordan_2015/metadata.yml
+++ b/data/Jordan_2015/metadata.yml
@@ -37,202 +37,202 @@ sites:
   15.5km along Mt Lewis road, Mt Lewis, Queensland (tropical rainforest):
     latitude (deg): -16.6
     longitude (deg): 145.283
-    Altitude (m): 1000.0
+    elevation (m): 1000.0
     description: tropical rainforest
   15km along Mt Lewis road, Mt Lewis, Queensland (tropical rainforest):
     latitude (deg): -16.6
     longitude (deg): 145.283
-    Altitude (m): 1000.0
+    elevation (m): 1000.0
     description: tropical rainforest
   15km E of Rosebery on Murchison Highway (wet heath):
     latitude (deg): -41.833
     longitude (deg): 145.4
-    Altitude (m): 150.0
+    elevation (m): 150.0
     description: wet heath
   Appin to Bulli Road, ~1km east of the Cataract Dam turnoff (dry sclerophyll woodland):
     latitude (deg): -34.25
     longitude (deg): 150.85
-    Altitude (m): 411.0
+    elevation (m): 411.0
     description: dry sclerophyll woodland
   Binna Burra area, Lamington National Park (subtropical rainforest):
     latitude (deg): -28.2
     longitude (deg): 153.183
-    Altitude (m): 900.0
+    elevation (m): 900.0
     description: subtropical rainforest
   Chimney Pot Hill Road, Tasmania (dry sclerophyll woodland):
     latitude (deg): -42.917
     longitude (deg): 147.283
-    Altitude (m): 340.0
+    elevation (m): 340.0
     description: dry sclerophyll woodland
   cultivated, Adelaide Botanic Gardens (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, Brisbane (subtropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: subtropical rainforest
   cultivated, CSIRO Arboretum, Queensland (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, Mt Annan Botanic Gardens (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, Mt Annan Botanic Gardens (temperate forest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: temperate forest
   cultivated, Mt Coot-Tha Botanical Gardens (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, Mt Tomah Botanic Garden (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, Mt Tomah Botanic Garden (montane heath):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: montane heath
   cultivated, Mt Tomah Botanic Garden (temperate forest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: temperate forest
   cultivated, Noosa Botanical Gardens (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, Proctors Road, Hobart (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, QRS Arboretum, Atherton (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, QRS Arboretum, Atherton, based on specimen collected by Bruce Gray (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, Royal Sydney Botanic Gardens (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, Royal Sydney Botanic Gardens (subtropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: subtropical rainforest
   cultivated, Royal Sydney Botanic Gardens (temperate forest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: temperate forest
   cultivated, Royal Sydney Botanic Gardens (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   cultivated, Royal Tasmanian Botanic Gardens (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, Tolga, North Queensland (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, University of Tasmania (dry sclerophyll woodland):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: dry sclerophyll woodland
   cultivated, University of Tasmania (montane heath):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: montane heath
   cultivated, University of Tasmania (temperate forest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: temperate forest
   cultivated, University of Tasmania (tropical rainforest):
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Altitude (m): .na.real
+    elevation (m): .na.real
     description: tropical rainforest
   Gingin, Western Australia (dry sclerophyll woodland):
     latitude (deg): -31.083
     longitude (deg): 115.65
-    Altitude (m): 150.0
+    elevation (m): 150.0
     description: dry sclerophyll woodland
   Glass House Mountains National Park, off Mawsons Road, E of Beerwah. (dry sclerophyll woodland):
     latitude (deg): -26.867
     longitude (deg): 152.983
-    Altitude (m): 20.0
+    elevation (m): 20.0
     description: dry sclerophyll woodland
   Glasshouse Mtns National Park, trachyte circuit track between Tiborgargan Creek and Caves Road (dry sclerophyll woodland):
     latitude (deg): -26.867
     longitude (deg): 152.983
-    Altitude (m): 30.0
+    elevation (m): 30.0
     description: dry sclerophyll woodland
   Malanda road, Milla Milla, North Queensland (tropical rainforest):
     latitude (deg): -17.367
     longitude (deg): 145.683
-    Altitude (m): 810.0
+    elevation (m): 810.0
     description: tropical rainforest
   Mt Bartle Frere Track near Bobbin Bobbin Falls (tropical rainforest):
     latitude (deg): -17.367
     longitude (deg): 145.767
-    Altitude (m): 850.0
+    elevation (m): 850.0
     description: tropical rainforest
   Mt Read, Tasmania, near summit (montane heath):
     latitude (deg): -41.833
     longitude (deg): 145.533
-    Altitude (m): 1000.0
+    elevation (m): 1000.0
     description: montane heath
   Mt Read, Tasmania, near summit (temperate forest):
     latitude (deg): -41.833
     longitude (deg): 145.533
-    Altitude (m): 1000.0
+    elevation (m): 1000.0
     description: temperate forest
   Mt Wellington, Tasmania, just below summit (montane heath):
     latitude (deg): -42.883
     longitude (deg): 147.283
-    Altitude (m): 1200.0
+    elevation (m): 1200.0
     description: montane heath
   Mt Wellington, Tasmania, just below summit (temperate forest):
     latitude (deg): -42.883
     longitude (deg): 147.283
-    Altitude (m): 1200.0
+    elevation (m): 1200.0
     description: temperate forest
   Mt Wilson Road, 2.35 km NE of Bells Line of Road (dry sclerophyll woodland):
     latitude (deg): -33.533
     longitude (deg): 150.35
-    Altitude (m): 930.0
+    elevation (m): 930.0
     description: dry sclerophyll woodland
   Wentworth Falls, Blue Mountains (dry sclerophyll woodland):
     latitude (deg): -33.683
     longitude (deg): 150.333
-    Altitude (m): 850.0
+    elevation (m): 850.0
     description: dry sclerophyll woodland
 contexts: .na
 config:
@@ -334,7 +334,8 @@ taxonomic_updates:
   reason: align to APNI name with known genus (E. Wenk, 2020-06-26)
 exclude_observations:
 - variable: taxon_name
-  find: Aulax cancellata, Leucadendron salignum, Protea neriifolia, Protea cynaroides, Protea gaguedii
+  find: Aulax cancellata, Leucadendron salignum, Protea neriifolia, Protea cynaroides,
+    Protea gaguedii
   reason: non-native (South African)
 - variable: taxon_name
   find: Knightia excelsa
@@ -346,4 +347,3 @@ exclude_observations:
   find: Roupala pseudocordata
   reason: non-native (South America)
 questions: .na
-

--- a/data/Jordan_2020/metadata.yml
+++ b/data/Jordan_2020/metadata.yml
@@ -1927,4 +1927,3 @@ exclude_observations:
 questions:
   additional_traits: Lots of binary traits describing detailed anatomical features
     to protect stomata; other anatomical traits
-

--- a/data/Jurado_1991/metadata.yml
+++ b/data/Jurado_1991/metadata.yml
@@ -36,7 +36,7 @@ sites:
   Kunoth_Paddock:
     longitude (deg): 133.616667
     latitude (deg): -23.5
-    rainfall (mm): 263
+    precipitation, MAP (mm): 263
     description: Collections were made in open woodlands, floodplains and mulga country
       around Alice Springs (23 deg 42' S, 133 deg 52' E), Northern Territory. Alice
       Springs has an arid climate, with a mean annual rainfall of 263 mm, of which
@@ -246,4 +246,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Jurado_1992/metadata.yml
+++ b/data/Jurado_1992/metadata.yml
@@ -113,4 +113,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: germination speed (days to 50% germination)
-

--- a/data/Kanowski_2000/metadata.yml
+++ b/data/Kanowski_2000/metadata.yml
@@ -79,141 +79,141 @@ dataset:
     R code, as John Kanowski suspects the values are lower than the reported value.
 sites:
   Arthur Baillie Rd:
-    site number: 7
+    site code: 7
     latitude (deg): -17.68914
     longitude (deg): 145.50649
-    altitude: highland (800-1200 m)
-    geology: acid igneous or metamorphic
-    comments: ridge with gently sloping sides
-    rainfall (MAP, mm): 1793
+    elevation (m): highland (800-1200 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: ridge with gently sloping sides
+    precipitation, MAP (mm): 1793
   Cairns Track:
-    site number: 13
+    site code: 13
     latitude (deg): -17.35164
     longitude (deg): 145.72726
-    altitude: upland (400 - 800 m)
-    geology: acid igneous or metamorphic
-    comments: steep ridge, close to basalt flow
-    rainfall (MAP, mm): 2488
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: steep ridge, close to basalt flow
+    precipitation, MAP (mm): 2488
   Lamins Hill (Cairns track):
-    site number: 9
+    site code: 9
     latitude (deg): -17.36528
     longitude (deg): 145.71537
-    altitude: upland (400 - 800 m)
-    geology: basalt
-    comments: ridge, near edge of basalt flow
-    rainfall (MAP, mm): 2844
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): basalt
+    notes: ridge, near edge of basalt flow
+    precipitation, MAP (mm): 2844
   Longlands Gap (basalt):
-    site number: 1
+    site code: 1
     latitude (deg): -17.46028
     longitude (deg): 145.47473
-    altitude: highland (800-1200 m)
-    geology: basalt
-    comments: ridge, near edge of basalt flow
-    rainfall (MAP, mm): 2244
+    elevation (m): highland (800-1200 m)
+    geology (parent material): basalt
+    notes: ridge, near edge of basalt flow
+    precipitation, MAP (mm): 2244
   Longlands Gap (rhyolite):
-    site number: 5
+    site code: 5
     latitude (deg): -17.45501
     longitude (deg): 145.47862
-    altitude: highland (800-1200 m)
-    geology: acid igneous or metamorphic
-    comments: narrow, steep-sided ridge
-    rainfall (MAP, mm): 2302
+    elevation (m): highland (800-1200 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: narrow, steep-sided ridge
+    precipitation, MAP (mm): 2302
   Malaan SF:
-    site number: 4
+    site code: 4
     latitude (deg): -17.58672
     longitude (deg): 145.582
-    altitude: highland (800-1200 m)
-    geology: basalt
-    comments: narrow, steep-sided ridge
-    rainfall (MAP, mm): 2292
+    elevation (m): highland (800-1200 m)
+    geology (parent material): basalt
+    notes: narrow, steep-sided ridge
+    precipitation, MAP (mm): 2292
   Massey Creek:
-    site number: 8
+    site code: 8
     latitude (deg): -17.60993
     longitude (deg): 145.56264
-    altitude: highland (800-1200 m)
-    geology: acid igneous or metamorphic
-    comments: rhyolite outcrop in basalt landscape
-    rainfall (MAP, mm): 2296
+    elevation (m): highland (800-1200 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: rhyolite outcrop in basalt landscape
+    precipitation, MAP (mm): 2296
   'Mt Fisher: Kjellberg Rd':
-    site number: 2
+    site code: 2
     latitude (deg): -17.54112
     longitude (deg): 145.56136
-    altitude: highland (800-1200 m)
-    geology: basalt
-    comments: narrow, steep-sided ridge
-    rainfall (MAP, mm): 2429
+    elevation (m): highland (800-1200 m)
+    geology (parent material): basalt
+    notes: narrow, steep-sided ridge
+    precipitation, MAP (mm): 2429
   Mt Haig:
-    site number: 6
+    site code: 6
     latitude (deg): -17.10111
     longitude (deg): 145.57346
-    altitude: highland (800-1200 m)
-    geology: acid igneous or metamorphic
-    comments: steep-sided ridge
-    rainfall (MAP, mm): 2897
+    elevation (m): highland (800-1200 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: steep-sided ridge
+    precipitation, MAP (mm): 2897
   'Palmerston: Malaan Rd turnoff':
-    site number: 12
+    site code: 12
     latitude (deg): -17.59143
     longitude (deg): 145.70355
-    altitude: upland (400 - 800 m)
-    geology: basalt
-    comments: gently sloping site
-    rainfall (MAP, mm): 3191
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): basalt
+    notes: gently sloping site
+    precipitation, MAP (mm): 3191
   Robson Ck:
-    site number: 14
+    site code: 14
     latitude (deg): -17.11917
     longitude (deg): 145.62952
-    altitude: upland (400 - 800 m)
-    geology: acid igneous or metamorphic
-    comments: saddle a short distance above a creek
-    rainfall (MAP, mm): 1953
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: saddle a short distance above a creek
+    precipitation, MAP (mm): 1953
   Sutties Gap Rd:
-    site number: 16
+    site code: 16
     latitude (deg): -17.64678
     longitude (deg): 145.63772
-    altitude: upland (400 - 800 m)
-    geology: acid igneous or metamorphic
-    comments: steep ridge, close to basalt flow
-    rainfall (MAP, mm): 2762
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: steep ridge, close to basalt flow
+    precipitation, MAP (mm): 2762
   TF Rd rhyolite:
-    site number: 15
+    site code: 15
     latitude (deg): -17.78676
     longitude (deg): 145.55958
-    altitude: upland (400 - 800 m)
-    geology: acid igneous or metamorphic
-    comments: gently sloping site
-    rainfall (MAP, mm): 2198
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): acid igneous or metamorphic
+    notes: gently sloping site
+    precipitation, MAP (mm): 2198
   Thomas Rd (recent basalt):
-    site number: 17
+    site code: 17
     latitude (deg): -17.26548
     longitude (deg): 145.56578
-    altitude: .na
-    geology: basalt
-    comments: .na
-    rainfall (MAP, mm): .na
+    elevation (m): .na
+    geology (parent material): basalt
+    notes: .na
+    precipitation, MAP (mm): .na
   Tully Falls Rd, near TF:
-    site number: 11
+    site code: 11
     latitude (deg): -17.75847
     longitude (deg): 145.54569
-    altitude: upland (400 - 800 m)
-    geology: basalt
-    comments: flat site
-    rainfall (MAP, mm): 2088
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): basalt
+    notes: flat site
+    precipitation, MAP (mm): 2088
   'Tully Falls Rd: Smiths':
-    site number: 3
+    site code: 3
     latitude (deg): -17.68174
     longitude (deg): 145.52989
-    altitude: highland (800-1200 m)
-    geology: basalt
-    comments: ridge, near edge of basalt flow
-    rainfall (MAP, mm): 2255
+    elevation (m): highland (800-1200 m)
+    geology (parent material): basalt
+    notes: ridge, near edge of basalt flow
+    precipitation, MAP (mm): 2255
   Wallace Rd (Glen Allyn):
-    site number: 10
+    site code: 10
     latitude (deg): -17.42063
     longitude (deg): 145.67164
-    altitude: upland (400 - 800 m)
-    geology: basalt
-    comments: flat site
-    rainfall (MAP, mm): 3004
+    elevation (m): upland (400 - 800 m)
+    geology (parent material): basalt
+    notes: flat site
+    precipitation, MAP (mm): 3004
 contexts:
   climax:
     description: Species in climax community
@@ -745,4 +745,3 @@ taxonomic_updates:
   reason: Alignment by E. Wenk based on APC/APNI search
 exclude_observations: .na
 questions: .na
-

--- a/data/Knox_2011/metadata.yml
+++ b/data/Knox_2011/metadata.yml
@@ -58,7 +58,7 @@ sites:
   nutrient-poor dry sclerophyll forest:
     latitude (deg): -29.35
     longitude (deg): 152.33
-    lat/lon notes: generic Washpool National Park coordinates entered by AusTraits
+    georeference remarks: generic Washpool National Park coordinates entered by AusTraits
     description: nutrient-poor dry sclerophyll forest
     soil temperature (C): 21.4
     soil N, total (%): 0.18
@@ -73,7 +73,7 @@ sites:
   nutrient-rich wet sclerophyll forest:
     latitude (deg): -29.35
     longitude (deg): 152.33
-    lat/lon notes: generic Washpool National Park coordinates entered by AusTraits
+    georeference remarks: generic Washpool National Park coordinates entered by AusTraits
     description: nutrient-rich wet sclerophyll forest
     soil temperature (C): 18.0
     soil N, total (%): 0.49

--- a/data/Knox_2011/metadata.yml
+++ b/data/Knox_2011/metadata.yml
@@ -58,35 +58,33 @@ sites:
   nutrient-poor dry sclerophyll forest:
     latitude (deg): -29.35
     longitude (deg): 152.33
-    coordinates information: generic Washpool National Park coordinates entered by
-      AusTraits
+    lat/lon notes: generic Washpool National Park coordinates entered by AusTraits
     description: nutrient-poor dry sclerophyll forest
-    Soil_temperature: 21.4
-    Soil_total_N: 0.18
-    Soil_total_P: 53.0
-    Soil_total_C: 3.8
-    exc_K: 0.21
-    exc_Mg: 0.14
-    exc_Ca: 0.18
-    NH4: 5.85
+    soil temperature (C): 21.4
+    soil N, total (%): 0.18
+    soil P, total (mg/kg): 53.0
+    soil C, total (%): 3.8
+    soil exchangeable K (cmol/kg, meq/100g): 0.21
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.14
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.18
+    soil NH4 content (mg/kg): 5.85
     elevation (m): 950
-    MAP (mm): 1800
+    precipitation, MAP (mm): 1800
   nutrient-rich wet sclerophyll forest:
     latitude (deg): -29.35
     longitude (deg): 152.33
-    coordinates information: generic Washpool National Park coordinates entered by
-      AusTraits
+    lat/lon notes: generic Washpool National Park coordinates entered by AusTraits
     description: nutrient-rich wet sclerophyll forest
-    Soil_temperature: 18.0
-    Soil_total_N: 0.49
-    Soil_total_P: 385.3
-    Soil_total_C: 7.4
-    exc_K: 0.48
-    exc_Mg: 0.94
-    exc_Ca: 1.96
-    NH4: 21.5
+    soil temperature (C): 18.0
+    soil N, total (%): 0.49
+    soil P, total (mg/kg): 385.3
+    soil C, total (%): 7.4
+    soil exchangeable K (cmol/kg, meq/100g): 0.48
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.94
+    soil exchangeable Ca (cmol/kg, meq/100g): 1.96
+    soil NH4 content (mg/kg): 21.5
     elevation (m): 950
-    MAP (mm): 1800
+    precipitation, MAP (mm): 1800
 contexts: .na
 config:
   data_is_long_format: no
@@ -191,4 +189,3 @@ questions:
   question3: If you have more detailed fire response data, we can include whether
     species are "weak" or "strong" resprouters and also the proportion of individuals
     censuses that resprouted following a fire.
-

--- a/data/Kotowska_2020/metadata.yml
+++ b/data/Kotowska_2020/metadata.yml
@@ -58,538 +58,538 @@ sites:
     latitude (deg): -33.370861
     longitude (deg): 151.316146
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.23
-    soil_P: 9.9
-    soil_Ptot: 50.47
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.23
+    soil P, extractable (mg/kg): 9.9
+    soil P, total (mg/kg): 50.47
   HighP_2:
     latitude (deg): -33.374671
     longitude (deg): 151.320612
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.57
-    soil_P: 5.03
-    soil_Ptot: 140.82
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.57
+    soil P, extractable (mg/kg): 5.03
+    soil P, total (mg/kg): 140.82
   HighP_3:
     latitude (deg): -33.376334
     longitude (deg): 151.322484
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.42
-    soil_P: 5.15
-    soil_Ptot: 192.16
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.42
+    soil P, extractable (mg/kg): 5.15
+    soil P, total (mg/kg): 192.16
   HighP_4:
     latitude (deg): -33.3788804
     longitude (deg): 151.323881
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.68
-    soil_P: 6.27
-    soil_Ptot: 198.93
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.68
+    soil P, extractable (mg/kg): 6.27
+    soil P, total (mg/kg): 198.93
   HighP_5:
     latitude (deg): -33.3788809
     longitude (deg): 151.3238807
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.51
-    soil_P: 4.73
-    soil_Ptot: 122.53
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.51
+    soil P, extractable (mg/kg): 4.73
+    soil P, total (mg/kg): 122.53
   HighP_6:
     latitude (deg): -33.371761
     longitude (deg): 151.318759
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: 3.01
-    soil_P: 5.12
-    soil_Ptot: 123.6
+    soil nutrient status: high P
+    soil N, total (mg/g): 3.01
+    soil P, extractable (mg/kg): 5.12
+    soil P, total (mg/kg): 123.6
   LowP_1:
     latitude (deg): -33.374057
     longitude (deg): 151.324011
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.93
-    soil_P: 4.52
-    soil_Ptot: 56.26
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.93
+    soil P, extractable (mg/kg): 4.52
+    soil P, total (mg/kg): 56.26
   LowP_2:
     latitude (deg): -33.3718338
     longitude (deg): 151.3210927
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.74
-    soil_P: 3.16
-    soil_Ptot: 48.72
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.74
+    soil P, extractable (mg/kg): 3.16
+    soil P, total (mg/kg): 48.72
   LowP_3:
     latitude (deg): -33.3716443
     longitude (deg): 151.3215423
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.69
-    soil_P: 1.67
-    soil_Ptot: 45.11
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.69
+    soil P, extractable (mg/kg): 1.67
+    soil P, total (mg/kg): 45.11
   LowP_4:
     latitude (deg): -33.3714206
     longitude (deg): 151.3207965
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.81
-    soil_P: 3.48
-    soil_Ptot: 51.71
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.81
+    soil P, extractable (mg/kg): 3.48
+    soil P, total (mg/kg): 51.71
   LowP_5:
     latitude (deg): -33.3707891
     longitude (deg): 151.317865
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.71
-    soil_P: 0.65
-    soil_Ptot: 15.91
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.71
+    soil P, extractable (mg/kg): 0.65
+    soil P, total (mg/kg): 15.91
   LowP_6:
     latitude (deg): -33.370757
     longitude (deg): 151.317931
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: 0.78
-    soil_P: 2.57
-    soil_Ptot: 44.22
+    soil nutrient status: low P
+    soil N, total (mg/g): 0.78
+    soil P, extractable (mg/kg): 2.57
+    soil P, total (mg/kg): 44.22
   tree_at_-33.3706_S_and_151.318_E:
     latitude (deg): -33.370585
     longitude (deg): 151.317994
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3706_S_and_151.3181_E:
     latitude (deg): -33.370597
     longitude (deg): 151.31813
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3707_S_and_151.3179_E:
     latitude (deg): -33.370709
     longitude (deg): 151.317859
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3708_S_and_151.3179_E:
     latitude (deg): -33.370758
     longitude (deg): 151.31786
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3708_S_and_151.318_E:
     latitude (deg): -33.37085
     longitude (deg): 151.317993
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3708_S_and_151.3181_E:
     latitude (deg): -33.370782
     longitude (deg): 151.318057
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3709_S_and_151.3163_E:
     latitude (deg): -33.370938
     longitude (deg): 151.316327
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3709_S_and_151.318_E:
     latitude (deg): -33.370892
     longitude (deg): 151.318015
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3709_S_and_151.3181_E:
     latitude (deg): -33.37086
     longitude (deg): 151.318069
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.371_S_and_151.3163_E:
     latitude (deg): -33.371011
     longitude (deg): 151.316342
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3711_S_and_151.3163_E:
     latitude (deg): -33.371076
     longitude (deg): 151.316276
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3711_S_and_151.3164_E:
     latitude (deg): -33.37108
     longitude (deg): 151.316398
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3711_S_and_151.3207_E:
     latitude (deg): -33.371136
     longitude (deg): 151.320739
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3713_S_and_151.3209_E:
     latitude (deg): -33.371287
     longitude (deg): 151.320906
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3715_S_and_151.3208_E:
     latitude (deg): -33.371498
     longitude (deg): 151.320847
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3716_S_and_151.3208_E:
     latitude (deg): -33.371588
     longitude (deg): 151.320783
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3717_S_and_151.3187_E:
     latitude (deg): -33.371717
     longitude (deg): 151.318688
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3717_S_and_151.3209_E:
     latitude (deg): -33.371744
     longitude (deg): 151.320916
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3717_S_and_151.321_E:
     latitude (deg): -33.371706
     longitude (deg): 151.321023
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3718_S_and_151.3187_E:
     latitude (deg): -33.371763
     longitude (deg): 151.318748
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3718_S_and_151.3188_E:
     latitude (deg): -33.371758
     longitude (deg): 151.318819
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3718_S_and_151.321_E:
     latitude (deg): -33.371804
     longitude (deg): 151.320982
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3718_S_and_151.3211_E:
     latitude (deg): -33.371757
     longitude (deg): 151.321087
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3722_S_and_151.3211_E:
     latitude (deg): -33.372216
     longitude (deg): 151.321149
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3722_S_and_151.3212_E:
     latitude (deg): -33.372235
     longitude (deg): 151.321169
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3723_S_and_151.3211_E:
     latitude (deg): -33.372347
     longitude (deg): 151.321082
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3724_S_and_151.321_E:
     latitude (deg): -33.372368
     longitude (deg): 151.321017
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3725_S_and_151.3212_E:
     latitude (deg): -33.372477
     longitude (deg): 151.321234
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.374_S_and_151.3234_E:
     latitude (deg): -33.373971
     longitude (deg): 151.323368
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3741_S_and_151.3243_E:
     latitude (deg): -33.374074
     longitude (deg): 151.324325
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3741_S_and_151.3244_E:
     latitude (deg): -33.374065
     longitude (deg): 151.324407
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3741_S_and_151.3245_E:
     latitude (deg): -33.374145
     longitude (deg): 151.324476
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3742_S_and_151.3237_E:
     latitude (deg): -33.374177
     longitude (deg): 151.323731
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3742_S_and_151.3238_E:
     latitude (deg): -33.374174
     longitude (deg): 151.323805
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3742_S_and_151.3239_E:
     latitude (deg): -33.37421
     longitude (deg): 151.323899
     description: sclerophyll forest on sandstone
-    nutrient status: low P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: low P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3747_S_and_151.3207_E:
     latitude (deg): -33.374715
     longitude (deg): 151.320675
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3748_S_and_151.3207_E:
     latitude (deg): -33.374822
     longitude (deg): 151.320729
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3748_S_and_151.3208_E:
     latitude (deg): -33.374846
     longitude (deg): 151.320762
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3759_S_and_151.3226_E:
     latitude (deg): -33.375946
     longitude (deg): 151.322602
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.376_S_and_151.3226_E:
     latitude (deg): -33.375952
     longitude (deg): 151.322622
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3763_S_and_151.3225_E:
     latitude (deg): -33.376342
     longitude (deg): 151.322492
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3764_S_and_151.3224_E:
     latitude (deg): -33.376378
     longitude (deg): 151.322396
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3765_S_and_151.3225_E:
     latitude (deg): -33.376504
     longitude (deg): 151.322461
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3787_S_and_151.3235_E:
     latitude (deg): -33.378722
     longitude (deg): 151.323528
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3788_S_and_151.3236_E:
     latitude (deg): -33.378761
     longitude (deg): 151.323611
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3788_S_and_151.3237_E:
     latitude (deg): -33.378782
     longitude (deg): 151.32368
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3788_S_and_151.3239_E:
     latitude (deg): -33.378791
     longitude (deg): 151.323889
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3789_S_and_151.3237_E:
     latitude (deg): -33.37886
     longitude (deg): 151.323739
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3789_S_and_151.3238_E:
     latitude (deg): -33.378895
     longitude (deg): 151.323785
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3789_S_and_151.324_E:
     latitude (deg): -33.378859
     longitude (deg): 151.323951
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.379_S_and_151.3238_E:
     latitude (deg): -33.378992
     longitude (deg): 151.323808
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.379_S_and_151.3239_E:
     latitude (deg): -33.379038
     longitude (deg): 151.323925
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.379_S_and_151.3241_E:
     latitude (deg): -33.378988
     longitude (deg): 151.324075
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3791_S_and_151.3241_E:
     latitude (deg): -33.379112
     longitude (deg): 151.324083
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
   tree_at_-33.3792_S_and_151.3241_E:
     latitude (deg): -33.379161
     longitude (deg): 151.324082
     description: sclerophyll forest with rainforest elements on shale
-    nutrient status: high P
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_Ptot: .na.real
+    soil nutrient status: high P
+    soil N, total (mg/g): .na.real
+    soil P, extractable (mg/kg): .na.real
+    soil P, total (mg/kg): .na.real
 contexts: .na
 config:
   data_is_long_format: no
@@ -2019,4 +2019,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Kuo_1982/metadata.yml
+++ b/data/Kuo_1982/metadata.yml
@@ -39,42 +39,43 @@ sites:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
   Sandplain north of Eneabba:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
   South-west of Chillitup:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: shallow, sandy topsoil containing lateritic gravel and overlay quartz sandstone
+    soil type: shallow, sandy topsoil containing lateritic gravel and overlay quartz
+      sandstone
   70 km north of Murchison River:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
   Sandplain between Northampton and Ajana:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
   Sandplain south of Tammin:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
   Private property west of Hopetoun:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: shallow bleached sand overlying quartzite
+    soil type: shallow bleached sand overlying quartzite
   Sandplain south of Eneabba:
     latitude (deg): .na
     longitude (deg): .na
     description: .na
-    soils: deep, mineral-deficient sands
+    soil type: deep, mineral-deficient sands
 contexts:
   cone:
     type: field
@@ -374,4 +375,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: micronutrient concentrations for seeds
-

--- a/data/Laliberte_2012/metadata.yml
+++ b/data/Laliberte_2012/metadata.yml
@@ -63,7 +63,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 8.07
     soil NH4 content (mg/kg): 3.258
     soil NO3 content: 0.609
@@ -77,7 +77,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 12.353
     soil NH4 content (mg/kg): 3.443
     soil NO3 content: 0.476
@@ -91,7 +91,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 9.794
     soil NH4 content (mg/kg): 1.426
     soil NO3 content: 1.372
@@ -105,7 +105,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 7.983
     soil NH4 content (mg/kg): 2.889
     soil NO3 content: 2.479
@@ -119,7 +119,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 7.538
     soil NH4 content (mg/kg): 1.469
     soil NO3 content: 1.843
@@ -133,7 +133,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 9.459
     soil NH4 content (mg/kg): 3.23
     soil NO3 content: 1.18
@@ -147,7 +147,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 9.731
     soil NH4 content (mg/kg): 3.596
     soil NO3 content: 3.204
@@ -161,7 +161,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 8.487
     soil NH4 content (mg/kg): 2.786
     soil NO3 content: 0.681
@@ -175,7 +175,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 7.465
     soil NH4 content (mg/kg): 2.089
     soil NO3 content: 0.368
@@ -189,7 +189,7 @@ sites:
     epoch: Early Pleistocene
     soil age: '2000000'
     geology (stratigraphic map unit): Bassendean Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 8.657
     soil NH4 content (mg/kg): 2.993
     soil NO3 content: 0.937
@@ -203,7 +203,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 15.314
     soil NH4 content (mg/kg): 7.786
     soil NO3 content: 5.838
@@ -217,7 +217,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 22.189
     soil NH4 content (mg/kg): 6.62
     soil NO3 content: 5.537
@@ -231,7 +231,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 21.676
     soil NH4 content (mg/kg): 8.124
     soil NO3 content: 5.221
@@ -245,7 +245,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -715340.0
+    date sampled: -715340.0
     soil disolved organic nitrogen: 21.417
     soil NH4 content (mg/kg): 9.427
     soil NO3 content: 5.707
@@ -259,7 +259,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -715340.0
+    date sampled: -715340.0
     soil disolved organic nitrogen: 28.945
     soil NH4 content (mg/kg): 12.775
     soil NO3 content: 4.323
@@ -273,7 +273,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 38.198
     soil NH4 content (mg/kg): 4.367
     soil NO3 content: 8.81
@@ -287,7 +287,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 24.844
     soil NH4 content (mg/kg): 4.56
     soil NO3 content: 15.823
@@ -301,7 +301,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 19.012
     soil NH4 content (mg/kg): 4.63
     soil NO3 content: 4.22
@@ -315,7 +315,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -715340.0
+    date sampled: -715340.0
     soil disolved organic nitrogen: 27.78
     soil NH4 content (mg/kg): 8.652
     soil NO3 content: 4.226
@@ -329,7 +329,7 @@ sites:
     epoch: Holocene
     soil age: '1000'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 18.234
     soil NH4 content (mg/kg): 3.466
     soil NO3 content: 1.9
@@ -343,7 +343,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 15.663
     soil NH4 content (mg/kg): 2.895
     soil NO3 content: 3.41
@@ -357,7 +357,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 16.459
     soil NH4 content (mg/kg): 3.682
     soil NO3 content: 3.853
@@ -371,7 +371,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 15.864
     soil NH4 content (mg/kg): 3.599
     soil NO3 content: 0.668
@@ -385,7 +385,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 20.754
     soil NH4 content (mg/kg): 2.88
     soil NO3 content: 4.01
@@ -399,7 +399,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -715340.0
+    date sampled: -715340.0
     soil disolved organic nitrogen: 26.74
     soil NH4 content (mg/kg): 6.837
     soil NO3 content: 10.886
@@ -413,7 +413,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 18.25
     soil NH4 content (mg/kg): 5.172
     soil NO3 content: 7.12
@@ -427,7 +427,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 18.414
     soil NH4 content (mg/kg): 4.825
     soil NO3 content: 3.915
@@ -441,7 +441,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 25.342
     soil NH4 content (mg/kg): 4.133
     soil NO3 content: 12.36
@@ -455,7 +455,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 19.345
     soil NH4 content (mg/kg): 2.772
     soil NO3 content: 5.311
@@ -469,7 +469,7 @@ sites:
     epoch: Holocene
     soil age: '6500'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 15.3
     soil NH4 content (mg/kg): 3.105
     soil NO3 content: 1.395
@@ -483,7 +483,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 8.657
     soil NH4 content (mg/kg): 2.291
     soil NO3 content: 0.085
@@ -497,7 +497,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 9.921
     soil NH4 content (mg/kg): 0.587
     soil NO3 content: 0.163
@@ -511,7 +511,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 8.561
     soil NH4 content (mg/kg): 2.25
     soil NO3 content: 0.016
@@ -525,7 +525,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 9.478
     soil NH4 content (mg/kg): 0.579
     soil NO3 content: 0.054
@@ -539,7 +539,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 9.944
     soil NH4 content (mg/kg): 0.945
     soil NO3 content: 0.071
@@ -553,7 +553,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 6.737
     soil NH4 content (mg/kg): 0.0
     soil NO3 content: 0.011
@@ -567,7 +567,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 8.915
     soil NH4 content (mg/kg): 2.342
     soil NO3 content: 0.135
@@ -581,7 +581,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 9.203
     soil NH4 content (mg/kg): 1.449
     soil NO3 content: 0.821
@@ -595,7 +595,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 10.959
     soil NH4 content (mg/kg): 1.048
     soil NO3 content: 0.037
@@ -609,7 +609,7 @@ sites:
     epoch: Holocene
     soil age: '50'
     geology (stratigraphic map unit): Safety Bay Sand
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 9.57
     soil NH4 content (mg/kg): 1.748
     soil NO3 content: 0.015
@@ -623,7 +623,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 12.18
     soil NH4 content (mg/kg): 1.727
     soil NO3 content: 2.166
@@ -637,7 +637,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 9.879
     soil NH4 content (mg/kg): 2.654
     soil NO3 content: 0.75
@@ -651,7 +651,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -713879.0
+    date sampled: -713879.0
     soil disolved organic nitrogen: 6.67
     soil NH4 content (mg/kg): 1.913
     soil NO3 content: 0.473
@@ -665,7 +665,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714974.0
+    date sampled: -714974.0
     soil disolved organic nitrogen: 12.059
     soil NH4 content (mg/kg): 3.424
     soil NO3 content: 0.455
@@ -679,7 +679,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 15.192
     soil NH4 content (mg/kg): 2.651
     soil NO3 content: 1.786
@@ -693,7 +693,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -713513.0
+    date sampled: -713513.0
     soil disolved organic nitrogen: 10.045
     soil NH4 content (mg/kg): 3.238
     soil NO3 content: 1.754
@@ -707,7 +707,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 6.911
     soil NH4 content (mg/kg): 3.144
     soil NO3 content: 1.221
@@ -721,7 +721,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714244.0
+    date sampled: -714244.0
     soil disolved organic nitrogen: 6.926
     soil NH4 content (mg/kg): 2.462
     soil NO3 content: 1.232
@@ -735,7 +735,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 7.633
     soil NH4 content (mg/kg): 3.518
     soil NO3 content: 2.015
@@ -749,7 +749,7 @@ sites:
     epoch: Late Pleistocene
     soil age: '120000'
     geology (stratigraphic map unit): Tamala Limestone
-    data sampled: -714609.0
+    date sampled: -714609.0
     soil disolved organic nitrogen: 14.416
     soil NH4 content (mg/kg): 4.031
     soil NO3 content: 0.959

--- a/data/Laliberte_2012/metadata.yml
+++ b/data/Laliberte_2012/metadata.yml
@@ -58,703 +58,703 @@ sites:
   B.HR.2:
     latitude (deg): -30.2950876
     longitude (deg): 115.1876421
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714609.0
-    don: 8.07
-    nh4: 3.258
-    no3: 0.609
-    totalPicp: 4.119
-    orgC: 0.605
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 8.07
+    soil NH4 content (mg/kg): 3.258
+    soil NO3 content: 0.609
+    soil P, total ICP: 4.119
+    soil organic carbon (%): 0.605
   B.HR.5:
     latitude (deg): -30.2942394
     longitude (deg): 115.1849383
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714974.0
-    don: 12.353
-    nh4: 3.443
-    no3: 0.476
-    totalPicp: 1.112
-    orgC: 0.556
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 12.353
+    soil NH4 content (mg/kg): 3.443
+    soil NO3 content: 0.476
+    soil P, total ICP: 1.112
+    soil organic carbon (%): 0.556
   B.L.10:
     latitude (deg): -30.1600016
     longitude (deg): 115.1205556
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -713513.0
-    don: 9.794
-    nh4: 1.426
-    no3: 1.372
-    totalPicp: 11.827
-    orgC: 0.729
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 9.794
+    soil NH4 content (mg/kg): 1.426
+    soil NO3 content: 1.372
+    soil P, total ICP: 11.827
+    soil organic carbon (%): 0.729
   B.L.14:
     latitude (deg): -30.1809
     longitude (deg): 115.1288
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714244.0
-    don: 7.983
-    nh4: 2.889
-    no3: 2.479
-    totalPicp: 2.248
-    orgC: 0.535
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 7.983
+    soil NH4 content (mg/kg): 2.889
+    soil NO3 content: 2.479
+    soil P, total ICP: 2.248
+    soil organic carbon (%): 0.535
   B.L.4:
     latitude (deg): -30.1867482
     longitude (deg): 115.109051
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714244.0
-    don: 7.538
-    nh4: 1.469
-    no3: 1.843
-    totalPicp: 4.525
-    orgC: 0.837
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 7.538
+    soil NH4 content (mg/kg): 1.469
+    soil NO3 content: 1.843
+    soil P, total ICP: 4.525
+    soil organic carbon (%): 0.837
   B.L.5:
     latitude (deg): -30.1643263
     longitude (deg): 115.122627
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714244.0
-    don: 9.459
-    nh4: 3.23
-    no3: 1.18
-    totalPicp: 1.681
-    orgC: 0.828
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 9.459
+    soil NH4 content (mg/kg): 3.23
+    soil NO3 content: 1.18
+    soil P, total ICP: 1.681
+    soil organic carbon (%): 0.828
   B.L.6:
     latitude (deg): -30.1714053
     longitude (deg): 115.1090639
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714244.0
-    don: 9.731
-    nh4: 3.596
-    no3: 3.204
-    totalPicp: 7.676
-    orgC: 0.677
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 9.731
+    soil NH4 content (mg/kg): 3.596
+    soil NO3 content: 3.204
+    soil P, total ICP: 7.676
+    soil organic carbon (%): 0.677
   B.L.9:
     latitude (deg): -30.1681836
     longitude (deg): 115.1057057
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714244.0
-    don: 8.487
-    nh4: 2.786
-    no3: 0.681
-    totalPicp: 3.524
-    orgC: 0.902
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 8.487
+    soil NH4 content (mg/kg): 2.786
+    soil NO3 content: 0.681
+    soil P, total ICP: 3.524
+    soil organic carbon (%): 0.902
   B.NL.1:
     latitude (deg): -30.12959
     longitude (deg): 115.1074556
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -714609.0
-    don: 7.465
-    nh4: 2.089
-    no3: 0.368
-    totalPicp: 6.378
-    orgC: 0.347
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 7.465
+    soil NH4 content (mg/kg): 2.089
+    soil NO3 content: 0.368
+    soil P, total ICP: 6.378
+    soil organic carbon (%): 0.347
   B.NL.3:
     latitude (deg): -30.12666
     longitude (deg): 115.10631
-    stage: '6'
+    choronosequence stage: '6'
     dune: Bassendean
     epoch: Early Pleistocene
-    age: '2000000'
-    geology: Bassendean Sand
-    date: -713513.0
-    don: 8.657
-    nh4: 2.993
-    no3: 0.937
-    totalPicp: 5.796
-    orgC: 0.291
+    soil age: '2000000'
+    geology (stratigraphic map unit): Bassendean Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 8.657
+    soil NH4 content (mg/kg): 2.993
+    soil NO3 content: 0.937
+    soil P, total ICP: 5.796
+    soil organic carbon (%): 0.291
   Q.M.18:
     latitude (deg): -30.059799
     longitude (deg): 114.983038
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 15.314
-    nh4: 7.786
-    no3: 5.838
-    totalPicp: 436.743
-    orgC: 0.57
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 15.314
+    soil NH4 content (mg/kg): 7.786
+    soil NO3 content: 5.838
+    soil P, total ICP: 436.743
+    soil organic carbon (%): 0.57
   Q.M.23:
     latitude (deg): -30.1703198
     longitude (deg): 115.0119435
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 22.189
-    nh4: 6.62
-    no3: 5.537
-    totalPicp: 497.971
-    orgC: 2.548
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 22.189
+    soil NH4 content (mg/kg): 6.62
+    soil NO3 content: 5.537
+    soil P, total ICP: 497.971
+    soil organic carbon (%): 2.548
   Q.M.25:
     latitude (deg): -30.22424
     longitude (deg): 115.010676
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 21.676
-    nh4: 8.124
-    no3: 5.221
-    totalPicp: 437.152
-    orgC: 3.123
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 21.676
+    soil NH4 content (mg/kg): 8.124
+    soil NO3 content: 5.221
+    soil P, total ICP: 437.152
+    soil organic carbon (%): 3.123
   Q.M.26:
     latitude (deg): -30.2140527
     longitude (deg): 115.010374
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -715340.0
-    don: 21.417
-    nh4: 9.427
-    no3: 5.707
-    totalPicp: 454.403
-    orgC: 1.147
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -715340.0
+    soil disolved organic nitrogen: 21.417
+    soil NH4 content (mg/kg): 9.427
+    soil NO3 content: 5.707
+    soil P, total ICP: 454.403
+    soil organic carbon (%): 1.147
   Q.M.30:
     latitude (deg): -30.27663
     longitude (deg): 115.045336
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -715340.0
-    don: 28.945
-    nh4: 12.775
-    no3: 4.323
-    totalPicp: 564.132
-    orgC: 1.728
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -715340.0
+    soil disolved organic nitrogen: 28.945
+    soil NH4 content (mg/kg): 12.775
+    soil NO3 content: 4.323
+    soil P, total ICP: 564.132
+    soil organic carbon (%): 1.728
   Q.M.31:
     latitude (deg): -30.07305
     longitude (deg): 114.98254
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -713513.0
-    don: 38.198
-    nh4: 4.367
-    no3: 8.81
-    totalPicp: 514.651
-    orgC: 1.661
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 38.198
+    soil NH4 content (mg/kg): 4.367
+    soil NO3 content: 8.81
+    soil P, total ICP: 514.651
+    soil organic carbon (%): 1.661
   Q.M.32:
     latitude (deg): -30.1646328
     longitude (deg): 115.0074926
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 24.844
-    nh4: 4.56
-    no3: 15.823
-    totalPicp: 475.136
-    orgC: 2.24
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 24.844
+    soil NH4 content (mg/kg): 4.56
+    soil NO3 content: 15.823
+    soil P, total ICP: 475.136
+    soil organic carbon (%): 2.24
   Q.M.33:
     latitude (deg): -30.09049
     longitude (deg): 114.9986206
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 19.012
-    nh4: 4.63
-    no3: 4.22
-    totalPicp: 546.467
-    orgC: 2.429
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 19.012
+    soil NH4 content (mg/kg): 4.63
+    soil NO3 content: 4.22
+    soil P, total ICP: 546.467
+    soil organic carbon (%): 2.429
   Q.M.7:
     latitude (deg): -30.2743268
     longitude (deg): 115.0469911
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -715340.0
-    don: 27.78
-    nh4: 8.652
-    no3: 4.226
-    totalPicp: 451.509
-    orgC: 1.634
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -715340.0
+    soil disolved organic nitrogen: 27.78
+    soil NH4 content (mg/kg): 8.652
+    soil NO3 content: 4.226
+    soil P, total ICP: 451.509
+    soil organic carbon (%): 1.634
   Q.M.8:
     latitude (deg): -30.226345
     longitude (deg): 115.0183784
-    stage: '2'
+    choronosequence stage: '2'
     dune: Quindalup medium
     epoch: Holocene
-    age: '1000'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 18.234
-    nh4: 3.466
-    no3: 1.9
-    totalPicp: 393.949
-    orgC: 1.728
+    soil age: '1000'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 18.234
+    soil NH4 content (mg/kg): 3.466
+    soil NO3 content: 1.9
+    soil P, total ICP: 393.949
+    soil organic carbon (%): 1.728
   Q.O.11:
     latitude (deg): -30.1911676
     longitude (deg): 115.0593393
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714244.0
-    don: 15.663
-    nh4: 2.895
-    no3: 3.41
-    totalPicp: 92.011
-    orgC: 0.931
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 15.663
+    soil NH4 content (mg/kg): 2.895
+    soil NO3 content: 3.41
+    soil P, total ICP: 92.011
+    soil organic carbon (%): 0.931
   Q.O.14:
     latitude (deg): -30.2406149
     longitude (deg): 115.066927
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 16.459
-    nh4: 3.682
-    no3: 3.853
-    totalPicp: 169.66
-    orgC: 0.999
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 16.459
+    soil NH4 content (mg/kg): 3.682
+    soil NO3 content: 3.853
+    soil P, total ICP: 169.66
+    soil organic carbon (%): 0.999
   Q.O.15:
     latitude (deg): -30.2406081
     longitude (deg): 115.0642989
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 15.864
-    nh4: 3.599
-    no3: 0.668
-    totalPicp: 280.94
-    orgC: 1.008
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 15.864
+    soil NH4 content (mg/kg): 3.599
+    soil NO3 content: 0.668
+    soil P, total ICP: 280.94
+    soil organic carbon (%): 1.008
   Q.O.17:
     latitude (deg): -30.2136657
     longitude (deg): 115.063878
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 20.754
-    nh4: 2.88
-    no3: 4.01
-    totalPicp: 158.684
-    orgC: 1.348
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 20.754
+    soil NH4 content (mg/kg): 2.88
+    soil NO3 content: 4.01
+    soil P, total ICP: 158.684
+    soil organic carbon (%): 1.348
   Q.O.20:
     latitude (deg): -30.3157197
     longitude (deg): 115.0665914
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -715340.0
-    don: 26.74
-    nh4: 6.837
-    no3: 10.886
-    totalPicp: 501.139
-    orgC: 2.195
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -715340.0
+    soil disolved organic nitrogen: 26.74
+    soil NH4 content (mg/kg): 6.837
+    soil NO3 content: 10.886
+    soil P, total ICP: 501.139
+    soil organic carbon (%): 2.195
   Q.O.22:
     latitude (deg): -30.27658
     longitude (deg): 115.061847
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 18.25
-    nh4: 5.172
-    no3: 7.12
-    totalPicp: 361.086
-    orgC: 2.1
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 18.25
+    soil NH4 content (mg/kg): 5.172
+    soil NO3 content: 7.12
+    soil P, total ICP: 361.086
+    soil organic carbon (%): 2.1
   Q.O.24:
     latitude (deg): -30.27088
     longitude (deg): 115.0708
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 18.414
-    nh4: 4.825
-    no3: 3.915
-    totalPicp: 191.052
-    orgC: 1.463
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 18.414
+    soil NH4 content (mg/kg): 4.825
+    soil NO3 content: 3.915
+    soil P, total ICP: 191.052
+    soil organic carbon (%): 1.463
   Q.O.3:
     latitude (deg): -30.0629937
     longitude (deg): 115.0120484
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -713513.0
-    don: 25.342
-    nh4: 4.133
-    no3: 12.36
-    totalPicp: 450.843
-    orgC: 2.776
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 25.342
+    soil NH4 content (mg/kg): 4.133
+    soil NO3 content: 12.36
+    soil P, total ICP: 450.843
+    soil organic carbon (%): 2.776
   Q.O.4:
     latitude (deg): -30.0354182
     longitude (deg): 115.0055205
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -713513.0
-    don: 19.345
-    nh4: 2.772
-    no3: 5.311
-    totalPicp: 399.042
-    orgC: 0.331
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 19.345
+    soil NH4 content (mg/kg): 2.772
+    soil NO3 content: 5.311
+    soil P, total ICP: 399.042
+    soil organic carbon (%): 0.331
   Q.O.5:
     latitude (deg): -30.2256609
     longitude (deg): 115.0648947
-    stage: '3'
+    choronosequence stage: '3'
     dune: Quindalup old
     epoch: Holocene
-    age: '6500'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 15.3
-    nh4: 3.105
-    no3: 1.395
-    totalPicp: 161.568
-    orgC: 1.497
+    soil age: '6500'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 15.3
+    soil NH4 content (mg/kg): 3.105
+    soil NO3 content: 1.395
+    soil P, total ICP: 161.568
+    soil organic carbon (%): 1.497
   Q.Y.1:
     latitude (deg): -30.405829
     longitude (deg): 115.094783
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 8.657
-    nh4: 2.291
-    no3: 0.085
-    totalPicp: 319.321
-    orgC: 0.751
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 8.657
+    soil NH4 content (mg/kg): 2.291
+    soil NO3 content: 0.085
+    soil P, total ICP: 319.321
+    soil organic carbon (%): 0.751
   Q.Y.12:
     latitude (deg): -30.181027
     longitude (deg): 115.003786
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 9.921
-    nh4: 0.587
-    no3: 0.163
-    totalPicp: 242.487
-    orgC: 1.962
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 9.921
+    soil NH4 content (mg/kg): 0.587
+    soil NO3 content: 0.163
+    soil P, total ICP: 242.487
+    soil organic carbon (%): 1.962
   Q.Y.15:
     latitude (deg): -30.407139
     longitude (deg): 115.081852
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -714974.0
-    don: 8.561
-    nh4: 2.25
-    no3: 0.016
-    totalPicp: 376.898
-    orgC: 0.942
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 8.561
+    soil NH4 content (mg/kg): 2.25
+    soil NO3 content: 0.016
+    soil P, total ICP: 376.898
+    soil organic carbon (%): 0.942
   Q.Y.16:
     latitude (deg): -30.115121
     longitude (deg): 115.006458
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 9.478
-    nh4: 0.579
-    no3: 0.054
-    totalPicp: 380.849
-    orgC: 1.227
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 9.478
+    soil NH4 content (mg/kg): 0.579
+    soil NO3 content: 0.054
+    soil P, total ICP: 380.849
+    soil organic carbon (%): 1.227
   Q.Y.17:
     latitude (deg): -30.045269
     longitude (deg): 114.962754
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713513.0
-    don: 9.944
-    nh4: 0.945
-    no3: 0.071
-    totalPicp: 390.265
-    orgC: 1.095
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 9.944
+    soil NH4 content (mg/kg): 0.945
+    soil NO3 content: 0.071
+    soil P, total ICP: 390.265
+    soil organic carbon (%): 1.095
   Q.Y.18:
     latitude (deg): -30.22362
     longitude (deg): 115.00817
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 6.737
-    nh4: 0.0
-    no3: 0.011
-    totalPicp: 412.107
-    orgC: 1.729
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 6.737
+    soil NH4 content (mg/kg): 0.0
+    soil NO3 content: 0.011
+    soil P, total ICP: 412.107
+    soil organic carbon (%): 1.729
   Q.Y.20:
     latitude (deg): -30.24837
     longitude (deg): 115.0482869
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 8.915
-    nh4: 2.342
-    no3: 0.135
-    totalPicp: 377.587
-    orgC: 1.473
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 8.915
+    soil NH4 content (mg/kg): 2.342
+    soil NO3 content: 0.135
+    soil P, total ICP: 377.587
+    soil organic carbon (%): 1.473
   Q.Y.3:
     latitude (deg): -30.253199
     longitude (deg): 115.039634
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -714609.0
-    don: 9.203
-    nh4: 1.449
-    no3: 0.821
-    totalPicp: 346.133
-    orgC: 2.101
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 9.203
+    soil NH4 content (mg/kg): 1.449
+    soil NO3 content: 0.821
+    soil P, total ICP: 346.133
+    soil organic carbon (%): 2.101
   Q.Y.7:
     latitude (deg): -30.093851
     longitude (deg): 114.990058
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 10.959
-    nh4: 1.048
-    no3: 0.037
-    totalPicp: 389.105
-    orgC: 1.983
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 10.959
+    soil NH4 content (mg/kg): 1.048
+    soil NO3 content: 0.037
+    soil P, total ICP: 389.105
+    soil organic carbon (%): 1.983
   Q.Y.8:
     latitude (deg): -30.106683
     longitude (deg): 114.996559
-    stage: '1'
+    choronosequence stage: '1'
     dune: Quindalup young
     epoch: Holocene
-    age: '50'
-    geology: Safety Bay Sand
-    date: -713879.0
-    don: 9.57
-    nh4: 1.748
-    no3: 0.015
-    totalPicp: 396.121
-    orgC: 0.76
+    soil age: '50'
+    geology (stratigraphic map unit): Safety Bay Sand
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 9.57
+    soil NH4 content (mg/kg): 1.748
+    soil NO3 content: 0.015
+    soil P, total ICP: 396.121
+    soil organic carbon (%): 0.76
   S.W.11:
     latitude (deg): -30.1920924
     longitude (deg): 115.0630152
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -713879.0
-    don: 12.18
-    nh4: 1.727
-    no3: 2.166
-    totalPicp: 21.68
-    orgC: 0.862
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 12.18
+    soil NH4 content (mg/kg): 1.727
+    soil NO3 content: 2.166
+    soil P, total ICP: 21.68
+    soil organic carbon (%): 0.862
   S.W.14:
     latitude (deg): -30.0826445
     longitude (deg): 115.0524686
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714609.0
-    don: 9.879
-    nh4: 2.654
-    no3: 0.75
-    totalPicp: 21.737
-    orgC: 0.391
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 9.879
+    soil NH4 content (mg/kg): 2.654
+    soil NO3 content: 0.75
+    soil P, total ICP: 21.737
+    soil organic carbon (%): 0.391
   S.W.17:
     latitude (deg): -30.2286499
     longitude (deg): 115.0685099
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -713879.0
-    don: 6.67
-    nh4: 1.913
-    no3: 0.473
-    totalPicp: 17.376
-    orgC: 0.577
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -713879.0
+    soil disolved organic nitrogen: 6.67
+    soil NH4 content (mg/kg): 1.913
+    soil NO3 content: 0.473
+    soil P, total ICP: 17.376
+    soil organic carbon (%): 0.577
   S.W.26:
     latitude (deg): -30.2403976
     longitude (deg): 115.0693132
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714974.0
-    don: 12.059
-    nh4: 3.424
-    no3: 0.455
-    totalPicp: 16.961
-    orgC: 0.927
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714974.0
+    soil disolved organic nitrogen: 12.059
+    soil NH4 content (mg/kg): 3.424
+    soil NO3 content: 0.455
+    soil P, total ICP: 16.961
+    soil organic carbon (%): 0.927
   S.W.3:
     latitude (deg): -30.14323
     longitude (deg): 115.0621127
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -713513.0
-    don: 15.192
-    nh4: 2.651
-    no3: 1.786
-    totalPicp: 43.089
-    orgC: 1.049
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 15.192
+    soil NH4 content (mg/kg): 2.651
+    soil NO3 content: 1.786
+    soil P, total ICP: 43.089
+    soil organic carbon (%): 1.049
   S.W.34:
     latitude (deg): -30.02759
     longitude (deg): 115.038893
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -713513.0
-    don: 10.045
-    nh4: 3.238
-    no3: 1.754
-    totalPicp: 16.048
-    orgC: 0.36
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -713513.0
+    soil disolved organic nitrogen: 10.045
+    soil NH4 content (mg/kg): 3.238
+    soil NO3 content: 1.754
+    soil P, total ICP: 16.048
+    soil organic carbon (%): 0.36
   S.W.35:
     latitude (deg): -30.1978913
     longitude (deg): 115.073864
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714244.0
-    don: 6.911
-    nh4: 3.144
-    no3: 1.221
-    totalPicp: 22.83
-    orgC: 0.628
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 6.911
+    soil NH4 content (mg/kg): 3.144
+    soil NO3 content: 1.221
+    soil P, total ICP: 22.83
+    soil organic carbon (%): 0.628
   S.W.36:
     latitude (deg): -30.1914824
     longitude (deg): 115.0742914
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714244.0
-    don: 6.926
-    nh4: 2.462
-    no3: 1.232
-    totalPicp: 22.648
-    orgC: 0.629
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714244.0
+    soil disolved organic nitrogen: 6.926
+    soil NH4 content (mg/kg): 2.462
+    soil NO3 content: 1.232
+    soil P, total ICP: 22.648
+    soil organic carbon (%): 0.629
   S.W.6:
     latitude (deg): -30.0980282
     longitude (deg): 115.0579672
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714609.0
-    don: 7.633
-    nh4: 3.518
-    no3: 2.015
-    totalPicp: 31.243
-    orgC: 0.689
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 7.633
+    soil NH4 content (mg/kg): 3.518
+    soil NO3 content: 2.015
+    soil P, total ICP: 31.243
+    soil organic carbon (%): 0.689
   S.W.8:
     latitude (deg): -30.2352837
     longitude (deg): 115.0706568
-    stage: '4'
+    choronosequence stage: '4'
     dune: Spearwood west
     epoch: Late Pleistocene
-    age: '120000'
-    geology: Tamala Limestone
-    date: -714609.0
-    don: 14.416
-    nh4: 4.031
-    no3: 0.959
-    totalPicp: 15.441
-    orgC: 0.695
+    soil age: '120000'
+    geology (stratigraphic map unit): Tamala Limestone
+    data sampled: -714609.0
+    soil disolved organic nitrogen: 14.416
+    soil NH4 content (mg/kg): 4.031
+    soil NO3 content: 0.959
+    soil P, total ICP: 15.441
+    soil organic carbon (%): 0.695
 contexts: .na
 config:
   data_is_long_format: no
@@ -1590,4 +1590,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Lamont_2002/metadata.yml
+++ b/data/Lamont_2002/metadata.yml
@@ -61,78 +61,78 @@ sites:
     latitude (deg): -29.82
     description: Low heath on laterite
     elevation (m): 100
-    rainfall (mm): 511
-    MAT (deg C): 27.4
+    precipitation, MAP (mm): 511
+    temperature, MAT (C): 27.4
   Esperance:
     longitude (deg): 121.88
     latitude (deg): -33.87
     description: Shrubland on granite outcrop, sand
     elevation (m): 25
-    rainfall (mm): 617
-    MAT (deg C): 21.8
+    precipitation, MAP (mm): 617
+    temperature, MAT (C): 21.8
   Fitzgerald River National Park:
     longitude (deg): 119.43
     latitude (deg): -34.07
     description: Scrub-heath on sandy quartzite
     elevation (m): 286
-    rainfall (mm): 526
-    MAT (deg C): 22.8
+    precipitation, MAP (mm): 526
+    temperature, MAT (C): 22.8
   John Forrest National Park:
     longitude (deg): 116.07
     latitude (deg): -31.98
     description: Scrub-heath/Eucalypt woodland on laterite/granite
     elevation (m): 210
-    rainfall (mm): 1003
-    MAT (deg C): 24.5
+    precipitation, MAP (mm): 1003
+    temperature, MAT (C): 24.5
   Kalbarri:
     longitude (deg): 114.17
     latitude (deg): -27.72
     description: Low heath on deep sand
     elevation (m): 6
-    rainfall (mm): 372
-    MAT (deg C): 28.2
+    precipitation, MAP (mm): 372
+    temperature, MAT (C): 28.2
   Lake King:
     longitude (deg): 119.68
     latitude (deg): -33.1
     description: Scrub-heath on loamy sand
     elevation (m): 310
-    rainfall (mm): 334
-    MAT (deg C): 22.7
+    precipitation, MAP (mm): 334
+    temperature, MAT (C): 22.7
   Merridin & other wheatbelt:
     longitude (deg): 118.22
     latitude (deg): -31.5
     description: Roadside remnants on sand
     elevation (m): 318
-    rainfall (mm): 331
-    MAT (deg C): 24.85
+    precipitation, MAP (mm): 331
+    temperature, MAT (C): 24.85
   Millbrook Reserve & nearby:
     longitude (deg): 117.88
     latitude (deg): -35.03
     description: Wet heath and low eucalypt woodland sand over laterite
     elevation (m): 68
-    rainfall (mm): 782
-    MAT (deg C): 20.3
+    precipitation, MAP (mm): 782
+    temperature, MAT (C): 20.3
   Stirling Ranges:
     longitude (deg): 118.22
     latitude (deg): -34.52
     description: Scrub-heath on sand and metaschist
     elevation (m): 300
-    rainfall (mm): 505
-    MAT (deg C): 20.3
+    precipitation, MAP (mm): 505
+    temperature, MAT (C): 20.3
   Walpole:
     longitude (deg): 116.73
     latitude (deg): -34.98
     description: Wet heath and low eucalypt woodland sand over laterite
     elevation (m): 18
-    rainfall (mm): 1201.5
-    MAT (deg C): 20.4
+    precipitation, MAP (mm): 1201.5
+    temperature, MAT (C): 20.4
   Watheroo:
     longitude (deg): 115.92
     latitude (deg): -30.12
     description: Scrub-heath on sand and loamy sand
     elevation (m): 198
-    rainfall (mm): 378
-    MAT (deg C): 26
+    precipitation, MAP (mm): 378
+    temperature, MAT (C): 26
 contexts: .na
 config:
   data_is_long_format: no
@@ -317,4 +317,3 @@ taxonomic_updates:
   reason: Confirm alignment with APC accepted species (E. Wenk, 2020-05-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Laxton_2005/metadata.yml
+++ b/data/Laxton_2005/metadata.yml
@@ -41,13 +41,13 @@ sites:
   Bola Creek Royal NP:
     longitude (deg): 151.0322222
     latitude (deg): -34.1477778
-    soil_pH (mol/l): 5.59
-    soil_%_water (%): 1.98
-    soil_%_organic_matter (%): 26.78
-    soil_oxidised_N (mgN/kg): 1.46
-    soil_total_Kjeldahl_N (mgN/kg): 664.4
-    soil_total_N (mgN/kg): 665.8
-    soil_total_P (mgP/kg): 290.8
+    soil pH (H2O): 5.59
+    soil water content (%): 1.98
+    soil organic carbon (%): 26.78
+    soil N, oxidised (mg/kg): 1.46
+    soil N, Kjeldahl (mg/kg): 664.4
+    soil N, total (ppm): 665.8
+    soil P, total (mg/kg): 290.8
     description: The more fertile site in Royal National Park was located on Narrabeen
       Shales (Fig. 2.5). Soils belong to the Watangan soil group and are described
       as shallow to deep (30-200 cm) loose, stony, brownish black fine sandy or clay
@@ -58,13 +58,13 @@ sites:
   Bundeena Road Royal NP:
     longitude (deg): 151.0861111
     latitude (deg): -34.1258333
-    soil_pH (mol/l): 5.75
-    soil_%_water (%): 1.39
-    soil_%_organic_matter (%): 2.73
-    soil_oxidised_N (mgN/kg): 0.17
-    soil_total_Kjeldahl_N (mgN/kg): 376.9
-    soil_total_N (mgN/kg): 377
-    soil_total_P (mgP/kg): 108.7
+    soil pH (H2O): 5.75
+    soil water content (%): 1.39
+    soil organic carbon (%): 2.73
+    soil N, oxidised (mg/kg): 0.17
+    soil N, Kjeldahl (mg/kg): 376.9
+    soil N, total (ppm): 377
+    soil P, total (mg/kg): 108.7
     description: The infertile sites in Ku-ring-gai Chase National Park and Royal
       National Park are on the Tertiary geological deposits of Hawkesbury Sandstone
       (Sydney and Wollongong Port Hacking 1:100 000 geological map sheets, NSW Department
@@ -77,13 +77,13 @@ sites:
   Challenger Track KCNP:
     longitude (deg): 151.2766667
     latitude (deg): -33.5966667
-    soil_pH (mol/l): 5.71
-    soil_%_water (%): 8.45
-    soil_%_organic_matter (%): 4.72
-    soil_oxidised_N (mgN/kg): 0.13
-    soil_total_Kjeldahl_N (mgN/kg): 404.9
-    soil_total_N (mgN/kg): 405.1
-    soil_total_P (mgP/kg): 179.9
+    soil pH (H2O): 5.71
+    soil water content (%): 8.45
+    soil organic carbon (%): 4.72
+    soil N, oxidised (mg/kg): 0.13
+    soil N, Kjeldahl (mg/kg): 404.9
+    soil N, total (ppm): 405.1
+    soil P, total (mg/kg): 179.9
     description: The infertile sites in Ku-ring-gai Chase National Park and Royal
       National Park are on the Tertiary geological deposits of Hawkesbury Sandstone
       (Sydney and Wollongong Port Hacking 1:100 000 geological map sheets, NSW Department
@@ -96,13 +96,13 @@ sites:
   Dyke KCNP:
     longitude (deg): 151.2938889
     latitude (deg): -33.5791667
-    soil_pH (mol/l): 6.11
-    soil_%_water (%): 27.05
-    soil_%_organic_matter (%): 11.08
-    soil_oxidised_N (mgN/kg): 0.09
-    soil_total_Kjeldahl_N (mgN/kg): 404.9
-    soil_total_N (mgN/kg): 625.7
-    soil_total_P (mgP/kg): 227
+    soil pH (H2O): 6.11
+    soil water content (%): 27.05
+    soil organic carbon (%): 11.08
+    soil N, oxidised (mg/kg): 0.09
+    soil N, Kjeldahl (mg/kg): 404.9
+    soil N, total (ppm): 625.7
+    soil P, total (mg/kg): 227
     description: The more fertile site in Ku-ring-gai Chase National Park was located
       on an approximately 20 m wide igneous dyke (Fig. 2.4), which has weathered to
       form deep red soils with a higher nutrient content than the surrounding areas.
@@ -307,4 +307,3 @@ taxonomic_updates: .na
 exclude_observations: .na
 questions:
   additional_traits: cellulose, hemicellulose, holocellulose, tannins
-

--- a/data/Leigh_2003/metadata.yml
+++ b/data/Leigh_2003/metadata.yml
@@ -9,7 +9,7 @@ source:
       Maireana pyramidata (Chenopodiaceae), a dioecious, semi-arid shrub
     volume: '51'
     number: '5'
-    pages: '509--514'
+    pages: 509--514
     doi: 10.1071/bt03043
 people:
 - name: Andrea Leigh
@@ -51,7 +51,7 @@ sites:
     latitude (deg): -35.34
     longitude (deg): 142.83
     description: road verge raised 1-1.5 m above salt lake shoreline
-    source lat/lon: AusTraits, centre of Lake Tyrrell, Victoria
+    lat/lon notes: AusTraits, centre of Lake Tyrrell, Victoria
 contexts:
   female:
     type: field
@@ -137,4 +137,3 @@ taxonomic_updates: .na
 exclude_observations: .na
 questions:
   additional_traits: author has gas exchange data that she may submit in the future
-

--- a/data/Leigh_2003/metadata.yml
+++ b/data/Leigh_2003/metadata.yml
@@ -51,7 +51,7 @@ sites:
     latitude (deg): -35.34
     longitude (deg): 142.83
     description: road verge raised 1-1.5 m above salt lake shoreline
-    lat/lon notes: AusTraits, centre of Lake Tyrrell, Victoria
+    georeference remarks: AusTraits, centre of Lake Tyrrell, Victoria
 contexts:
   female:
     type: field

--- a/data/Lim_2017/metadata.yml
+++ b/data/Lim_2017/metadata.yml
@@ -66,231 +66,231 @@ sites:
   23N:
     latitude (deg): -36.91565
     longitude (deg): 147.2866167
-    Elevation: 1698.0
+    elevation (m): 1698.0
     description: 'This site was one of the sites in Williams, R. J. "Patterns of air
       temperature and accumulation of snow in subalpine heathlands and grasslands
       on the Bogong High Plains, Victoria." Australian Journal of Ecology 12.2 (1987):
       153-163.'
-    aspect: north
+    slope aspect (degrees): north
   23S:
     latitude (deg): -36.9127333
     longitude (deg): 147.2862667
-    Elevation: 1692.0
+    elevation (m): 1692.0
     description: 'This site was one of the sites in Williams, R. J. "Patterns of air
       temperature and accumulation of snow in subalpine heathlands and grasslands
       on the Bogong High Plains, Victoria." Australian Journal of Ecology 12.2 (1987):
       153-163.'
-    aspect: south
+    slope aspect (degrees): south
   BPN:
     latitude (deg): -36.9356667
     longitude (deg): 147.3439667
-    Elevation: 1562.0
+    elevation (m): 1562.0
     description: Buckety plains
-    aspect: north
+    slope aspect (degrees): north
   Cope:
     latitude (deg): -36.9006333
     longitude (deg): 147.2494833
-    Elevation: 1671.0
+    elevation (m): 1671.0
     description: Cope Saddle Track
-    aspect: south
+    slope aspect (degrees): south
   F03:
     latitude (deg): -36.9120833
     longitude (deg): 147.2813333
-    Elevation: 1693.0
+    elevation (m): 1693.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F04N:
     latitude (deg): -36.9251833
     longitude (deg): 147.2961833
-    Elevation: 1669.0
+    elevation (m): 1669.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F04South:
     latitude (deg): -36.92495
     longitude (deg): 147.2959333
-    Elevation: 1669.0
+    elevation (m): 1669.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F05N:
     latitude (deg): -36.8528167
     longitude (deg): 147.3332333
-    Elevation: 1705.0
+    elevation (m): 1705.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F06:
     latitude (deg): -36.9059
     longitude (deg): 147.2726333
-    Elevation: 1665.0
+    elevation (m): 1665.0
     description: F06S
-    aspect: south
+    slope aspect (degrees): south
   F07N:
     latitude (deg): -36.90965
     longitude (deg): 147.2764
-    Elevation: 1703.0
+    elevation (m): 1703.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F07S:
     latitude (deg): -36.91065
     longitude (deg): 147.2750667
-    Elevation: 1702.0
+    elevation (m): 1702.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F08:
     latitude (deg): -36.9070333
     longitude (deg): 147.27315
-    Elevation: 1674.0
+    elevation (m): 1674.0
     description: F08N
-    aspect: north
+    slope aspect (degrees): north
   F09:
     latitude (deg): -36.8797
     longitude (deg): 147.313
-    Elevation: 1632.0
+    elevation (m): 1632.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F10S:
     latitude (deg): -36.8948667
     longitude (deg): 147.3127167
-    Elevation: 1602.0
+    elevation (m): 1602.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F123N:
     latitude (deg): -36.9159833
     longitude (deg): 147.2721167
-    Elevation: 1676.0
+    elevation (m): 1676.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F123S:
     latitude (deg): -36.91505
     longitude (deg): 147.2723167
-    Elevation: 1681.0
+    elevation (m): 1681.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F12N:
     latitude (deg): -36.9187833
     longitude (deg): 147.2741667
-    Elevation: 1696.0
+    elevation (m): 1696.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F12S:
     latitude (deg): -36.9176167
     longitude (deg): 147.2715833
-    Elevation: 1684.0
+    elevation (m): 1684.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F13N:
     latitude (deg): -36.8788667
     longitude (deg): 147.3114
-    Elevation: 1632.0
+    elevation (m): 1632.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F13S:
     latitude (deg): -36.8786833
     longitude (deg): 147.3114167
-    Elevation: 1632.0
+    elevation (m): 1632.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F14N:
     latitude (deg): -36.91985
     longitude (deg): 147.2818667
-    Elevation: 1710.0
+    elevation (m): 1710.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F14S:
     latitude (deg): -36.9180167
     longitude (deg): 147.2867167
-    Elevation: 1720.0
+    elevation (m): 1720.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F15N:
     latitude (deg): -36.92255
     longitude (deg): 147.2909667
-    Elevation: 1731.0
+    elevation (m): 1731.0
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F15S:
     latitude (deg): -36.9250667
     longitude (deg): 147.2911167
-    Elevation: 1737.0
+    elevation (m): 1737.0
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F16S:
     latitude (deg): -36.9343
     longitude (deg): 147.2568167
-    Elevation: 1631
+    elevation (m): 1631
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F17N:
     latitude (deg): -36.9155833
     longitude (deg): 147.2585167
-    Elevation: 1678
+    elevation (m): 1678
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F17S:
     latitude (deg): -36.9198333
     longitude (deg): 147.2569
-    Elevation: 1698
+    elevation (m): 1698
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F18S:
     latitude (deg): -36.9221333
     longitude (deg): 147.2575667
-    Elevation: 1700
+    elevation (m): 1700
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F19S:
     latitude (deg): -36.92145
     longitude (deg): 147.2239333
-    Elevation: 1730
+    elevation (m): 1730
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F20:
     latitude (deg): -36.9222667
     longitude (deg): 147.27275
-    Elevation: 1720
+    elevation (m): 1720
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F20S:
     latitude (deg): -36.9222667
     longitude (deg): 147.27275
-    Elevation: 1720
+    elevation (m): 1720
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F21N:
     latitude (deg): -36.82555
     longitude (deg): 147.31575
-    Elevation: 1806
+    elevation (m): 1806
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F21S:
     latitude (deg): -36.8246667
     longitude (deg): 147.3157667
-    Elevation: 1813
+    elevation (m): 1813
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   F25N:
     latitude (deg): -36.9020667
     longitude (deg): 147.2706167
-    Elevation: 1677
+    elevation (m): 1677
     description: .na.character
-    aspect: north
+    slope aspect (degrees): north
   F25S:
     latitude (deg): -36.9023
     longitude (deg): 147.2692667
-    Elevation: 1672
+    elevation (m): 1672
     description: .na.character
-    aspect: south
+    slope aspect (degrees): south
   JimHillN:
     latitude (deg): -36.9206333
     longitude (deg): 147.2153667
-    Elevation: 1792
+    elevation (m): 1792
     description: Jims Hill North
-    aspect: north
+    slope aspect (degrees): north
   JimHillS:
     latitude (deg): -36.92285
     longitude (deg): 147.21555
-    Elevation: 1777
+    elevation (m): 1777
     description: Jims Hill South
-    aspect: south
+    slope aspect (degrees): south
 contexts:
   Bottom:
     description: site at the bottom of a frost hollow in open heathland
@@ -446,4 +446,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: leaf bud size, proportion air space in leaf bud
-

--- a/data/Lusk_2010/metadata.yml
+++ b/data/Lusk_2010/metadata.yml
@@ -39,8 +39,8 @@ sites:
   shade_5-8%_canopy_openness:
     latitude (deg): -28.633
     longitude (deg): 153.333
-    MAT: 22.4
-    MAP: 2314 mm
+    temperature, MAT (C): 22.4
+    precipitation, MAP (mm): 2314 mm
     description: The study was carried out in subtropical rainforest in Nightcap National
       Park (New South Wales, Australia) located at 28deg38min S, 153deg20min E and
       at an elevation of 380 m asl. Mean annual temperature at the nearest meteorological
@@ -51,12 +51,12 @@ sites:
       per species were sampled in each light environment. There was no significant
       interspecific variation in mean light environments of either sun leaves (ANOVA,
       F = 1.19, P = 0.32) or shade leaves (F = 1.12, P = 0.36).
-    canopy: 5-8% canopy openness
+    crown cover: 5-8% canopy openness
   sun_15-24%_canopy_openness:
     latitude (deg): -28.633
     longitude (deg): 153.333
-    MAT: 22.4
-    MAP: 2314 mm
+    temperature, MAT (C): 22.4
+    precipitation, MAP (mm): 2314 mm
     description: The study was carried out in subtropical rainforest in Nightcap National
       Park (New South Wales, Australia) located at 28deg38min S, 153deg20min E and
       at an elevation of 380 m asl. Mean annual temperature at the nearest meteorological
@@ -70,7 +70,7 @@ sites:
       300-700 m2 treefall gaps in tropical rainforest by Brown (1993). There was no
       significant interspecific variation in mean light environments of either sun
       leaves (ANOVA, F = 1.19, P = 0.32) or shade leaves (F = 1.12, P = 0.36).
-    canopy: 15-24% canopy openness
+    crown cover: 15-24% canopy openness
 contexts: .na
 config:
   data_is_long_format: no
@@ -306,4 +306,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: cell contents per area (g/m2), Cell wall mass per unit area (g/m2)
-

--- a/data/Lusk_2012/metadata.yml
+++ b/data/Lusk_2012/metadata.yml
@@ -197,4 +197,3 @@ exclude_observations: .na
 questions:
   additional traits: RGR also in data file and methods given above, but not currently
     mapped onto trait names for AusTraits.
-

--- a/data/MacinnisNg_2004/metadata.yml
+++ b/data/MacinnisNg_2004/metadata.yml
@@ -9,7 +9,7 @@ source:
       amongst habitats and across seasons in Sydney
     volume: '31'
     number: '5'
-    pages: '429--439'
+    pages: 429--439
     doi: 10.1071/fp03194
   secondary:
     key: McClenahan_2004
@@ -21,7 +21,7 @@ source:
       sites around Sydney
     volume: '52'
     number: '4'
-    pages: '509--518'
+    pages: 509--518
     doi: 10.1071/bt03123
 people:
 - name: Catriona Macinnis-Ng
@@ -74,31 +74,32 @@ dataset:
     obtained from the Bureau of Meteorology. These are the closest meteorological
     stations to Royal National Park and Crosslands Reserve, respectively.
   original_file: Hydraulic traits for Austraits.xls
-  notes: Adjusted values for sapwood_specific_conductivity to match those in publication (10x too big in contributed data vs. publication, although same units provided)
+  notes: Adjusted values for sapwood_specific_conductivity to match those in publication
+    (10x too big in contributed data vs. publication, although same units provided)
 sites:
   Crosslands_mangrove:
     latitude (deg): -33.667
     longitude (deg): 151.167
     description: mangrove stands
-    soil: Sydney sandstone derived soil
+    geology (parent material): Sydney sandstone derived soil
     elevation (m): 0
   Crosslands_ridgetop:
     latitude (deg): -33.667
     longitude (deg): 151.167
     description: ridgetop woodland
-    soil: Sydney sandstone derived soil
+    geology (parent material): Sydney sandstone derived soil
     elevation (m): 150
   Crosslands_river_flat:
     latitude (deg): -33.667
     longitude (deg): 151.167
     description: river flat woodland
-    soil: Sydney sandstone derived soil
+    geology (parent material): Sydney sandstone derived soil
     elevation (m): 10
   Royal NP:
     latitude (deg): -34.098056
     longitude (deg): 151.059444
     description: heathland along Walumarra track
-    soil: Sydney sandstone derived soil
+    geology (parent material): Sydney sandstone derived soil
     elevation (m): .na
 contexts:
   winter:
@@ -148,8 +149,8 @@ traits:
     accommodate three branches. The solution was pulled through the branch in the
     normal direction of the transpiration stream by applying a vacuum to the chamber.
     Flow rate of the acidified de-gassed water was measured at four levels of vacuum
-    (pressure difference (delta P) = 20, 30, 40 and 50 kPa), which was measured with a
-    vacuum gauge (Leybold, Germany). Branches were allowed to reach an equilibrium
+    (pressure difference (delta P) = 20, 30, 40 and 50 kPa), which was measured with
+    a vacuum gauge (Leybold, Germany). Branches were allowed to reach an equilibrium
     flow rate before flow rate was recorded. Hydraulic conductance (kg s-1 MPa-1)
     was calculated as the slope of the relationship between flow rate and pressure
     difference using linear regression. Hydraulic conductivity (kg s-1 m MPa-1) was
@@ -175,8 +176,8 @@ traits:
     accommodate three branches. The solution was pulled through the branch in the
     normal direction of the transpiration stream by applying a vacuum to the chamber.
     Flow rate of the acidified de-gassed water was measured at four levels of vacuum
-    (pressure difference (delta P) = 20, 30, 40 and 50 kPa), which was measured with a
-    vacuum gauge (Leybold, Germany). Branches were allowed to reach an equilibrium
+    (pressure difference (delta P) = 20, 30, 40 and 50 kPa), which was measured with
+    a vacuum gauge (Leybold, Germany). Branches were allowed to reach an equilibrium
     flow rate before flow rate was recorded. Hydraulic conductance (kg s-1 MPa-1)
     was calculated as the slope of the relationship between flow rate and pressure
     difference using linear regression. Hydraulic conductivity (kg s-1 m MPa-1) was
@@ -202,11 +203,11 @@ traits:
     2 m long and 30 cm wide, each of which could accommodate three branches. The solution
     was pulled through the branch in the normal direction of the transpiration stream
     by applying a vacuum to the chamber. Flow rate of the acidified de-gassed water
-    was measured at four levels of vacuum (pressure difference (delta P) = 20, 30, 40 and
-    50 kPa), which was measured with a vacuum gauge (Leybold, Germany). Branches were
-    allowed to reach an equilibrium flow rate before flow rate was recorded. Hydraulic
-    conductance (kg s-1 MPa-1) was calculated as the slope of the relationship between
-    flow rate and pressure difference using linear regression. Hydraulic conductivity
+    was measured at four levels of vacuum (pressure difference (delta P) = 20, 30,
+    40 and 50 kPa), which was measured with a vacuum gauge (Leybold, Germany). Branches
+    were allowed to reach an equilibrium flow rate before flow rate was recorded.
+    Hydraulic conductance (kg s-1 MPa-1) was calculated as the slope of the relationship
+    between flow rate and pressure difference using linear regression. Hydraulic conductivity
     (kg s-1 m MPa-1) was calculated by multiplying the conductance by the branch length
     and was expressed in terms of leaf area, sapwood area and branch transverse area.
 - var_in: HC per SW area
@@ -229,11 +230,11 @@ traits:
     m long and 30 cm wide, each of which could accommodate three branches. The solution
     was pulled through the branch in the normal direction of the transpiration stream
     by applying a vacuum to the chamber. Flow rate of the acidified de-gassed water
-    was measured at four levels of vacuum (pressure difference (delta P) = 20, 30, 40 and
-    50 kPa), which was measured with a vacuum gauge (Leybold, Germany). Branches were
-    allowed to reach an equilibrium flow rate before flow rate was recorded. Hydraulic
-    conductance (kg s-1 MPa-1) was calculated as the slope of the relationship between
-    flow rate and pressure difference using linear regression. Hydraulic conductivity
+    was measured at four levels of vacuum (pressure difference (delta P) = 20, 30,
+    40 and 50 kPa), which was measured with a vacuum gauge (Leybold, Germany). Branches
+    were allowed to reach an equilibrium flow rate before flow rate was recorded.
+    Hydraulic conductance (kg s-1 MPa-1) was calculated as the slope of the relationship
+    between flow rate and pressure difference using linear regression. Hydraulic conductivity
     (kg s-1 m MPa-1) was calculated by multiplying the conductance by the branch length
     and was expressed in terms of leaf area, sapwood area and branch transverse area.
 - var_in: Predawn water potential
@@ -267,16 +268,17 @@ traits:
   trait_name: photosynthetic_rate_per_dry_mass_saturated
   value_type: site_mean
   replicates: 3
-  methods: Measurements made in summer; Light-saturated photosynthesis (Amax) was measured with an HCM-1000 portable
-    infrared gas analyser (IRGA; Walz, portable photosynthesis system HCM-1000 handbook,
-    Germany) operated in differential mode. Measurements of intact, fully expanded
-    leaves were taken in the morning (between 0930 hours and 1130 hours local time)
-    between May and August (winter) 2001 and in February and March (summer) 2002.
-    Leaves were in full sunlight at the time of sampling and light-saturating conditions
-    (PAR > 1000 umol m-2 s-1) were used throughout the study. Ambient levels of atmospheric
-    CO2, humidity and temperatures were maintained in the leaf chamber at the start
-    of each measurement period. Three leaves, on each of three plants, in each of
-    two plots, for each species, were sampled.
+  methods: Measurements made in summer; Light-saturated photosynthesis (Amax) was
+    measured with an HCM-1000 portable infrared gas analyser (IRGA; Walz, portable
+    photosynthesis system HCM-1000 handbook, Germany) operated in differential mode.
+    Measurements of intact, fully expanded leaves were taken in the morning (between
+    0930 hours and 1130 hours local time) between May and August (winter) 2001 and
+    in February and March (summer) 2002. Leaves were in full sunlight at the time
+    of sampling and light-saturating conditions (PAR > 1000 umol m-2 s-1) were used
+    throughout the study. Ambient levels of atmospheric CO2, humidity and temperatures
+    were maintained in the leaf chamber at the start of each measurement period. Three
+    leaves, on each of three plants, in each of two plots, for each species, were
+    sampled.
 substitutions: .na
 taxonomic_updates:
 - find: Eucalypyus haemostoma
@@ -287,10 +289,9 @@ taxonomic_updates:
   reason: Alignment with existing species identified by TaxonStand (2020-06-16)
 exclude_observations: .na
 questions:
-  contributor: I've been struggling with the units for the conductivity measures. I've
-    compared the values in Table 3 from McClenahan_2004 and Figure 2 from Macinnis-Ng_2004
+  contributor: I've been struggling with the units for the conductivity measures.
+    I've compared the values in Table 3 from McClenahan_2004 and Figure 2 from Macinnis-Ng_2004
     and your spreadsheet and various bits don't match. For now I've taken the liberty
     to align them with what puts your data in line with other studies, but would like
     to figure out which numbers to use. (I've tried re-creating some of your values
     from the table in McClenahan 2004 and haven't been completely successful either.)
-

--- a/data/MacinnisNg_2016/metadata.yml
+++ b/data/MacinnisNg_2016/metadata.yml
@@ -343,4 +343,3 @@ questions:
   contributor: You'll notice that the values for leaf_specific_conductivity seem about
     10x higher than other studies. Does this ring true?
   additional_traits: ETRmax, calculated from fluorescence data (Jmax per area)
-

--- a/data/McCarthy_2017/metadata.yml
+++ b/data/McCarthy_2017/metadata.yml
@@ -86,333 +86,333 @@ sites:
   Bania:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Bania
+    coordinate uncertainty (m): .na.real
+    locality: Bania
   Benarkin:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Benarkin
+    coordinate uncertainty (m): .na.real
+    locality: Benarkin
   Bulburin:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Bulburin
+    coordinate uncertainty (m): .na.real
+    locality: Bulburin
   Curra:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Curra
+    coordinate uncertainty (m): .na.real
+    locality: Curra
   FraserCooloola:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: FraserCooloola
+    coordinate uncertainty (m): .na.real
+    locality: FraserCooloola
   FraserIsland:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: FraserIsland
+    coordinate uncertainty (m): .na.real
+    locality: FraserIsland
   FraserIsland_1:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: FraserIsland_1
+    coordinate uncertainty (m): .na.real
+    locality: FraserIsland_1
   Girraween:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Girraween
+    coordinate uncertainty (m): .na.real
+    locality: Girraween
   John:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: John
+    coordinate uncertainty (m): .na.real
+    locality: John
   Littabella:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Littabella
+    coordinate uncertainty (m): .na.real
+    locality: Littabella
   Littabella etc:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Littabella etc
+    coordinate uncertainty (m): .na.real
+    locality: Littabella etc
   Mt Binga:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Mt Binga
+    coordinate uncertainty (m): .na.real
+    locality: Mt Binga
   MtEdwards:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: MtEdwards
+    coordinate uncertainty (m): .na.real
+    locality: MtEdwards
   MtEdwards etc:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: MtEdwards etc
+    coordinate uncertainty (m): .na.real
+    locality: MtEdwards etc
   Noosa:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Noosa
+    coordinate uncertainty (m): .na.real
+    locality: Noosa
   NoosaEtc:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: NoosaEtc
+    coordinate uncertainty (m): .na.real
+    locality: NoosaEtc
   site_at_-24.541389_degS_151.486667_degE:
     latitude (deg): -24.541389
     longitude (deg): 151.486667
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Bulburin
+    coordinate uncertainty (m): 50.0
+    locality: Bulburin
   site_at_-24.705278_degS_151.995278_degE:
     latitude (deg): -24.705278
     longitude (deg): 151.995278
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Littabella
+    coordinate uncertainty (m): 50.0
+    locality: Littabella
   site_at_-25.015556_degS_152.432778_degE:
     latitude (deg): -25.015556
     longitude (deg): 152.432778
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woodgate
+    coordinate uncertainty (m): 50.0
+    locality: Woodgate
   site_at_-25.023611_degS_151.468611_degE:
     latitude (deg): -25.023611
     longitude (deg): 151.468611
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Bania
+    coordinate uncertainty (m): 50.0
+    locality: Bania
   site_at_-25.049444_degS_152.487222_degE:
     latitude (deg): -25.049444
     longitude (deg): 152.487222
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woodgate
+    coordinate uncertainty (m): 50.0
+    locality: Woodgate
   site_at_-25.059167_degS_153.2425_degE:
     latitude (deg): -25.059167
     longitude (deg): 153.2425
-    Coordinate uncertainty (m): 50.0
-    trip identifier: FraserCooloola
+    coordinate uncertainty (m): 50.0
+    locality: FraserCooloola
   site_at_-25.143056_degS_152.591667_degE:
     latitude (deg): -25.143056
     longitude (deg): 152.591667
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woodgate
+    coordinate uncertainty (m): 50.0
+    locality: Woodgate
   site_at_-25.293889_degS_153.167222_degE:
     latitude (deg): -25.293889
     longitude (deg): 153.167222
-    Coordinate uncertainty (m): 50.0
-    trip identifier: FraserCooloola
+    coordinate uncertainty (m): 50.0
+    locality: FraserCooloola
   site_at_-25.448641_degS_152.987443_degE:
     latitude (deg): -25.448641
     longitude (deg): 152.987443
-    Coordinate uncertainty (m): 10.0
-    trip identifier: FraserIsland
+    coordinate uncertainty (m): 10.0
+    locality: FraserIsland
   site_at_-25.478056_degS_152.436389_degE:
     latitude (deg): -25.478056
     longitude (deg): 152.436389
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woodgate
+    coordinate uncertainty (m): 50.0
+    locality: Woodgate
   site_at_-25.69291_degS_152.551705_degE:
     latitude (deg): -25.69291
     longitude (deg): 152.551705
-    Coordinate uncertainty (m): 5000.0
-    trip identifier: StMary
+    coordinate uncertainty (m): 5000.0
+    locality: StMary
   site_at_-26.017042_degS_153.023793_degE:
     latitude (deg): -26.017042
     longitude (deg): 153.023793
-    Coordinate uncertainty (m): 10.0
-    trip identifier: FraserCooloola
+    coordinate uncertainty (m): 10.0
+    locality: FraserCooloola
   site_at_-26.049722_degS_153.040278_degE:
     latitude (deg): -26.049722
     longitude (deg): 153.040278
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Cooloola_2
+    coordinate uncertainty (m): 10.0
+    locality: Cooloola_2
   site_at_-26.054444_degS_153.010833_degE:
     latitude (deg): -26.054444
     longitude (deg): 153.010833
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Cooloola_3
+    coordinate uncertainty (m): 10.0
+    locality: Cooloola_3
   site_at_-26.057778_degS_151.754444_degE:
     latitude (deg): -26.057778
     longitude (deg): 151.754444
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woroon
+    coordinate uncertainty (m): 50.0
+    locality: Woroon
   site_at_-26.073889_degS_151.749722_degE:
     latitude (deg): -26.073889
     longitude (deg): 151.749722
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Woroon
+    coordinate uncertainty (m): 50.0
+    locality: Woroon
   site_at_-26.075278_degS_152.984444_degE:
     latitude (deg): -26.075278
     longitude (deg): 152.984444
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Cooloola_1
+    coordinate uncertainty (m): 10.0
+    locality: Cooloola_1
   site_at_-26.360781_degS_151.941388_degE:
     latitude (deg): -26.360781
     longitude (deg): 151.941388
-    Coordinate uncertainty (m): 20000.0
-    trip identifier: Wondai
+    coordinate uncertainty (m): 20000.0
+    locality: Wondai
   site_at_-26.397692_degS_152.928118_degE:
     latitude (deg): -26.397692
     longitude (deg): 152.928118
-    Coordinate uncertainty (m): 10000.0
-    trip identifier: Cooroy
+    coordinate uncertainty (m): 10000.0
+    locality: Cooroy
   site_at_-26.456831_degS_152.881515_degE:
     latitude (deg): -26.456831
     longitude (deg): 152.881515
-    Coordinate uncertainty (m): 100.0
-    trip identifier: Cooroy
+    coordinate uncertainty (m): 100.0
+    locality: Cooroy
   site_at_-26.603611_degS_152.848611_degE:
     latitude (deg): -26.603611
     longitude (deg): 152.848611
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Mapleton
+    coordinate uncertainty (m): 10.0
+    locality: Mapleton
   site_at_-26.70583_degS_152.583036_degE:
     latitude (deg): -26.70583
     longitude (deg): 152.583036
-    Coordinate uncertainty (m): 20000.0
-    trip identifier: Conondales
+    coordinate uncertainty (m): 20000.0
+    locality: Conondales
   site_at_-26.855815_degS_153.007686_degE:
     latitude (deg): -26.855815
     longitude (deg): 153.007686
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: RoysRd
+    coordinate uncertainty (m): 1000.0
+    locality: RoysRd
   site_at_-26.9025_degS_151.636389_degE:
     latitude (deg): -26.9025
     longitude (deg): 151.636389
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Bunyas
+    coordinate uncertainty (m): 50.0
+    locality: Bunyas
   site_at_-26.953056_degS_152.1975_degE:
     latitude (deg): -26.953056
     longitude (deg): 152.1975
-    Coordinate uncertainty (m): 50.0
-    trip identifier: Benarkin
+    coordinate uncertainty (m): 50.0
+    locality: Benarkin
   site_at_-26.991944_degS_151.904167_degE:
     latitude (deg): -26.991944
     longitude (deg): 151.904167
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Mt Binga
+    coordinate uncertainty (m): 10.0
+    locality: Mt Binga
   site_at_-27.097282_degS_152.685105_degE:
     latitude (deg): -27.097282
     longitude (deg): 152.685105
-    Coordinate uncertainty (m): 5000.0
-    trip identifier: MtMee
+    coordinate uncertainty (m): 5000.0
+    locality: MtMee
   site_at_-27.417854_degS_152.835665_degE:
     latitude (deg): -27.417854
     longitude (deg): 152.835665
-    Coordinate uncertainty (m): 5000.0
-    trip identifier: BrisbaneForestPark
+    coordinate uncertainty (m): 5000.0
+    locality: BrisbaneForestPark
   site_at_-27.479254_degS_153.083929_degE:
     latitude (deg): -27.479254
     longitude (deg): 153.083929
-    Coordinate uncertainty (m): 500.0
-    trip identifier: SevenHills
+    coordinate uncertainty (m): 500.0
+    locality: SevenHills
   site_at_-27.489375_degS_153.080106_degE:
     latitude (deg): -27.489375
     longitude (deg): 153.080106
-    Coordinate uncertainty (m): 10.0
-    trip identifier: Home
+    coordinate uncertainty (m): 10.0
+    locality: Home
   site_at_-27.492263_degS_153.079737_degE:
     latitude (deg): -27.492263
     longitude (deg): 153.079737
-    Coordinate uncertainty (m): 100.0
-    trip identifier: CampHillPrimary
+    coordinate uncertainty (m): 100.0
+    locality: CampHillPrimary
   site_at_-27.49808_degS_153.01494_degE:
     latitude (deg): -27.49808
     longitude (deg): 153.01494
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: UQ
+    coordinate uncertainty (m): 1000.0
+    locality: UQ
   site_at_-27.509934_degS_153.083068_degE:
     latitude (deg): -27.509934
     longitude (deg): 153.083068
-    Coordinate uncertainty (m): 3000.0
-    trip identifier: WhitesHills
+    coordinate uncertainty (m): 3000.0
+    locality: WhitesHills
   site_at_-27.540327_degS_152.967908_degE:
     latitude (deg): -27.540327
     longitude (deg): 152.967908
-    Coordinate uncertainty (m): 2000.0
-    trip identifier: FigTreePocket
+    coordinate uncertainty (m): 2000.0
+    locality: FigTreePocket
   site_at_-27.543139_degS_153.054614_degE:
     latitude (deg): -27.543139
     longitude (deg): 153.054614
-    Coordinate uncertainty (m): 3000.0
-    trip identifier: Toohey
+    coordinate uncertainty (m): 3000.0
+    locality: Toohey
   site_at_-27.733278_degS_153.180969_degE:
     latitude (deg): -27.733278
     longitude (deg): 153.180969
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: BahrsScrub
+    coordinate uncertainty (m): 1000.0
+    locality: BahrsScrub
   site_at_-28.078611_degS_152.406944_degE:
     latitude (deg): -28.078611
     longitude (deg): 152.406944
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: MainRange
+    coordinate uncertainty (m): 1000.0
+    locality: MainRange
   site_at_-28.079148_degS_153.203051_degE:
     latitude (deg): -28.079148
     longitude (deg): 153.203051
-    Coordinate uncertainty (m): 500.0
-    trip identifier: KillarneyGlen
+    coordinate uncertainty (m): 500.0
+    locality: KillarneyGlen
   site_at_-28.199882_degS_153.188043_degE:
     latitude (deg): -28.199882
     longitude (deg): 153.188043
-    Coordinate uncertainty (m): 200.0
-    trip identifier: Lamington
+    coordinate uncertainty (m): 200.0
+    locality: Lamington
   site_at_-28.21159_degS_153.192527_degE:
     latitude (deg): -28.21159
     longitude (deg): 153.192527
-    Coordinate uncertainty (m): 2000.0
-    trip identifier: DavesCreek
+    coordinate uncertainty (m): 2000.0
+    locality: DavesCreek
   site_at_-28.220655_degS_153.207943_degE:
     latitude (deg): -28.220655
     longitude (deg): 153.207943
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: DavesCreek
+    coordinate uncertainty (m): 1000.0
+    locality: DavesCreek
   site_at_-28.229881_degS_153.146648_degE:
     latitude (deg): -28.229881
     longitude (deg): 153.146648
-    Coordinate uncertainty (m): 5000.0
-    trip identifier: Lamington_2
+    coordinate uncertainty (m): 5000.0
+    locality: Lamington_2
   site_at_-28.521457_degS_151.948843_degE:
     latitude (deg): -28.521457
     longitude (deg): 151.948843
-    Coordinate uncertainty (m): 100.0
-    trip identifier: Girraween
+    coordinate uncertainty (m): 100.0
+    locality: Girraween
   site_at_-28.844333_degS_152.152503_degE:
     latitude (deg): -28.844333
     longitude (deg): 152.152503
-    Coordinate uncertainty (m): 1000.0
-    trip identifier: Girraween
+    coordinate uncertainty (m): 1000.0
+    locality: Girraween
   Tewantin:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Tewantin
+    coordinate uncertainty (m): .na.real
+    locality: Tewantin
   Tewantin1:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Tewantin1
+    coordinate uncertainty (m): .na.real
+    locality: Tewantin1
   Tewantin2:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Tewantin2
+    coordinate uncertainty (m): .na.real
+    locality: Tewantin2
   Toohey/Bahrs:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Toohey/Bahrs
+    coordinate uncertainty (m): .na.real
+    locality: Toohey/Bahrs
   Woodgate:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Woodgate
+    coordinate uncertainty (m): .na.real
+    locality: Woodgate
   Woroon:
     latitude (deg): .na.real
     longitude (deg): .na.real
-    Coordinate uncertainty (m): .na.real
-    trip identifier: Woroon
+    coordinate uncertainty (m): .na.real
+    locality: Woroon
 contexts: .na
 config:
   data_is_long_format: yes
@@ -479,4 +479,3 @@ exclude_observations:
   find: Boehmeria platanifolia
   reason: non-native (Asia)
 questions: .na
-

--- a/data/Meers_2007/metadata.yml
+++ b/data/Meers_2007/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Thesis
     author: Trevor Meers
     year: 2007
-    title: Role of plant functional traits in determining the response of vegetation to land use change on the Delatite Peninsula, Victoria.
+    title: Role of plant functional traits in determining the response of vegetation
+      to land use change on the Delatite Peninsula, Victoria.
     institution: University of Melbourne
     type: PhD
   secondary:
@@ -17,7 +18,7 @@ source:
       sclerophyllous flora?
     volume: '58'
     number: '4'
-    pages: '257--270'
+    pages: 257--270
     doi: 10.1071/bt10013
   secondary_02:
     key: Meers_2010_2
@@ -84,10 +85,10 @@ sites:
   Delatite Peninsula:
     latitude (deg): -37.133
     longitude (deg): 145.967
-    MAP (mm): 850
+    precipitation, MAP (mm): 850
     description: mosaic of native forests, abandoned farmland, Pinus radiata plantations
       and recently harvested plantations
-    soils: silty loams or light clays developed on Late Silurian to Early Devonian
+    soil type: silty loams or light clays developed on Late Silurian to Early Devonian
       sandstones, siltstones and shales
 contexts: .na
 config:
@@ -437,4 +438,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Metcalfe_2009/metadata.yml
+++ b/data/Metcalfe_2009/metadata.yml
@@ -49,7 +49,7 @@ dataset:
 sites:
   Harney's:
     site code: 1.1
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.016
     longitude (deg): 145.9509
     elevation (m): 5.0
@@ -67,14 +67,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 2.35
     soil exchangeable K (cmol/kg, meq/100g): 1.54
     soil cation exchange capacity (cmol/kg): 7.56
-    data sampled: Feb-05
+    date sampled: Feb-05
     species count (per plot): 39.0
     tallest tree measured in plot (m): 24.0
     no. stems >10 cm/0.1 ha: 89.0
     fragment size: '>100 ha'
   Henry's:
     site code: 2.2
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.02929
     longitude (deg): 145.86262
     elevation (m): 25.0
@@ -92,14 +92,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 1.8
     soil exchangeable K (cmol/kg, meq/100g): 0.28
     soil cation exchange capacity (cmol/kg): 5.75
-    data sampled: Sep-05
+    date sampled: Sep-05
     species count (per plot): 85.0
     tallest tree measured in plot (m): 35.0
     no. stems >10 cm/0.1 ha: 108.0
     fragment size: 90 ha
   Mackay's:
     site code: 3.1
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -17.9531
     longitude (deg): 145.80872
     elevation (m): 15.0
@@ -117,14 +117,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 3.0
     soil exchangeable K (cmol/kg, meq/100g): 0.43
     soil cation exchange capacity (cmol/kg): 13.12
-    data sampled: Jul-06
+    date sampled: Jul-06
     species count (per plot): 125.0
     tallest tree measured in plot (m): 40.0
     no. stems >10 cm/0.1 ha: 53.0
     fragment size: 11 ha
   McDonald's:
     site code: 1.2
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.00741
     longitude (deg): 145.99097
     elevation (m): 10.0
@@ -142,14 +142,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 3.0
     soil exchangeable K (cmol/kg, meq/100g): 0.55
     soil cation exchange capacity (cmol/kg): 10.98
-    data sampled: May-05
+    date sampled: May-05
     species count (per plot): 100.0
     tallest tree measured in plot (m): 37.0
     no. stems >10 cm/0.1 ha: 135.0
     fragment size: 6 ha
   Shane's:
     site code: 3.2
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.0165
     longitude (deg): 145.96706
     elevation (m): 5.0
@@ -167,14 +167,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.24
     soil exchangeable K (cmol/kg, meq/100g): 0.05
     soil cation exchange capacity (cmol/kg): 0.5
-    data sampled: Feb-05
+    date sampled: Feb-05
     species count (per plot): 69.0
     tallest tree measured in plot (m): 28.0
     no. stems >10 cm/0.1 ha: 187.0
     fragment size: 2.5 ha
   Siam:
     site code: 4.2
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -17.97553
     longitude (deg): 145.85248
     elevation (m): 15.0
@@ -192,14 +192,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.68
     soil exchangeable K (cmol/kg, meq/100g): 0.2
     soil cation exchange capacity (cmol/kg): 1.25
-    data sampled: May-05
+    date sampled: May-05
     species count (per plot): 73.0
     tallest tree measured in plot (m): 16.0
     no. stems >10 cm/0.1 ha: 61.0
     fragment size: <1 ha
   Weiss:
     site code: 5.2
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.00518
     longitude (deg): 145.92534
     elevation (m): 10.0
@@ -217,14 +217,14 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 3.0
     soil exchangeable K (cmol/kg, meq/100g): 0.55
     soil cation exchange capacity (cmol/kg): 10.98
-    data sampled: May-05
+    date sampled: May-05
     species count (per plot): 83.0
     tallest tree measured in plot (m): 15.0
     no. stems >10 cm/0.1 ha: 141.0
     fragment size: <1 ha
   Zonta:
     site code: 2.1
-    Geodetic datum: GDA94
+    geodetic datum: GDA94
     latitude (deg): -18.02467
     longitude (deg): 145.96619
     elevation (m): 5.0
@@ -242,7 +242,7 @@ sites:
     soil exchangeable Mg (cmol/kg, meq/100g): 0.24
     soil exchangeable K (cmol/kg, meq/100g): 0.05
     soil cation exchange capacity (cmol/kg): 0.5
-    data sampled: Feb-05
+    date sampled: Feb-05
     species count (per plot): 64.0
     tallest tree measured in plot (m): 35.0
     no. stems >10 cm/0.1 ha: 188.0

--- a/data/Metcalfe_2009/metadata.yml
+++ b/data/Metcalfe_2009/metadata.yml
@@ -48,201 +48,201 @@ dataset:
     data shows that most species are present on more than one site.
 sites:
   Harney's:
-    Site Numbers: 1.1
-    GPS Coordinate datum: GDA94
+    site code: 1.1
+    Geodetic datum: GDA94
     latitude (deg): -18.016
     longitude (deg): 145.9509
     elevation (m): 5.0
-    Landscape: Tully-Murray
-    land use intensity: 1.0
+    locality: Tully-Murray
+    land use (intensity): 1.0
     land use: Natural
     description: lightly-logged continuous rain forest
-    Distance to Forest: 0.0
-    Soil series: Timara
+    distance to forest: 0.0
+    soil series: Timara
     soil type: alluvium
-    carbon (%): 5.14
-    total nitrogen (%): 0.3
-    extractable P (ppm): 80.0
-    exchangeable Ca (m.e./100 g soil): 3.67
-    exchangeable Mg (m.e./100 g soil): 2.35
-    exchangeable K (m.e./100 g soil): 1.54
-    SumEC: 7.56
-    Date sampled: Feb-05
+    soil C, total (%): 5.14
+    soil N, total (%): 0.3
+    soil P, extractable (mg/kg): 80.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.67
+    soil exchangeable Mg (cmol/kg, meq/100g): 2.35
+    soil exchangeable K (cmol/kg, meq/100g): 1.54
+    soil cation exchange capacity (cmol/kg): 7.56
+    data sampled: Feb-05
     species count (per plot): 39.0
     tallest tree measured in plot (m): 24.0
     no. stems >10 cm/0.1 ha: 89.0
     fragment size: '>100 ha'
   Henry's:
-    Site Numbers: 2.2
-    GPS Coordinate datum: GDA94
+    site code: 2.2
+    Geodetic datum: GDA94
     latitude (deg): -18.02929
     longitude (deg): 145.86262
     elevation (m): 25.0
-    Landscape: Tully-Murray
-    land use intensity: 1.0
+    locality: Tully-Murray
+    land use (intensity): 1.0
     land use: Natural
     description: lightly-logged rain forest fragment
-    Distance to Forest: 0.0
-    Soil series: Coom
+    distance to forest: 0.0
+    soil series: Coom
     soil type: alluvium
-    carbon (%): 2.71
-    total nitrogen (%): 0.19
-    extractable P (ppm): 13.0
-    exchangeable Ca (m.e./100 g soil): 3.43
-    exchangeable Mg (m.e./100 g soil): 1.8
-    exchangeable K (m.e./100 g soil): 0.28
-    SumEC: 5.75
-    Date sampled: Sep-05
+    soil C, total (%): 2.71
+    soil N, total (%): 0.19
+    soil P, extractable (mg/kg): 13.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.43
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.8
+    soil exchangeable K (cmol/kg, meq/100g): 0.28
+    soil cation exchange capacity (cmol/kg): 5.75
+    data sampled: Sep-05
     species count (per plot): 85.0
     tallest tree measured in plot (m): 35.0
     no. stems >10 cm/0.1 ha: 108.0
     fragment size: 90 ha
   Mackay's:
-    Site Numbers: 3.1
-    GPS Coordinate datum: GDA94
+    site code: 3.1
+    Geodetic datum: GDA94
     latitude (deg): -17.9531
     longitude (deg): 145.80872
     elevation (m): 15.0
-    Landscape: Tully-Murray
-    land use intensity: 2.0
+    locality: Tully-Murray
+    land use (intensity): 2.0
     land use: Natural
     description: disturbed riparian rain forest fragment
-    Distance to Forest: 0.0
-    Soil series: Innisfail
+    distance to forest: 0.0
+    soil series: Innisfail
     soil type: alluvium
-    carbon (%): 4.06
-    total nitrogen (%): 0.3
-    extractable P (ppm): 47.0
-    exchangeable Ca (m.e./100 g soil): 9.6
-    exchangeable Mg (m.e./100 g soil): 3.0
-    exchangeable K (m.e./100 g soil): 0.43
-    SumEC: 13.12
-    Date sampled: Jul-06
+    soil C, total (%): 4.06
+    soil N, total (%): 0.3
+    soil P, extractable (mg/kg): 47.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 9.6
+    soil exchangeable Mg (cmol/kg, meq/100g): 3.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.43
+    soil cation exchange capacity (cmol/kg): 13.12
+    data sampled: Jul-06
     species count (per plot): 125.0
     tallest tree measured in plot (m): 40.0
     no. stems >10 cm/0.1 ha: 53.0
     fragment size: 11 ha
   McDonald's:
-    Site Numbers: 1.2
-    GPS Coordinate datum: GDA94
+    site code: 1.2
+    Geodetic datum: GDA94
     latitude (deg): -18.00741
     longitude (deg): 145.99097
     elevation (m): 10.0
-    Landscape: Tully-Murray
-    land use intensity: 1.0
+    locality: Tully-Murray
+    land use (intensity): 1.0
     land use: Natural
     description: lightly-logged riparian rain forest fragment
-    Distance to Forest: 0.0
-    Soil series: Tully
+    distance to forest: 0.0
+    soil series: Tully
     soil type: alluvium
-    carbon (%): 3.98
-    total nitrogen (%): 0.37
-    extractable P (ppm): 22.0
-    exchangeable Ca (m.e./100 g soil): 7.4
-    exchangeable Mg (m.e./100 g soil): 3.0
-    exchangeable K (m.e./100 g soil): 0.55
-    SumEC: 10.98
-    Date sampled: May-05
+    soil C, total (%): 3.98
+    soil N, total (%): 0.37
+    soil P, extractable (mg/kg): 22.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 7.4
+    soil exchangeable Mg (cmol/kg, meq/100g): 3.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.55
+    soil cation exchange capacity (cmol/kg): 10.98
+    data sampled: May-05
     species count (per plot): 100.0
     tallest tree measured in plot (m): 37.0
     no. stems >10 cm/0.1 ha: 135.0
     fragment size: 6 ha
   Shane's:
-    Site Numbers: 3.2
-    GPS Coordinate datum: GDA94
+    site code: 3.2
+    Geodetic datum: GDA94
     latitude (deg): -18.0165
     longitude (deg): 145.96706
     elevation (m): 5.0
-    Landscape: Tully-Murray
-    land use intensity: 2.0
+    locality: Tully-Murray
+    land use (intensity): 2.0
     land use: Natural
     description: heavily disturbed rain forest fragment
-    Distance to Forest: 0.0
-    Soil series: Bulgun
+    distance to forest: 0.0
+    soil series: Bulgun
     soil type: organic
-    carbon (%): 4.25
-    total nitrogen (%): 0.19
-    extractable P (ppm): 14.0
-    exchangeable Ca (m.e./100 g soil): 0.13
-    exchangeable Mg (m.e./100 g soil): 0.24
-    exchangeable K (m.e./100 g soil): 0.05
-    SumEC: 0.5
-    Date sampled: Feb-05
+    soil C, total (%): 4.25
+    soil N, total (%): 0.19
+    soil P, extractable (mg/kg): 14.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.13
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.24
+    soil exchangeable K (cmol/kg, meq/100g): 0.05
+    soil cation exchange capacity (cmol/kg): 0.5
+    data sampled: Feb-05
     species count (per plot): 69.0
     tallest tree measured in plot (m): 28.0
     no. stems >10 cm/0.1 ha: 187.0
     fragment size: 2.5 ha
   Siam:
-    Site Numbers: 4.2
-    GPS Coordinate datum: GDA94
+    site code: 4.2
+    Geodetic datum: GDA94
     latitude (deg): -17.97553
     longitude (deg): 145.85248
     elevation (m): 15.0
-    Landscape: Tully-Murray
-    land use intensity: 3.0
+    locality: Tully-Murray
+    land use (intensity): 3.0
     land use: Semi-natural
     description: 10 year old riparian revegetation
-    Distance to Forest: 2500.0
-    Soil series: Liverpool
+    distance to forest: 2500.0
+    soil series: Liverpool
     soil type: alluvium
-    carbon (%): 1.27
-    total nitrogen (%): 0.11
-    extractable P (ppm): 19.0
-    exchangeable Ca (m.e./100 g soil): 0.35
-    exchangeable Mg (m.e./100 g soil): 0.68
-    exchangeable K (m.e./100 g soil): 0.2
-    SumEC: 1.25
-    Date sampled: May-05
+    soil C, total (%): 1.27
+    soil N, total (%): 0.11
+    soil P, extractable (mg/kg): 19.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.35
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.68
+    soil exchangeable K (cmol/kg, meq/100g): 0.2
+    soil cation exchange capacity (cmol/kg): 1.25
+    data sampled: May-05
     species count (per plot): 73.0
     tallest tree measured in plot (m): 16.0
     no. stems >10 cm/0.1 ha: 61.0
     fragment size: <1 ha
   Weiss:
-    Site Numbers: 5.2
-    GPS Coordinate datum: GDA94
+    site code: 5.2
+    Geodetic datum: GDA94
     latitude (deg): -18.00518
     longitude (deg): 145.92534
     elevation (m): 10.0
-    Landscape: Tully-Murray
-    land use intensity: 3.0
+    locality: Tully-Murray
+    land use (intensity): 3.0
     land use: Semi-natural
     description: 10 year old riparian revegetation
-    Distance to Forest: 3125.0
-    Soil series: Tully
+    distance to forest: 3125.0
+    soil series: Tully
     soil type: alluvium
-    carbon (%): 3.98
-    total nitrogen (%): 0.37
-    extractable P (ppm): 22.0
-    exchangeable Ca (m.e./100 g soil): 7.4
-    exchangeable Mg (m.e./100 g soil): 3.0
-    exchangeable K (m.e./100 g soil): 0.55
-    SumEC: 10.98
-    Date sampled: May-05
+    soil C, total (%): 3.98
+    soil N, total (%): 0.37
+    soil P, extractable (mg/kg): 22.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 7.4
+    soil exchangeable Mg (cmol/kg, meq/100g): 3.0
+    soil exchangeable K (cmol/kg, meq/100g): 0.55
+    soil cation exchange capacity (cmol/kg): 10.98
+    data sampled: May-05
     species count (per plot): 83.0
     tallest tree measured in plot (m): 15.0
     no. stems >10 cm/0.1 ha: 141.0
     fragment size: <1 ha
   Zonta:
-    Site Numbers: 2.1
-    GPS Coordinate datum: GDA94
+    site code: 2.1
+    Geodetic datum: GDA94
     latitude (deg): -18.02467
     longitude (deg): 145.96619
-    Altitude: 5.0
-    Landscape: Tully-Murray
-    land use intensity: 1.0
+    elevation (m): 5.0
+    locality: Tully-Murray
+    land use (intensity): 1.0
     land use: Natural
     description: lightly-logged continuous rain forest
-    Distance to Forest: 0.0
-    Soil series: Bulgun
+    distance to forest: 0.0
+    soil series: Bulgun
     soil type: organic
-    carbon (%): 4.25
-    total nitrogen (%): 0.19
-    extractable P (ppm): 14.0
-    exchangeable Ca (m.e./100 g soil): 0.13
-    exchangeable Mg (m.e./100 g soil): 0.24
-    exchangeable K (m.e./100 g soil): 0.05
-    SumEC: 0.5
-    Date sampled: Feb-05
+    soil C, total (%): 4.25
+    soil N, total (%): 0.19
+    soil P, extractable (mg/kg): 14.0
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.13
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.24
+    soil exchangeable K (cmol/kg, meq/100g): 0.05
+    soil cation exchange capacity (cmol/kg): 0.5
+    data sampled: Feb-05
     species count (per plot): 64.0
     tallest tree measured in plot (m): 35.0
     no. stems >10 cm/0.1 ha: 188.0
@@ -510,4 +510,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Milberg_1997/metadata.yml
+++ b/data/Milberg_1997/metadata.yml
@@ -43,12 +43,12 @@ sites:
     latitude (deg): -29.817
     longitude (deg): 115.27
     description: scrub-heath
-    soil: sandy soil
+    soil type: sandy soil
   Watheroo National Park:
     latitude (deg): -30.25
     longitude (deg): 115.88
     description: eucalypt woodland
-    soil: loamy soil
+    soil type: loamy soil
 contexts: .na
 config:
   data_is_long_format: no
@@ -165,4 +165,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Mokany_2008/metadata.yml
+++ b/data/Mokany_2008/metadata.yml
@@ -57,12 +57,12 @@ sites:
   field site north of Canberra:
     latitude (deg): -35.1167
     longitude (deg): 149.1167
-    MAP (mm): 622
+    precipitation, MAP (mm): 622
     description: native grassland
   Australian National University glasshouse:
     latitude (deg): -35.283
     longitude (deg): 149.1167
-    MAP (mm): 622
+    precipitation, MAP (mm): 622
     description: ANU glasshouses
 contexts: .na
 config:
@@ -425,4 +425,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Moles_2000/metadata.yml
+++ b/data/Moles_2000/metadata.yml
@@ -48,21 +48,21 @@ sites:
   heath:
     longitude (deg): 151.233056
     latitude (deg): -33.661111
-    soil_total_N (%): 0.05
+    soil N, total (%): 0.05
     description: The site 'heath' was on a sandstone ridge top. Terrace and heath
       sites had low levels of both nutrients (terrace; 144 ug g-1 total phosphorus;
       0.08% nitrogen; heath; 79 ug g-1 total phosphorus; 0.05% nitrogen).
   terrace:
     longitude (deg): 151.245833
     latitude (deg): -33.66388
-    soil_total_N (%): 0.08
+    soil N, total (%): 0.08
     description: The site 'terrace' was near a stream in a sandstone gully. Terrace
       and heath sites had low levels of both nutrients (terrace; 144 ug g-1 total
       phosphorus; 0.08% nitrogen; heath; 79 ug g-1 total phosphorus; 0.05% nitrogen).
   diatreme:
     longitude (deg): 151.2917
     latitude (deg): -33.57775
-    soil_total_N (%): 0.41
+    soil N, total (%): 0.41
     description: The first site (diatreme) was located on volcanic soils. The diatreme
       site had the highest levels of phosphorus and nitrogen (646 ug g-1 total phosphorus;
       0.41% nitrogen)
@@ -138,4 +138,3 @@ taxonomic_updates:
   reason: Align to species by E. Wenk (2020-05-13)
 exclude_observations: .na
 questions: .na
-

--- a/data/Moles_2003/metadata.yml
+++ b/data/Moles_2003/metadata.yml
@@ -43,7 +43,7 @@ dataset:
   notes:
 sites:
   Sturt National Park:
-    rainfall (mm): 230
+    precipitation, MAP (mm): 230
     latitude (deg): -29.0976
     longitude (deg): 141.4126
     description: Sturt National Park receives an average of 230 mm rain per year (Australian
@@ -142,4 +142,3 @@ taxonomic_updates:
   reason: Align to accepted hybrid species on APC list (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Moore_2019/metadata.yml
+++ b/data/Moore_2019/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     year: 2019
     author: Ben D. Moore and Jane L. DeGabriel
-    title: 'Unpublished data: Leaf traits of the Eucalyptus series Siderophloiae, Western Sydney University'
+    title: 'Unpublished data: Leaf traits of the Eucalyptus series Siderophloiae,
+      Western Sydney University'
     doi: .na
 people:
 - name: Ben D. Moore
@@ -71,717 +72,717 @@ sites:
   Blackbraes:
     longitude (deg): 144.2263333
     latitude (deg): -19.5512333
-    soil_TOC: 2.2479593
-    soil_pH: 5.76
-    soil_conductivity: 0.029892
-    soil_N: 1.6159879
-    soil_P: 0.2621816
-    soil_K: 0.2542852
-    soil_Sand: 44.5406593
-    soil_Silt: 28.1043956
-    soil_Clay: 27.3549451
-    site_elevation: 896.0
-    site_name: site_53
+    soil organic content (%): 2.2479593
+    soil pH (H2O): 5.76
+    soil conductivity (dS/m): 0.029892
+    soil N, total (%): 1.6159879
+    soil P, Olsen (mg/kg): 0.2621816
+    soil K: 0.2542852
+    soil sand (%): 44.5406593
+    soil silt (%): 28.1043956
+    soil clay (%): 27.3549451
+    elevation (m): 896.0
+    site code: site_53
   Blackbraes NP_1:
     longitude (deg): 144.18488
     latitude (deg): -19.52276
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 927.0
-    site_name: site_28
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 927.0
+    site code: site_28
   Blackbraes NP_2:
     longitude (deg): 144.15107
     latitude (deg): -19.50498
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 868.0
-    site_name: site_29
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 868.0
+    site code: site_29
   Blackbraes NP_4:
     longitude (deg): 143.95165
     latitude (deg): -19.5444
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 942.0
-    site_name: site_36
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 942.0
+    site code: site_36
   Clothespeg_54:
     longitude (deg): 144.25575
     latitude (deg): -19.7715333
-    soil_TOC: 2.3109601
-    soil_pH: 5.47
-    soil_conductivity: 0.012402
-    soil_N: 1.465597
-    soil_P: 0.0214204
-    soil_K: 0.0366061
-    soil_Sand: 80.9901227
-    soil_Silt: 8.91088
-    soil_Clay: 10.0989973
-    site_elevation: 936.0
-    site_name: site_54
+    soil organic content (%): 2.3109601
+    soil pH (H2O): 5.47
+    soil conductivity (dS/m): 0.012402
+    soil N, total (%): 1.465597
+    soil P, Olsen (mg/kg): 0.0214204
+    soil K: 0.0366061
+    soil sand (%): 80.9901227
+    soil silt (%): 8.91088
+    soil clay (%): 10.0989973
+    elevation (m): 936.0
+    site code: site_54
   Clothespeg_55:
     longitude (deg): 144.25575
     latitude (deg): -19.7715333
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 936.0
-    site_name: site_55
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 936.0
+    site code: site_55
   Hidden Valley_1:
     longitude (deg): 146.01037
     latitude (deg): -18.97201
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 660.0
-    site_name: site_21
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 660.0
+    site code: site_21
   Hillgrove:
     longitude (deg): 145.8062778
     latitude (deg): -19.6864167
-    soil_TOC: 1.0166263
-    soil_pH: 5.64
-    soil_conductivity: 0.026818
-    soil_N: 0.628701
-    soil_P: 0.0331745
-    soil_K: 0.2943952
-    soil_Sand: 42.5007668
-    soil_Silt: 15.0324793
-    soil_Clay: 42.4667539
-    site_elevation: 323.0
-    site_name: site_3
+    soil organic content (%): 1.0166263
+    soil pH (H2O): 5.64
+    soil conductivity (dS/m): 0.026818
+    soil N, total (%): 0.628701
+    soil P, Olsen (mg/kg): 0.0331745
+    soil K: 0.2943952
+    soil sand (%): 42.5007668
+    soil silt (%): 15.0324793
+    soil clay (%): 42.4667539
+    elevation (m): 323.0
+    site code: site_3
   Homestead:
     longitude (deg): 145.5257222
     latitude (deg): -20.4469722
-    soil_TOC: 0.9867202
-    soil_pH: 5.35
-    soil_conductivity: 0.009858
-    soil_N: 0.2701539
-    soil_P: 0.0058628
-    soil_K: 0.1538306
-    soil_Sand: 63.1442489
-    soil_Silt: 23.7779039
-    soil_Clay: 13.0778472
-    site_elevation: 383.0
-    site_name: site_7
+    soil organic content (%): 0.9867202
+    soil pH (H2O): 5.35
+    soil conductivity (dS/m): 0.009858
+    soil N, total (%): 0.2701539
+    soil P, Olsen (mg/kg): 0.0058628
+    soil K: 0.1538306
+    soil sand (%): 63.1442489
+    soil silt (%): 23.7779039
+    soil clay (%): 13.0778472
+    elevation (m): 383.0
+    site code: site_7
   Hughenden:
     longitude (deg): 144.3597667
     latitude (deg): -20.7091167
-    soil_TOC: 1.1952952
-    soil_pH: 6.45
-    soil_conductivity: 0.038902
-    soil_N: 0.7228938
-    soil_P: 0.0212144
-    soil_K: 0.1585078
-    soil_Sand: 80.9730866
-    soil_Silt: 7.9278806
-    soil_Clay: 11.0990328
-    site_elevation: 345.0
-    site_name: site_56
+    soil organic content (%): 1.1952952
+    soil pH (H2O): 6.45
+    soil conductivity (dS/m): 0.038902
+    soil N, total (%): 0.7228938
+    soil P, Olsen (mg/kg): 0.0212144
+    soil K: 0.1585078
+    soil sand (%): 80.9730866
+    soil silt (%): 7.9278806
+    soil clay (%): 11.0990328
+    elevation (m): 345.0
+    site code: site_56
   James Cook University_1:
     longitude (deg): 146.76488
     latitude (deg): -19.32179
-    soil_TOC: 2.0198216
-    soil_pH: 5.76
-    soil_conductivity: 0.026394
-    soil_N: 0.9697196
-    soil_P: 0.0142826
-    soil_K: 0.2623082
-    soil_Sand: 60.4421418
-    soil_Silt: 26.5687107
-    soil_Clay: 12.9891475
-    site_elevation: 21.0
-    site_name: site_23
+    soil organic content (%): 2.0198216
+    soil pH (H2O): 5.76
+    soil conductivity (dS/m): 0.026394
+    soil N, total (%): 0.9697196
+    soil P, Olsen (mg/kg): 0.0142826
+    soil K: 0.2623082
+    soil sand (%): 60.4421418
+    soil silt (%): 26.5687107
+    soil clay (%): 12.9891475
+    elevation (m): 21.0
+    site code: site_23
   Juntala tall forest:
     longitude (deg): 144.0269167
     latitude (deg): -19.5912167
-    soil_TOC: 2.1442649
-    soil_pH: 5.32
-    soil_conductivity: 0.015794
-    soil_N: 0.7270455
-    soil_P: 0.0116408
-    soil_K: 0.0611179
-    soil_Sand: 72.1504438
-    soil_Silt: 15.8011666
-    soil_Clay: 12.0483896
-    site_elevation: 1057.0
-    site_name: site_52
+    soil organic content (%): 2.1442649
+    soil pH (H2O): 5.32
+    soil conductivity (dS/m): 0.015794
+    soil N, total (%): 0.7270455
+    soil P, Olsen (mg/kg): 0.0116408
+    soil K: 0.0611179
+    soil sand (%): 72.1504438
+    soil silt (%): 15.8011666
+    soil clay (%): 12.0483896
+    elevation (m): 1057.0
+    site code: site_52
   Juntala_50:
     longitude (deg): 143.9784167
     latitude (deg): -19.5570667
-    soil_TOC: 3.4143193
-    soil_pH: 4.2
-    soil_conductivity: 0.01325
-    soil_N: 1.6482459
-    soil_P: 0.0164969
-    soil_K: 0.1342918
-    soil_Sand: 40.4106304
-    soil_Silt: 19.160569
-    soil_Clay: 40.4288006
-    site_elevation: 1034.0
-    site_name: site_50
+    soil organic content (%): 3.4143193
+    soil pH (H2O): 4.2
+    soil conductivity (dS/m): 0.01325
+    soil N, total (%): 1.6482459
+    soil P, Olsen (mg/kg): 0.0164969
+    soil K: 0.1342918
+    soil sand (%): 40.4106304
+    soil silt (%): 19.160569
+    soil clay (%): 40.4288006
+    elevation (m): 1034.0
+    site code: site_50
   Juntala_51:
     longitude (deg): 143.9784167
     latitude (deg): -19.5570667
-    soil_TOC: 2.8191467
-    soil_pH: 4.24
-    soil_conductivity: 0.014204
-    soil_N: 1.380372
-    soil_P: 0.0218938
-    soil_K: 0.2775139
-    soil_Sand: 45.0975069
-    soil_Silt: 20.1565097
-    soil_Clay: 34.7459834
-    site_elevation: 1034.0
-    site_name: site_51
+    soil organic content (%): 2.8191467
+    soil pH (H2O): 4.24
+    soil conductivity (dS/m): 0.014204
+    soil N, total (%): 1.380372
+    soil P, Olsen (mg/kg): 0.0218938
+    soil K: 0.2775139
+    soil sand (%): 45.0975069
+    soil silt (%): 20.1565097
+    soil clay (%): 34.7459834
+    elevation (m): 1034.0
+    site code: site_51
   Mornington:
     longitude (deg): 125.8517
     latitude (deg): -16.77326
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 303.0
-    site_name: site_26
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 303.0
+    site code: site_26
   Mount Fox_1:
     longitude (deg): 145.79003
     latitude (deg): -18.82321
-    soil_TOC: 3.8500474
-    soil_pH: 5.46
-    soil_conductivity: 0.091054
-    soil_N: 1.8964049
-    soil_P: 0.0438879
-    soil_K: 0.0735119
-    soil_Sand: 40.3449805
-    soil_Silt: 17.545594
-    soil_Clay: 42.1094255
-    site_elevation: 623.0
-    site_name: site_22
+    soil organic content (%): 3.8500474
+    soil pH (H2O): 5.46
+    soil conductivity (dS/m): 0.091054
+    soil N, total (%): 1.8964049
+    soil P, Olsen (mg/kg): 0.0438879
+    soil K: 0.0735119
+    soil sand (%): 40.3449805
+    soil silt (%): 17.545594
+    soil clay (%): 42.1094255
+    elevation (m): 623.0
+    site code: site_22
   Mount Stuart:
     longitude (deg): 146.78059
     latitude (deg): -19.3442
-    soil_TOC: 2.6090765
-    soil_pH: 5.16
-    soil_conductivity: 0.024592
-    soil_N: 1.6422626
-    soil_P: 0.0222967
-    soil_K: 0.1657347
-    soil_Sand: 55.8276784
-    soil_Silt: 25.4088576
-    soil_Clay: 18.763464
-    site_elevation: 563.0
-    site_name: site_24
+    soil organic content (%): 2.6090765
+    soil pH (H2O): 5.16
+    soil conductivity (dS/m): 0.024592
+    soil N, total (%): 1.6422626
+    soil P, Olsen (mg/kg): 0.0222967
+    soil K: 0.1657347
+    soil sand (%): 55.8276784
+    soil silt (%): 25.4088576
+    soil clay (%): 18.763464
+    elevation (m): 563.0
+    site code: site_24
   outside Darwin:
     longitude (deg): 131.13
     latitude (deg): -13.48
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: .na.real
-    site_name: site_25
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): .na.real
+    site code: site_25
   Prairie:
     longitude (deg): 144.6838333
     latitude (deg): -20.8530278
-    soil_TOC: 1.1068669
-    soil_pH: 5.82
-    soil_conductivity: 0.0318
-    soil_N: 0.4035406
-    soil_P: 0.0092726
-    soil_K: 0.196892
-    soil_Sand: 71.1248595
-    soil_Silt: 13.8442454
-    soil_Clay: 15.030895
-    site_elevation: 437.0
-    site_name: site_4
+    soil organic content (%): 1.1068669
+    soil pH (H2O): 5.82
+    soil conductivity (dS/m): 0.0318
+    soil N, total (%): 0.4035406
+    soil P, Olsen (mg/kg): 0.0092726
+    soil K: 0.196892
+    soil sand (%): 71.1248595
+    soil silt (%): 13.8442454
+    soil clay (%): 15.030895
+    elevation (m): 437.0
+    site code: site_4
   site_10:
     longitude (deg): 153.0539
     latitude (deg): -27.54899
-    soil_TOC: 5.8200159
-    soil_pH: 4.44
-    soil_conductivity: 0.069218
-    soil_N: 2.1100504
-    soil_P: 0.0186725
-    soil_K: 1.6561139
-    soil_Sand: 53.9722839
-    soil_Silt: 27.3045774
-    soil_Clay: 18.7231388
-    site_elevation: 91.0
-    site_name: site_10
+    soil organic content (%): 5.8200159
+    soil pH (H2O): 4.44
+    soil conductivity (dS/m): 0.069218
+    soil N, total (%): 2.1100504
+    soil P, Olsen (mg/kg): 0.0186725
+    soil K: 1.6561139
+    soil sand (%): 53.9722839
+    soil silt (%): 27.3045774
+    soil clay (%): 18.7231388
+    elevation (m): 91.0
+    site code: site_10
   site_11:
     longitude (deg): 152.14576
     latitude (deg): -27.48962
-    soil_TOC: 5.6367908
-    soil_pH: 4.78
-    soil_conductivity: 0.037206
-    soil_N: 1.6857483
-    soil_P: 0.008788
-    soil_K: 0.0808149
-    soil_Sand: 65.8787461
-    soil_Silt: 18.4177223
-    soil_Clay: 15.7035316
-    site_elevation: 407.0
-    site_name: site_11
+    soil organic content (%): 5.6367908
+    soil pH (H2O): 4.78
+    soil conductivity (dS/m): 0.037206
+    soil N, total (%): 1.6857483
+    soil P, Olsen (mg/kg): 0.008788
+    soil K: 0.0808149
+    soil sand (%): 65.8787461
+    soil silt (%): 18.4177223
+    soil clay (%): 15.7035316
+    elevation (m): 407.0
+    site code: site_11
   site_12:
     longitude (deg): 151.44364
     latitude (deg): -28.14618
-    soil_TOC: 4.5671843
-    soil_pH: 4.92
-    soil_conductivity: 0.069536
-    soil_N: 1.4211315
-    soil_P: 0.0160562
-    soil_K: 0.2084037
-    soil_Sand: 63.552275
-    soil_Silt: 21.5551062
-    soil_Clay: 14.8926188
-    site_elevation: 518.0
-    site_name: site_12
+    soil organic content (%): 4.5671843
+    soil pH (H2O): 4.92
+    soil conductivity (dS/m): 0.069536
+    soil N, total (%): 1.4211315
+    soil P, Olsen (mg/kg): 0.0160562
+    soil K: 0.2084037
+    soil sand (%): 63.552275
+    soil silt (%): 21.5551062
+    soil clay (%): 14.8926188
+    elevation (m): 518.0
+    site code: site_12
   site_13:
     longitude (deg): 151.51673
     latitude (deg): -28.12802
-    soil_TOC: 3.8557159
-    soil_pH: 4.14
-    soil_conductivity: 0.050986
-    soil_N: 1.1437839
-    soil_P: 0.0096308
-    soil_K: 0.0949016
-    soil_Sand: 82.0406054
-    soil_Silt: 6.9074595
-    soil_Clay: 11.0519352
-    site_elevation: 511.0
-    site_name: site_13
+    soil organic content (%): 3.8557159
+    soil pH (H2O): 4.14
+    soil conductivity (dS/m): 0.050986
+    soil N, total (%): 1.1437839
+    soil P, Olsen (mg/kg): 0.0096308
+    soil K: 0.0949016
+    soil sand (%): 82.0406054
+    soil silt (%): 6.9074595
+    soil clay (%): 11.0519352
+    elevation (m): 511.0
+    site code: site_13
   site_14:
     longitude (deg): 151.51659
     latitude (deg): -28.12787
-    soil_TOC: 5.3540723
-    soil_pH: 4.38
-    soil_conductivity: 0.061268
-    soil_N: 1.64283
-    soil_P: 0.011904
-    soil_K: 0.1348067
-    soil_Sand: 79.1972765
-    soil_Silt: 7.8500844
-    soil_Clay: 12.9526392
-    site_elevation: 511.0
-    site_name: site_14
+    soil organic content (%): 5.3540723
+    soil pH (H2O): 4.38
+    soil conductivity (dS/m): 0.061268
+    soil N, total (%): 1.64283
+    soil P, Olsen (mg/kg): 0.011904
+    soil K: 0.1348067
+    soil sand (%): 79.1972765
+    soil silt (%): 7.8500844
+    soil clay (%): 12.9526392
+    elevation (m): 511.0
+    site code: site_14
   site_15:
     longitude (deg): 151.51717
     latitude (deg): -28.12798
-    soil_TOC: 3.9075641
-    soil_pH: 4.69
-    soil_conductivity: 0.064236
-    soil_N: 1.2539659
-    soil_P: 0.0113956
-    soil_K: 0.0644549
-    soil_Sand: 79.092638
-    soil_Silt: 7.8895706
-    soil_Clay: 13.0177914
-    site_elevation: 511.0
-    site_name: site_15
+    soil organic content (%): 3.9075641
+    soil pH (H2O): 4.69
+    soil conductivity (dS/m): 0.064236
+    soil N, total (%): 1.2539659
+    soil P, Olsen (mg/kg): 0.0113956
+    soil K: 0.0644549
+    soil sand (%): 79.092638
+    soil silt (%): 7.8895706
+    soil clay (%): 13.0177914
+    elevation (m): 511.0
+    site code: site_15
   site_16:
     longitude (deg): 151.65083
     latitude (deg): -27.69067
-    soil_TOC: 4.6049163
-    soil_pH: 5.67
-    soil_conductivity: 0.091584
-    soil_N: 0.330479
-    soil_P: 0.1604762
-    soil_K: 0.2437746
-    soil_Sand: 38.8764885
-    soil_Silt: 28.1243151
-    soil_Clay: 32.9991964
-    site_elevation: 559.0
-    site_name: site_16
+    soil organic content (%): 4.6049163
+    soil pH (H2O): 5.67
+    soil conductivity (dS/m): 0.091584
+    soil N, total (%): 0.330479
+    soil P, Olsen (mg/kg): 0.1604762
+    soil K: 0.2437746
+    soil sand (%): 38.8764885
+    soil silt (%): 28.1243151
+    soil clay (%): 32.9991964
+    elevation (m): 559.0
+    site code: site_16
   site_30:
     longitude (deg): 153.2039139
     latitude (deg): -27.6321222
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 96.0
-    site_name: site_30
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 96.0
+    site code: site_30
   site_31:
     longitude (deg): 151.97265
     latitude (deg): -27.67652
-    soil_TOC: 5.5809332
-    soil_pH: 5.78
-    soil_conductivity: 0.114692
-    soil_N: 0.4046885
-    soil_P: 0.1508099
-    soil_K: 0.1649027
-    soil_Sand: 54.0368804
-    soil_Silt: 22.4210339
-    soil_Clay: 23.5420856
-    site_elevation: 573.0
-    site_name: site_31
+    soil organic content (%): 5.5809332
+    soil pH (H2O): 5.78
+    soil conductivity (dS/m): 0.114692
+    soil N, total (%): 0.4046885
+    soil P, Olsen (mg/kg): 0.1508099
+    soil K: 0.1649027
+    soil sand (%): 54.0368804
+    soil silt (%): 22.4210339
+    soil clay (%): 23.5420856
+    elevation (m): 573.0
+    site code: site_31
   site_32:
     longitude (deg): 152.10837
     latitude (deg): -27.25776
-    soil_TOC: 5.2172159
-    soil_pH: 4.59
-    soil_conductivity: 0.05141
-    soil_N: 0.2450621
-    soil_P: 0.0257278
-    soil_K: 0.0913572
-    soil_Sand: 83.2416229
-    soil_Silt: 7.794594
-    soil_Clay: 8.9637831
-    site_elevation: 446.0
-    site_name: site_32
+    soil organic content (%): 5.2172159
+    soil pH (H2O): 4.59
+    soil conductivity (dS/m): 0.05141
+    soil N, total (%): 0.2450621
+    soil P, Olsen (mg/kg): 0.0257278
+    soil K: 0.0913572
+    soil sand (%): 83.2416229
+    soil silt (%): 7.794594
+    soil clay (%): 8.9637831
+    elevation (m): 446.0
+    site code: site_32
   site_33:
     longitude (deg): 152.11122
     latitude (deg): -27.25872
-    soil_TOC: 4.2021236
-    soil_pH: 4.78
-    soil_conductivity: 0.035086
-    soil_N: 0.1458915
-    soil_P: 0.0126312
-    soil_K: 0.0799119
-    soil_Sand: 85.0738187
-    soil_Silt: 6.8738993
-    soil_Clay: 8.052282
-    site_elevation: 432.0
-    site_name: site_33
+    soil organic content (%): 4.2021236
+    soil pH (H2O): 4.78
+    soil conductivity (dS/m): 0.035086
+    soil N, total (%): 0.1458915
+    soil P, Olsen (mg/kg): 0.0126312
+    soil K: 0.0799119
+    soil sand (%): 85.0738187
+    soil silt (%): 6.8738993
+    soil clay (%): 8.052282
+    elevation (m): 432.0
+    site code: site_33
   site_34:
     longitude (deg): 151.73432
     latitude (deg): -27.71725
-    soil_TOC: 8.7217036
-    soil_pH: 6.52
-    soil_conductivity: 0.23532
-    soil_N: 0.6300466
-    soil_P: 0.2067294
-    soil_K: 0.3920122
-    soil_Sand: 57.7064361
-    soil_Silt: 24.3281562
-    soil_Clay: 17.9654077
-    site_elevation: 499.0
-    site_name: site_34
+    soil organic content (%): 8.7217036
+    soil pH (H2O): 6.52
+    soil conductivity (dS/m): 0.23532
+    soil N, total (%): 0.6300466
+    soil P, Olsen (mg/kg): 0.2067294
+    soil K: 0.3920122
+    soil sand (%): 57.7064361
+    soil silt (%): 24.3281562
+    soil clay (%): 17.9654077
+    elevation (m): 499.0
+    site code: site_34
   site_35:
     longitude (deg): 151.63045
     latitude (deg): -27.65899
-    soil_TOC: 4.952168
-    soil_pH: 6.16
-    soil_conductivity: 0.15052
-    soil_N: 0.612241
-    soil_P: 0.1433655
-    soil_K: 0.2920774
-    soil_Sand: 49.8454907
-    soil_Silt: 21.6833405
-    soil_Clay: 28.4711688
-    site_elevation: 571.0
-    site_name: site_35
+    soil organic content (%): 4.952168
+    soil pH (H2O): 6.16
+    soil conductivity (dS/m): 0.15052
+    soil N, total (%): 0.612241
+    soil P, Olsen (mg/kg): 0.1433655
+    soil K: 0.2920774
+    soil sand (%): 49.8454907
+    soil silt (%): 21.6833405
+    soil clay (%): 28.4711688
+    elevation (m): 571.0
+    site code: site_35
   site_40:
     longitude (deg): 145.33763
     latitude (deg): -17.38766
-    soil_TOC: 3.7593561
-    soil_pH: 5.92
-    soil_conductivity: 0.035934
-    soil_N: 0.1564229
-    soil_P: 0.0310917
-    soil_K: 1.46553
-    soil_Sand: 55.8842775
-    soil_Silt: 29.2803468
-    soil_Clay: 14.8353757
-    site_elevation: 999.0
-    site_name: site_40
+    soil organic content (%): 3.7593561
+    soil pH (H2O): 5.92
+    soil conductivity (dS/m): 0.035934
+    soil N, total (%): 0.1564229
+    soil P, Olsen (mg/kg): 0.0310917
+    soil K: 1.46553
+    soil sand (%): 55.8842775
+    soil silt (%): 29.2803468
+    soil clay (%): 14.8353757
+    elevation (m): 999.0
+    site code: site_40
   site_41:
     longitude (deg): .na.real
     latitude (deg): .na.real
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: .na.real
-    site_name: site_41
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): .na.real
+    site code: site_41
   site_42:
     longitude (deg): 145.33856
     latitude (deg): -17.38746
-    soil_TOC: 3.6465911
-    soil_pH: 5.0
-    soil_conductivity: 0.040068
-    soil_N: 0.1101241
-    soil_P: 0.0161741
-    soil_K: 1.3986581
-    soil_Sand: 55.6410189
-    soil_Silt: 32.3859818
-    soil_Clay: 11.9729993
-    site_elevation: 1026.0
-    site_name: site_42
+    soil organic content (%): 3.6465911
+    soil pH (H2O): 5.0
+    soil conductivity (dS/m): 0.040068
+    soil N, total (%): 0.1101241
+    soil P, Olsen (mg/kg): 0.0161741
+    soil K: 1.3986581
+    soil sand (%): 55.6410189
+    soil silt (%): 32.3859818
+    soil clay (%): 11.9729993
+    elevation (m): 1026.0
+    site code: site_42
   site_43:
     longitude (deg): 144.31473
     latitude (deg): -16.96219
-    soil_TOC: 1.865595
-    soil_pH: 5.49
-    soil_conductivity: 0.019928
-    soil_N: 0.0923046
-    soil_P: 0.0131344
-    soil_K: 0.7857367
-    soil_Sand: 65.0864569
-    soil_Silt: 23.8046885
-    soil_Clay: 11.1088546
-    site_elevation: 269.0
-    site_name: site_43
+    soil organic content (%): 1.865595
+    soil pH (H2O): 5.49
+    soil conductivity (dS/m): 0.019928
+    soil N, total (%): 0.0923046
+    soil P, Olsen (mg/kg): 0.0131344
+    soil K: 0.7857367
+    soil sand (%): 65.0864569
+    soil silt (%): 23.8046885
+    soil clay (%): 11.1088546
+    elevation (m): 269.0
+    site code: site_43
   site_44:
     longitude (deg): 144.31447
     latitude (deg): -16.96205
-    soil_TOC: 1.4245874
-    soil_pH: 5.35
-    soil_conductivity: 0.012084
-    soil_N: 0.1017243
-    soil_P: 0.0085053
-    soil_K: 1.1838869
-    soil_Sand: 61.1284857
-    soil_Silt: 27.7653674
-    soil_Clay: 11.1061469
-    site_elevation: 269.0
-    site_name: site_44
+    soil organic content (%): 1.4245874
+    soil pH (H2O): 5.35
+    soil conductivity (dS/m): 0.012084
+    soil N, total (%): 0.1017243
+    soil P, Olsen (mg/kg): 0.0085053
+    soil K: 1.1838869
+    soil sand (%): 61.1284857
+    soil silt (%): 27.7653674
+    soil clay (%): 11.1061469
+    elevation (m): 269.0
+    site code: site_44
   site_45:
     longitude (deg): 144.54868
     latitude (deg): -17.19103
-    soil_TOC: 1.8527233
-    soil_pH: 6.06
-    soil_conductivity: 0.034662
-    soil_N: 0.0781009
-    soil_P: 0.0248198
-    soil_K: 0.1414606
-    soil_Sand: 67.3755744
-    soil_Silt: 13.7572879
-    soil_Clay: 18.8671377
-    site_elevation: 422.0
-    site_name: site_45
+    soil organic content (%): 1.8527233
+    soil pH (H2O): 6.06
+    soil conductivity (dS/m): 0.034662
+    soil N, total (%): 0.0781009
+    soil P, Olsen (mg/kg): 0.0248198
+    soil K: 0.1414606
+    soil sand (%): 67.3755744
+    soil silt (%): 13.7572879
+    soil clay (%): 18.8671377
+    elevation (m): 422.0
+    site code: site_45
   site_46:
     longitude (deg): 145.06569
     latitude (deg): -17.41847
-    soil_TOC: 2.215663
-    soil_pH: 5.45
-    soil_conductivity: 0.012826
-    soil_N: 0.0627606
-    soil_P: 0.0099205
-    soil_K: 1.2750794
-    soil_Sand: 79.0289544
-    soil_Silt: 9.8920027
-    soil_Clay: 11.079043
-    site_elevation: 569.0
-    site_name: site_46
+    soil organic content (%): 2.215663
+    soil pH (H2O): 5.45
+    soil conductivity (dS/m): 0.012826
+    soil N, total (%): 0.0627606
+    soil P, Olsen (mg/kg): 0.0099205
+    soil K: 1.2750794
+    soil sand (%): 79.0289544
+    soil silt (%): 9.8920027
+    soil clay (%): 11.079043
+    elevation (m): 569.0
+    site code: site_46
   site_47:
     longitude (deg): 145.06576
     latitude (deg): -17.41806
-    soil_TOC: 1.8442695
-    soil_pH: 5.53
-    soil_conductivity: 0.020246
-    soil_N: 0.0825255
-    soil_P: 0.0120839
-    soil_K: 1.465425
-    soil_Sand: 79.0591951
-    soil_Silt: 9.8777382
-    soil_Clay: 11.0630667
-    site_elevation: 569.0
-    site_name: site_47
+    soil organic content (%): 1.8442695
+    soil pH (H2O): 5.53
+    soil conductivity (dS/m): 0.020246
+    soil N, total (%): 0.0825255
+    soil P, Olsen (mg/kg): 0.0120839
+    soil K: 1.465425
+    soil sand (%): 79.0591951
+    soil silt (%): 9.8777382
+    soil clay (%): 11.0630667
+    elevation (m): 569.0
+    site code: site_47
   site_48:
     longitude (deg): 145.22595
     latitude (deg): -17.39505
-    soil_TOC: 2.4053026
-    soil_pH: 5.46
-    soil_conductivity: 0.12084
-    soil_N: 0.6992463
-    soil_P: 0.0157558
-    soil_K: 0.8286631
-    soil_Sand: 77.1282204
-    soil_Silt: 13.801936
-    soil_Clay: 9.0698436
-    site_elevation: 762.0
-    site_name: site_48
+    soil organic content (%): 2.4053026
+    soil pH (H2O): 5.46
+    soil conductivity (dS/m): 0.12084
+    soil N, total (%): 0.6992463
+    soil P, Olsen (mg/kg): 0.0157558
+    soil K: 0.8286631
+    soil sand (%): 77.1282204
+    soil silt (%): 13.801936
+    soil clay (%): 9.0698436
+    elevation (m): 762.0
+    site code: site_48
   site_49:
     longitude (deg): 145.4332778
     latitude (deg): -17.1058056
-    soil_TOC: 2.8605089
-    soil_pH: 5.59
-    soil_conductivity: 0.39962
-    soil_N: 1.8392908
-    soil_P: 0.0430804
-    soil_K: 0.1150363
-    soil_Sand: 45.5768376
-    soil_Silt: 18.0776239
-    soil_Clay: 36.3455385
-    site_elevation: 569.0
-    site_name: site_49
+    soil organic content (%): 2.8605089
+    soil pH (H2O): 5.59
+    soil conductivity (dS/m): 0.39962
+    soil N, total (%): 1.8392908
+    soil P, Olsen (mg/kg): 0.0430804
+    soil K: 0.1150363
+    soil sand (%): 45.5768376
+    soil silt (%): 18.0776239
+    soil clay (%): 36.3455385
+    elevation (m): 569.0
+    site code: site_49
   Tabletop_1:
     longitude (deg): 146.46538
     latitude (deg): -19.39593
-    soil_TOC: 2.3408167
-    soil_pH: 5.54
-    soil_conductivity: 0.027454
-    soil_N: 1.044181
-    soil_P: 0.0340501
-    soil_K: 0.2637111
-    soil_Sand: 65.3416975
-    soil_Silt: 18.7076065
-    soil_Clay: 15.950696
-    site_elevation: 406.0
-    site_name: site_19
+    soil organic content (%): 2.3408167
+    soil pH (H2O): 5.54
+    soil conductivity (dS/m): 0.027454
+    soil N, total (%): 1.044181
+    soil P, Olsen (mg/kg): 0.0340501
+    soil K: 0.2637111
+    soil sand (%): 65.3416975
+    soil silt (%): 18.7076065
+    soil clay (%): 15.950696
+    elevation (m): 406.0
+    site code: site_19
   Tabletop_2:
     longitude (deg): 146.42174
     latitude (deg): -19.35504
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 394.0
-    site_name: site_20
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 394.0
+    site code: site_20
   Taravale_1_01:
     longitude (deg): 146.07923
     latitude (deg): -19.12686
-    soil_TOC: 1.6274747
-    soil_pH: 4.85
-    soil_conductivity: 0.021094
-    soil_N: 0.8054948
-    soil_P: 0.0054705
-    soil_K: 0.4041557
-    soil_Sand: 61.066102
-    soil_Silt: 28.8031388
-    soil_Clay: 10.1307592
-    site_elevation: 710.0
-    site_name: site_1
+    soil organic content (%): 1.6274747
+    soil pH (H2O): 4.85
+    soil conductivity (dS/m): 0.021094
+    soil N, total (%): 0.8054948
+    soil P, Olsen (mg/kg): 0.0054705
+    soil K: 0.4041557
+    soil sand (%): 61.066102
+    soil silt (%): 28.8031388
+    soil clay (%): 10.1307592
+    elevation (m): 710.0
+    site code: site_1
   Taravale_1_02:
     longitude (deg): 146.07923
     latitude (deg): -19.12686
-    soil_TOC: 2.516056
-    soil_pH: 5.16
-    soil_conductivity: 0.024486
-    soil_N: 0.830439
-    soil_P: 0.0084378
-    soil_K: 0.3845637
-    soil_Sand: 57.3161834
-    soil_Silt: 32.6056932
-    soil_Clay: 10.0781234
-    site_elevation: 710.0
-    site_name: site_2
+    soil organic content (%): 2.516056
+    soil pH (H2O): 5.16
+    soil conductivity (dS/m): 0.024486
+    soil N, total (%): 0.830439
+    soil P, Olsen (mg/kg): 0.0084378
+    soil K: 0.3845637
+    soil sand (%): 57.3161834
+    soil silt (%): 32.6056932
+    soil clay (%): 10.0781234
+    elevation (m): 710.0
+    site code: site_2
   Taravale_1_08:
     longitude (deg): 146.07923
     latitude (deg): -19.12686
-    soil_TOC: 1.5902292
-    soil_pH: 5.09
-    soil_conductivity: 0.017172
-    soil_N: 0.4228878
-    soil_P: 0.0054566
-    soil_K: 0.3682419
-    soil_Sand: 61.0285384
-    soil_Silt: 29.8250981
-    soil_Clay: 9.1463634
-    site_elevation: 710.0
-    site_name: site_8
+    soil organic content (%): 1.5902292
+    soil pH (H2O): 5.09
+    soil conductivity (dS/m): 0.017172
+    soil N, total (%): 0.4228878
+    soil P, Olsen (mg/kg): 0.0054566
+    soil K: 0.3682419
+    soil sand (%): 61.0285384
+    soil silt (%): 29.8250981
+    soil clay (%): 9.1463634
+    elevation (m): 710.0
+    site code: site_8
   Taravale_1_09:
     longitude (deg): 146.10512
     latitude (deg): -19.1152
-    soil_TOC: 3.7545158
-    soil_pH: 4.95
-    soil_conductivity: 0.02915
-    soil_N: 1.0766556
-    soil_P: 0.0072842
-    soil_K: 0.467645
-    soil_Sand: 63.2292308
-    soil_Silt: 21.7461538
-    soil_Clay: 15.0246154
-    site_elevation: 755.0
-    site_name: site_9
+    soil organic content (%): 3.7545158
+    soil pH (H2O): 4.95
+    soil conductivity (dS/m): 0.02915
+    soil N, total (%): 1.0766556
+    soil P, Olsen (mg/kg): 0.0072842
+    soil K: 0.467645
+    soil sand (%): 63.2292308
+    soil silt (%): 21.7461538
+    soil clay (%): 15.0246154
+    elevation (m): 755.0
+    site code: site_9
   Taravale_2:
     longitude (deg): 146.10512
     latitude (deg): -19.1152
-    soil_TOC: 3.1570041
-    soil_pH: 4.45
-    soil_conductivity: 0.02014
-    soil_N: 0.8021878
-    soil_P: 0.0079841
-    soil_K: 0.5474573
-    soil_Sand: 60.2853693
-    soil_Silt: 24.6981534
-    soil_Clay: 15.0164773
-    site_elevation: 755.0
-    site_name: site_17
+    soil organic content (%): 3.1570041
+    soil pH (H2O): 4.45
+    soil conductivity (dS/m): 0.02014
+    soil N, total (%): 0.8021878
+    soil P, Olsen (mg/kg): 0.0079841
+    soil K: 0.5474573
+    soil sand (%): 60.2853693
+    soil silt (%): 24.6981534
+    soil clay (%): 15.0164773
+    elevation (m): 755.0
+    site code: site_17
   Taravale_3:
     longitude (deg): 146.05164
     latitude (deg): -19.19092
-    soil_TOC: .na.real
-    soil_pH: .na.real
-    soil_conductivity: .na.real
-    soil_N: .na.real
-    soil_P: .na.real
-    soil_K: .na.real
-    soil_Sand: .na.real
-    soil_Silt: .na.real
-    soil_Clay: .na.real
-    site_elevation: 689.0
-    site_name: site_18
+    soil organic content (%): .na.real
+    soil pH (H2O): .na.real
+    soil conductivity (dS/m): .na.real
+    soil N, total (%): .na.real
+    soil P, Olsen (mg/kg): .na.real
+    soil K: .na.real
+    soil sand (%): .na.real
+    soil silt (%): .na.real
+    soil clay (%): .na.real
+    elevation (m): 689.0
+    site code: site_18
   White Mountains:
     longitude (deg): 145.13605
     latitude (deg): -20.6340667
-    soil_TOC: 1.342362
-    soil_pH: 6.04
-    soil_conductivity: 0.012402
-    soil_N: 0.4693408
-    soil_P: 0.0107215
-    soil_K: 0.0569461
-    soil_Sand: 65.1306736
-    soil_Silt: 15.8496938
-    soil_Clay: 19.0196326
-    site_elevation: 553.0
-    site_name: site_57
+    soil organic content (%): 1.342362
+    soil pH (H2O): 6.04
+    soil conductivity (dS/m): 0.012402
+    soil N, total (%): 0.4693408
+    soil P, Olsen (mg/kg): 0.0107215
+    soil K: 0.0569461
+    soil sand (%): 65.1306736
+    soil silt (%): 15.8496938
+    soil clay (%): 19.0196326
+    elevation (m): 553.0
+    site code: site_57
 contexts: .na
 config:
   data_is_long_format: no
@@ -875,4 +876,3 @@ taxonomic_updates:
   reason: Aign to first of two names given (E. Wenk, 2020-05-26)
 exclude_observations: .na
 questions: .na
-

--- a/data/Morgan_2005/metadata.yml
+++ b/data/Morgan_2005/metadata.yml
@@ -29,25 +29,25 @@ dataset:
   notes: none
 sites:
   mallee:
-    rainfall: low
+    precipitation, MAP (mm): low
     soil texture: coarse
     latitude (deg): .na
     longitude (deg): .na
     description: .na
   woodland:
-    rainfall: low
+    precipitation, MAP (mm): low
     soil texture: fine
     latitude (deg): .na
     longitude (deg): .na
     description: .na
   olney:
-    rainfall: high
+    precipitation, MAP (mm): high
     soil texture: fine
     latitude (deg): .na
     longitude (deg): .na
     description: .na
   ourimbah:
-    rainfall: high
+    precipitation, MAP (mm): high
     soil texture: coarse
     latitude (deg): .na
     longitude (deg): .na
@@ -150,4 +150,3 @@ exclude_observations: .na
 questions:
   additional_traits: additional root measurements, including ratio of steep to shallow
     rootps and 'tip_RML'
-

--- a/data/Morgan_2014/metadata.yml
+++ b/data/Morgan_2014/metadata.yml
@@ -35,7 +35,7 @@ sites:
   Mt Nelse-Bogong High Plains-Mt Hotham:
     latitude (deg): -36.87
     longitude (deg): 147.32
-    lat/lon notes: lat/lon for location near Bogong High Plains Road given, but data
+    georeference remarks: lat/lon for location near Bogong High Plains Road given, but data
       more broadly collected between Mt Nelse-Bogong High Plains-Mt Hotham in Victoria
     description: dataset collected between Mt Nelse-Bogong High Plains-Mt Hotham in
       Victoria

--- a/data/Morgan_2014/metadata.yml
+++ b/data/Morgan_2014/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: John Morgan
     year: 2004
-    title: 'Unpublished data: Trait data from Victorian alpine plant species, La Trobe University'
+    title: 'Unpublished data: Trait data from Victorian alpine plant species, La Trobe
+      University'
 people:
 - name: John Morgan
   institution: La Trobe University
@@ -147,4 +148,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Muir_2014/metadata.yml
+++ b/data/Muir_2014/metadata.yml
@@ -96,28 +96,28 @@ dataset:
     includes height data for many individual plants.
 sites:
   Bunyip SP / Kurth Kiln_45:
-    Location: Bunyip SP / Kurth Kiln
-    years since fire: 45.0
+    locality: Bunyip SP / Kurth Kiln
+    fire history (years since fire): 45.0
     latitude (deg): -37.9391833
     longitude (deg): 145.6141833
   Dandenong Ranges NP_22:
-    Location: Dandenong Ranges NP
-    years since fire: 22.0
+    locality: Dandenong Ranges NP
+    fire history (years since fire): 22.0
     latitude (deg): -37.8497667
     longitude (deg): 145.3994667
   Dandenong Ranges NP_23:
-    Location: Dandenong Ranges NP
-    years since fire: 23.0
+    locality: Dandenong Ranges NP
+    fire history (years since fire): 23.0
     latitude (deg): -37.8479667
     longitude (deg): 145.39385
   Dandenong Ranges NP_45a:
-    Location: Dandenong Ranges NP
-    years since fire: 45.0
+    locality: Dandenong Ranges NP
+    fire history (years since fire): 45.0
     latitude (deg): -37.837
     longitude (deg): 145.3965333
   Dandenong Ranges NP_45b:
-    Location: Dandenong Ranges NP
-    years since fire: 45.0
+    locality: Dandenong Ranges NP
+    fire history (years since fire): 45.0
     latitude (deg): -37.8447167
     longitude (deg): 145.3500667
 contexts: .na
@@ -171,4 +171,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Nicholson_2017/metadata.yml
+++ b/data/Nicholson_2017/metadata.yml
@@ -160,4 +160,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Niinemets_2009/metadata.yml
+++ b/data/Niinemets_2009/metadata.yml
@@ -79,89 +79,89 @@ sites:
   AgnesBanks:
     longitude (deg): 150.696
     latitude (deg): -33.642
-    description: Agnes Banks Nature Reserve
-    vegetation: Low open woodland dominated by Banksia aemula and Eucalyptus sclerophylla
-    phosphorus: low
-    rainfall: low
-    MAP (mm): 801
-    soil_total_P (ug/g): 5
-    soil_total_N (%): <0.01
+    locality: Agnes Banks Nature Reserve
+    description: Low open woodland dominated by Banksia aemula and Eucalyptus sclerophylla
+    soil P, description: low
+    precipitation, description: low
+    precipitation, MAP (mm): 801
+    soil P, total (mg/kg): 5
+    soil N, total (%): <0.01
     soil type: yellow sand
-    soil parent rock: windblown dunes of Pliocene to Pleistocene
+    geology (stratigraphic map unit): windblown dunes of Pliocene to Pleistocene
   Castlereagh:
     longitude (deg): 150.755
     latitude (deg): -33.68
-    description: Castlereagh Nature Reserve. Samples from two sub-sites, one accessed
+    locality: Castlereagh Nature Reserve. Samples from two sub-sites, one accessed
       from west side of the park (via Barbaras Trail), the other accessed from east
       side (in part near Llandillo Trail).
-    vegetation: Open woodland dominated by Angophora bakeri, Eucalyptus fibrosa, and
+    description: Open woodland dominated by Angophora bakeri, Eucalyptus fibrosa, and
       Eucalyptus umbria
-    phosphorus: high
-    rainfall: low
-    MAP (mm): 801
-    soil_total_P (ug/g): 205
-    soil_total_N (%): 0.059
+    soil P, description: high
+    precipitation, description: low
+    precipitation, MAP (mm): 801
+    soil P, total (mg/kg): 205
+    soil N, total (%): 0.059
     soil type: sandy clay
-    soil parent rock: tertiary alluvial deposits
+    geology (stratigraphic map unit): tertiary alluvial deposits
   KCNP_Basin_Track:
     longitude (deg): 151.28
     latitude (deg): -33.591
-    description: start of Basin Track in Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: start of Basin Track in Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   KCNP_Murrua_Track:
     longitude (deg): 151.145
     latitude (deg): -33.693
-    description: Murrua Track in Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: Murrua Track in Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   KCNP_unknown_track:
     longitude (deg): 151.145
     latitude (deg): -33.693
-    description: probably Murrua Track in Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: probably Murrua Track in Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   MU_forest:
     longitude (deg): 151.1166667
     latitude (deg): -33.7833333
-    description: native species from that tiny fragment of turpentine forest still
-      on campus
-    phosphorus: high
-    rainfall: high
+    locality: native species from that tiny fragment of turpentine forest still on
+      campus
+    soil P, description: high
+    precipitation, description: high
   MU_campus:
     longitude (deg): 151.1166667
     latitude (deg): -33.7833333
-    description: plantings of some native species, varying considerably how far they
+    locality: plantings of some native species, varying considerably how far they
       are from native range
-    phosphorus: high
-    rainfall: high
+    soil P, description: high
+    precipitation, description: high
   WestHead:
     longitude (deg): 151.298
     latitude (deg): -33.578
-    description: West Head diatreme in Ku-ring-gai Chase National Park
-    vegetation: closed forest dominated by Eucalyptus umbra, Livistona australis,
-      and Syncarpia glomulifera
-    phosphorus: high
-    rainfall: high
-    soil_total_P (ug/g): 440
-    soil_total_N (%): 0.26
+    locality: West Head diatreme in Ku-ring-gai Chase National Park
+    description: closed forest dominated by Eucalyptus umbra, Livistona australis, and
+      Syncarpia glomulifera
+    soil P, description: high
+    precipitation, description: high
+    soil P, total (mg/kg): 440
+    soil N, total (%): 0.26
     soil type: red-brown clay
-    soil parent roc: weathered volcanic dyke
+    geology (stratigraphic map unit): weathered volcanic dyke
 contexts: .na
 config:
   data_is_long_format: no
@@ -601,4 +601,3 @@ exclude_observations:
 questions:
   additional_traits: triose phosphate utilization (TPU), electron transport rate (ETR),
     Jmax per area, Vcmax per area, and other manipulations of fluorescence measuremnets
-

--- a/data/OReillyNugent_2018/metadata.yml
+++ b/data/OReillyNugent_2018/metadata.yml
@@ -5,7 +5,8 @@ source:
     author: A. O'Reilly-Nugent, E. Wandrag, C.A. Catford, B. Gruber, D. Driscoll,
       R.P. Duncan
     year: 2018
-    title: 'Measuring competitive impact: Joint‐species modelling of invaded plant communities'
+    title: 'Measuring competitive impact: Joint-species modelling of invaded plant
+      communities'
     journal: Journal of Ecology
     volume: 108
     pages: 449--459
@@ -63,9 +64,9 @@ sites:
     elevation (m): 620 - 708
     latitude (deg): -35.257188
     longitude (deg): 149.038875
-    rainfall (mm): 600
-    soils: Soils are typically low fertility, shallow and rocky, although some deeper
-      soils occur on slopes and in depressions.
+    precipitation, MAP (mm): 600
+    soil type: Soils are typically low fertility, shallow and rocky, although some
+      deeper soils occur on slopes and in depressions.
 contexts: .na
 config:
   data_is_long_format: no
@@ -109,4 +110,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Onoda_2010/metadata.yml
+++ b/data/Onoda_2010/metadata.yml
@@ -53,61 +53,61 @@ dataset:
     the data.csv file
 sites:
   Mallee, RoundHill:
-    Rainfall: low
-    Soil.nutrient: low
+    precipitation, description: low
+    soil nutrient summary: low
     latitude (deg): -32.9666667
     longitude (deg): 146.1333333
     description: open shrub mallee
-    MAP (mm): 387.0
-    MAT max (C): 24.1
-    MAT min (C): 11.1
+    precipitation, MAP (mm): 387.0
+    temperature, max MAT (C): 24.1
+    temperature, min MAT (C): 11.1
     soil type: loamy red sand
-    total P (ppm): 132.4
-    total N (%): 0.031
-    total C (%): 0.67
-    CEC (mEq kg-1): 38.7
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
   Murrua, Kuringai:
-    Rainfall: high
-    Soil.nutrient: low
+    precipitation, description: high
+    soil nutrient summary: low
     latitude (deg): -33.6833333
     longitude (deg): 151.1333333
     description: low open woodland
-    MAP (mm): 1220.0
-    MAT max (C): 22.0
-    MAT min (C): 13.0
+    precipitation, MAP (mm): 1220.0
+    temperature, max MAT (C): 22.0
+    temperature, min MAT (C): 13.0
     soil type: yellow-grey sand
-    total P (ppm): 93.6
-    total N (%): 0.03
-    total C (%): 0.95
-    CEC (mEq kg-1): 9.0
+    soil P, total (mg/kg): 93.6
+    soil N, total (%): 0.03
+    soil C, total (%): 0.95
+    soil cation exchange capacity (meq/kg): 9.0
   Westhead, Kuringai:
-    Rainfall: high
-    Soil.nutrient: high
+    precipitation, description: high
+    soil nutrient summary: high
     latitude (deg): -33.5666667
     longitude (deg): 151.2833333
     description: closed forest
-    MAP (mm): 1220.0
-    MAT max (C): 22.0
-    MAT min (C): 13.0
+    precipitation, MAP (mm): 1220.0
+    temperature, max MAT (C): 22.0
+    temperature, min MAT (C): 13.0
     soil type: red-brown clay
-    total P (ppm): 442.3
-    total N (%): 0.256
-    total C (%): 5.91
-    CEC (mEq kg-1): 55.6
+    soil P, total (mg/kg): 442.3
+    soil N, total (%): 0.256
+    soil C, total (%): 5.91
+    soil cation exchange capacity (meq/kg): 55.6
   Woodland, RoundHill:
-    Rainfall: low
-    Soil.nutrient: high
+    precipitation, description: low
+    soil nutrient summary: high
     latitude (deg): -32.9666667
     longitude (deg): 146.1333333
     description: open woodland
-    MAP (mm): 387.0
-    MAT max (C): 24.1
-    MAT min (C): 11.1
+    precipitation, MAP (mm): 387.0
+    temperature, max MAT (C): 24.1
+    temperature, min MAT (C): 11.1
     soil type: lightr ed clay
-    total P (ppm): 250.4
-    total N (%): 0.071
-    total C (%): 1.2
-    CEC (mEq kg-1): 65.8
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
 contexts: .na
 config:
   data_is_long_format: no
@@ -248,4 +248,3 @@ exclude_observations: .na
 questions:
   additional_traits: density of fresh stems; all values for entire stem (only sapwood
     values included)
-

--- a/data/Ooi_2018/metadata.yml
+++ b/data/Ooi_2018/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     year: 2018
     author: Mark K. J. Ooi
-    title: "Unpublished data: Herbivory survey within Royal National Park, University of New South Wales"
+    title: 'Unpublished data: Herbivory survey within Royal National Park, University
+      of New South Wales'
 people:
 - name: Mark Ooi
   institution: University of New South Wales, Centre for Ecosystem Science
@@ -52,4 +53,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Peeters_2002/metadata.yml
+++ b/data/Peeters_2002/metadata.yml
@@ -34,7 +34,7 @@ sites:
   BunyipSP:
     longitude (deg): 145.8
     latitude (deg): -37.983
-    rainfall (mm): 1000
+    precipitation, MAP (mm): 1000
     description: tall open eucalypt forest (sensu Specht, 1970), at an altitude of
       120-220 m. The site experiences a temperate climate (mean winter minimum 2.6C,
       mean summer maximum 24.8C) with a median annual rainfall of 1000 mm (see Peeters
@@ -219,4 +219,3 @@ exclude_observations: .na
 questions:
   additional_traits: additional anatomical traits including, surface hair density,
     stomatal characteristics, and distances to phloem and xylem from the leaf surface
-

--- a/data/Pickering_2014/metadata.yml
+++ b/data/Pickering_2014/metadata.yml
@@ -93,296 +93,296 @@ sites:
     latitude (deg): -36.434
     longitude (deg): 148.301
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Betts Creek:
     latitude (deg): -36.427
     longitude (deg): 148.372
     description: unknown
-    region: alpine
+    biome: alpine
   Between Clarke 3 and 2:
     elevation (m): 2034
     latitude (deg): -36.433
     longitude (deg): 148.293
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Charlotte Pass below Mt Stilwell:
     latitude (deg): -36.443
     longitude (deg): 148.323
     description: unknown
-    region: alpine
+    biome: alpine
   Charlotte Pass Cafe:
     elevation (m): 1681
     latitude (deg): -36.435
     longitude (deg): 148.332
     description: unknown
-    region: alpine
+    biome: alpine
   Charlotte Pass Carpark:
     elevation (m): 1804
     latitude (deg): -36.432
     longitude (deg): 148.331
     description: unknown
-    region: alpine
+    biome: alpine
   Charlotte Pass Chairlift:
     elevation (m): 1953
     latitude (deg): -36.439
     longitude (deg): 148.324
     description: unknown
-    region: alpine
+    biome: alpine
   Charlotte Pass Lodge:
     elevation (m): 1785
     latitude (deg): -36.437
     longitude (deg): 148.335
     description: unknown
-    region: alpine and subalpine
+    biome: alpine and subalpine
   Charlotte Pass Phenology Site:
     elevation (m): 1870
     latitude (deg): -36.43
     longitude (deg): 148.331
     description: unknown
-    region: alpine
+    biome: alpine
   Club Lake Creek:
     elevation (m): 1786
     latitude (deg): -36.43
     longitude (deg): 148.304
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Club Lake Creek Pool:
     latitude (deg): -36.428
     longitude (deg): 148.301
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Club Lake FF:
     latitude (deg): -36.417
     longitude (deg): 148.286
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Dainers Gap:
     elevation (m): 1671
     latitude (deg): -36.376
     longitude (deg): 148.472
     description: unknown
-    region: alpine and subalpine
+    biome: alpine and subalpine
   Dainers Gap carpark:
     elevation (m): 1688
     latitude (deg): -36.372
     longitude (deg): 148.471
     description: unknown
-    region: subalpine
+    biome: subalpine
   Dainers Gap SAG3 Site:
     elevation (m): 1668
     latitude (deg): -36.376
     longitude (deg): 148.472
     description: unknown
-    region: alpine and subalpine
+    biome: alpine and subalpine
   East of main range 500m from junction:
     elevation (m): 2121
     latitude (deg): -36.448
     longitude (deg): 148.267
     description: unknown
-    region: alpine
+    biome: alpine
   Edge of track Mt Kosciuszko:
     elevation (m): 2234
     latitude (deg): -36.457
     longitude (deg): 148.264
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Feldmark:
     elevation (m): 2073
     latitude (deg): -36.406
     longitude (deg): 148.297
     description: unknown
-    region: alpine
+    biome: alpine
   FMUB1:
     elevation (m): 2080
     latitude (deg): -36.416
     longitude (deg): 148.286
     description: unknown
-    region: alpine
+    biome: alpine
   FMUB2:
     elevation (m): 2109
     latitude (deg): -36.412
     longitude (deg): 148.287
     description: unknown
-    region: alpine
+    biome: alpine
   Near Snowy river:
     elevation (m): 1742
     latitude (deg): -36.431
     longitude (deg): 148.319
     description: unknown
-    region: alpine
+    biome: alpine
   On way to Club Lake:
     elevation (m): 1901
     latitude (deg): -36.42
     longitude (deg): 148.302
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Rennix Walk Car Park:
     elevation (m): 1601
     latitude (deg): -36.361
     longitude (deg): 148.507
     description: unknown
-    region: subalpine
+    biome: subalpine
   Saw Pitt Creek Waterfall Walk:
     elevation (m): 1225
     latitude (deg): -36.345
     longitude (deg): 148.559
     description: unknown
-    region: alpine
+    biome: alpine
   Snow bank1:
     elevation (m): 2045
     latitude (deg): -36.447
     longitude (deg): 148.326
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Snowbank below Stillwell:
     elevation (m): 1987
     latitude (deg): -36.443
     longitude (deg): 148.326
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Snowy River Phebalium heath:
     elevation (m): 1745
     latitude (deg): -36.431
     longitude (deg): 148.322
     description: Phebalium heath
-    region: alpine and subalpine
+    biome: alpine and subalpine
   Spencers Creek:
     elevation (m): 1720
     latitude (deg): -36.429
     longitude (deg): 148.358
     description: unknown
-    region: alpine
+    biome: alpine
   Start of Club Lake Creek:
     elevation (m): 1944
     latitude (deg): -36.415
     longitude (deg): 148.292
     description: snowpatch vegetation
-    region: alpine
+    biome: alpine
   Stillwell Basin:
     elevation (m): 1989
     latitude (deg): -36.442
     longitude (deg): 148.325
     description: unknown
-    region: alpine
+    biome: alpine
   Stillwell Path between chairlift and Charlotte Pass:
     elevation (m): 1924
     latitude (deg): -36.436
     longitude (deg): 148.325
     description: unknown
-    region: alpine
+    biome: alpine
   Stillwell Path chairlift:
     latitude (deg): -36.438
     longitude (deg): 148.324
     description: unknown
-    region: alpine
+    biome: alpine
   Tall alpine herbfield near Club Lake:
     elevation (m): 1870
     latitude (deg): -36.419
     longitude (deg): 148.294
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield next to snowbank:
     elevation (m): 2029
     latitude (deg): -36.448
     longitude (deg): 148.324
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield next to Snowy River1:
     elevation (m): 1954
     latitude (deg): -36.459
     longitude (deg): 148.297
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield next to Snowy River2:
     elevation (m): 1842
     latitude (deg): -36.42
     longitude (deg): 148.296
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield raised bog:
     elevation (m): 2022
     latitude (deg): -36.444
     longitude (deg): 148.331
     description: tall alpine herbfield; raised bog
-    region: alpine
+    biome: alpine
   Tall alpine herbfield1:
     elevation (m): 1943
     latitude (deg): -36.453
     longitude (deg): 148.294
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield10:
     elevation (m): 2117
     latitude (deg): -36.404
     longitude (deg): 148.301
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield11:
     elevation (m): 2108
     latitude (deg): -36.401
     longitude (deg): 148.305
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield2:
     elevation (m): 1928
     latitude (deg): -36.452
     longitude (deg): 148.301
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield3:
     elevation (m): 1903
     latitude (deg): -36.452
     longitude (deg): 148.305
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield4:
     elevation (m): 1953
     latitude (deg): -36.452
     longitude (deg): 148.298
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield5:
     elevation (m): 2047
     latitude (deg): -36.447
     longitude (deg): 148.327
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield6:
     elevation (m): 2045
     latitude (deg): -36.447
     longitude (deg): 148.326
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield7:
     elevation (m): 1918
     latitude (deg): -36.419
     longitude (deg): 148.301
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield8:
     elevation (m): 1884
     latitude (deg): -36.418
     longitude (deg): 148.293
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Tall alpine herbfield9:
     elevation (m): 2110
     latitude (deg): -36.404
     longitude (deg): 148.304
     description: tall alpine herbfield
-    region: alpine
+    biome: alpine
   Up Heartbreak Hill:
     elevation (m): 1758
     latitude (deg): -36.431
     longitude (deg): 148.323
     description: unknown
-    region: alpine
+    biome: alpine
   Up Lodge:
     elevation (m): 1783
     latitude (deg): -36.396
     longitude (deg): 148.404
     description: unknown
-    region: alpine
+    biome: alpine
 contexts: .na
 config:
   data_is_long_format: no
@@ -538,4 +538,3 @@ questions:
     (1269) have been excluded as having SLA values outside allowable trait limits.
     Since most species have completely "normal" SLA values I'm fairly certain the
     assigned units are correct. Should I just exclude the outliers?
-

--- a/data/Pickup_2002/metadata.yml
+++ b/data/Pickup_2002/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     year: 2002
     author: Melinda Pickup
-    title: "Unpublished data: Wood density data from Kuring-gai National Park, Macquarie University"
+    title: 'Unpublished data: Wood density data from Kuring-gai National Park, Macquarie
+      University'
 people:
 - name: Ian Wright
   institution: Macquarie University
@@ -25,7 +26,7 @@ sites:
   Kuringgai National Park:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
-    location: lat and lon are approximate; values used are those from Wright_2002
+    lat/lon notes: lat and lon are approximate; values used are those from Wright_2002
 contexts:
   branch segment tt:
     description: branch tip; actual branch diameter in data.csv file
@@ -76,4 +77,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Pickup_2002/metadata.yml
+++ b/data/Pickup_2002/metadata.yml
@@ -26,7 +26,7 @@ sites:
   Kuringgai National Park:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
-    lat/lon notes: lat and lon are approximate; values used are those from Wright_2002
+    georeference remarks: lat and lon are approximate; values used are those from Wright_2002
 contexts:
   branch segment tt:
     description: branch tip; actual branch diameter in data.csv file

--- a/data/Pickup_2005/metadata.yml
+++ b/data/Pickup_2005/metadata.yml
@@ -49,49 +49,50 @@ sites:
   Round Hill woodland:
     longitude (deg): 146.1547222
     latitude (deg): -32.9666667
-    description: Round Hill Nature Reserve, woodland site
-    vegetation: Open woodland
-    nutrient summary: loRhiP
-    MAP (mm): 387
-    soil_total_P (ppm): 250.4
-    soil_total_N (%): 0.071
-    soil_total_C (%): 1.2
-    soil_cation_exchange_capacity (meq/kg): 65.8
-    geology: Light red clay (residual deposits overlying Mt Hope volcanics)
+    locality: Round Hill Nature Reserve, woodland site
+    description: Open woodland
+    soil nutrient summary: loRhiP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
+    geology (parent material): Light red clay (residual deposits overlying Mt Hope
+      volcanics)
   Round Hill mallee:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
-    description: Round Hill Nature Reserve, mallee site
-    vegetation: Open shrub mallee
-    nutrient summary: loRloP
-    MAP (mm): 387
-    soil_total_P (ppm): 132.4
-    soil_total_N (%): 0.031
-    soil_total_C (%): 0.67
-    soil_cation_exchange_capacity (meq/kg): 38.7
-    geology: Loamy red sand (Quaternary dune systems)
+    locality: Round Hill Nature Reserve, mallee site
+    description: Open shrub mallee
+    soil nutrient summary: loRloP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
+    geology (parent material): Loamy red sand (Quaternary dune systems)
   Gosford High P:
     longitude (deg): 151.3166667
     latitude (deg): -33.3833333
-    description: Strickland State Forest, near Gosford NSW
-    vegetation: Closed forest
-    nutrient summary: hiRhiP
-    MAP (mm): 1300
-    MAT (deg): 17.5
-    soil_total_P (ppm): 335
-    soil_total_N (%): 0.37
-    soil_total_C (%): 5.57
+    locality: Strickland State Forest, near Gosford NSW
+    description: Closed forest
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1300
+    temperature, MAT (C): 17.5
+    soil P, total (mg/kg): 335
+    soil N, total (%): 0.37
+    soil C, total (%): 5.57
   Gosford low P:
     longitude (deg): 151.3166667
     latitude (deg): -33.3667
-    description: Strickland State Forest, near Gosford NSW
-    vegetation: Open woodland
-    nutrient summary: hiRloP
-    MAP (mm): 1300
-    MAT (deg): 17.5
-    soil_total_P (ppm): 98
-    soil_total_N (%): 0.057
-    soil_total_C (%): 2.15
+    locality: Strickland State Forest, near Gosford NSW
+    description: Open woodland
+    soil nutrient summary: hiRloP
+    precipitation, MAP (mm): 1300
+    temperature, MAT (C): 17.5
+    soil P, total (mg/kg): 98
+    soil N, total (%): 0.057
+    soil C, total (%): 2.15
 contexts: .na
 config:
   data_is_long_format: no
@@ -310,4 +311,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Pollock_2012/metadata.yml
+++ b/data/Pollock_2012/metadata.yml
@@ -77,1351 +77,1351 @@ sites:
     latitude (deg): -37.5903
     elevation (m): .na.real
     notes: ''
-    PerSlope: 24.0
-    aspect: 82.235557
-    Soil Depth class: 25.0
-    Rock cover %: 40.0
-    Soil Type: sandy loam
+    slope angle (degrees): 24.0
+    slope aspect (degrees): 82.235557
+    soil depth class: 25.0
+    rock cover (%): 40.0
+    soil type: sandy loam
   BARK1:
     longitude (deg): 142.5051
     latitude (deg): -37.1524
     elevation (m): .na.real
     notes: ''
-    PerSlope: 36.0
-    aspect: 298.977874
-    Soil Depth class: 5.0
-    Rock cover %: 95.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 36.0
+    slope aspect (degrees): 298.977874
+    soil depth class: 5.0
+    rock cover (%): 95.0
+    soil type: sandy clay loam
   Black Range:
     longitude (deg): 142.736294
     latitude (deg): -37.14129
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   BLK1:
     longitude (deg): 142.4895
     latitude (deg): -37.1851
     elevation (m): .na.real
     notes: ''
-    PerSlope: 24.0
-    aspect: 319.159667
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 24.0
+    slope aspect (degrees): 319.159667
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   Book:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   campground:
     longitude (deg): 142.522362
     latitude (deg): -37.130881
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   CGS1:
     longitude (deg): 142.3645
     latitude (deg): -37.572
     elevation (m): .na.real
     notes: ''
-    PerSlope: 38.0
-    aspect: 25.920322
-    Soil Depth class: 10.0
-    Rock cover %: 90.0
-    Soil Type: sandy loam
+    slope angle (degrees): 38.0
+    slope aspect (degrees): 25.920322
+    soil depth class: 10.0
+    rock cover (%): 90.0
+    soil type: sandy loam
   CGS7:
     longitude (deg): 142.3673
     latitude (deg): -37.5679
     elevation (m): .na.real
     notes: ''
-    PerSlope: 14.0
-    aspect: 98.673606
-    Soil Depth class: 20.0
-    Rock cover %: 10.0
-    Soil Type: sandy loam
+    slope angle (degrees): 14.0
+    slope aspect (degrees): 98.673606
+    soil depth class: 20.0
+    rock cover (%): 10.0
+    soil type: sandy loam
   COPR:
     longitude (deg): 142.4123
     latitude (deg): -36.9254
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   COPR2:
     longitude (deg): 142.4115
     latitude (deg): -36.9259
     elevation (m): .na.real
     notes: ''
-    PerSlope: 7.0
-    aspect: 345.383209
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy loam
+    slope angle (degrees): 7.0
+    slope aspect (degrees): 345.383209
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy loam
   COPR3:
     longitude (deg): 142.4112
     latitude (deg): -36.9264
     elevation (m): .na.real
     notes: ''
-    PerSlope: 6.0
-    aspect: 342.044616
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 6.0
+    slope aspect (degrees): 342.044616
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay loam
   D5:
     longitude (deg): 142.4593
     latitude (deg): -37.4361
     elevation (m): .na.real
     notes: ''
-    PerSlope: 10.0
-    aspect: 114.448524
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 10.0
+    slope aspect (degrees): 114.448524
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay loam
   DC1:
     longitude (deg): 142.4113
     latitude (deg): -37.1779
     elevation (m): .na.real
     notes: ''
-    PerSlope: 1.0
-    aspect: 358.024566
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 1.0
+    slope aspect (degrees): 358.024566
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay loam
   DC5:
     longitude (deg): 142.4593
     latitude (deg): -37.4361
     elevation (m): .na.real
     notes: ''
-    PerSlope: 2.0
-    aspect: 346.457702
-    Soil Depth class: 100.0
-    Rock cover %: 5.0
-    Soil Type: sandy loam
+    slope angle (degrees): 2.0
+    slope aspect (degrees): 346.457702
+    soil depth class: 100.0
+    rock cover (%): 5.0
+    soil type: sandy loam
   DC6:
     longitude (deg): 142.4016
     latitude (deg): -37.2888
     elevation (m): .na.real
     notes: ''
-    PerSlope: 2.0
-    aspect: 297.584136
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 2.0
+    slope aspect (degrees): 297.584136
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay loam
   E4:
     longitude (deg): 142.4964667
     latitude (deg): -37.3559
     elevation (m): .na.real
     notes: ''
-    PerSlope: 63.0
-    aspect: 95.72071
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 63.0
+    slope aspect (degrees): 95.72071
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   GBOR3:
     longitude (deg): 142.502
     latitude (deg): -37.0816
     elevation (m): .na.real
     notes: ''
-    PerSlope: 27.0
-    aspect: 94.022277
-    Soil Depth class: 25.0
-    Rock cover %: 20.0
-    Soil Type: sandy loam
+    slope angle (degrees): 27.0
+    slope aspect (degrees): 94.022277
+    soil depth class: 25.0
+    rock cover (%): 20.0
+    soil type: sandy loam
   GGLE1:
     longitude (deg): 142.4398
     latitude (deg): -37.1515
     elevation (m): .na.real
     notes: ''
-    PerSlope: 14.0
-    aspect: 171.878189
-    Soil Depth class: 25.0
-    Rock cover %: 0.0
-    Soil Type: sandy loam
+    slope angle (degrees): 14.0
+    slope aspect (degrees): 171.878189
+    soil depth class: 25.0
+    rock cover (%): 0.0
+    soil type: sandy loam
   GGOR1:
     longitude (deg): 142.4257
     latitude (deg): -36.926
     elevation (m): .na.real
     notes: ''
-    PerSlope: 8.0
-    aspect: 76.200698
-    Soil Depth class: 10.0
-    Rock cover %: 90.0
-    Soil Type: loamy sand
+    slope angle (degrees): 8.0
+    slope aspect (degrees): 76.200698
+    soil depth class: 10.0
+    rock cover (%): 90.0
+    soil type: loamy sand
   GGOR4:
     longitude (deg): 142.4266
     latitude (deg): -36.9254
     elevation (m): .na.real
     notes: ''
-    PerSlope: 7.0
-    aspect: 54.149986
-    Soil Depth class: 15.0
-    Rock cover %: 75.0
-    Soil Type: loamy sand
+    slope angle (degrees): 7.0
+    slope aspect (degrees): 54.149986
+    soil depth class: 15.0
+    rock cover (%): 75.0
+    soil type: loamy sand
   GHAM1:
     longitude (deg): 142.5012
     latitude (deg): -37.2737
     elevation (m): .na.real
     notes: ''
-    PerSlope: 24.0
-    aspect: 199.107589
-    Soil Depth class: 10.0
-    Rock cover %: 95.0
-    Soil Type: sandy loam
+    slope angle (degrees): 24.0
+    slope aspect (degrees): 199.107589
+    soil depth class: 10.0
+    rock cover (%): 95.0
+    soil type: sandy loam
   GHAM3:
     longitude (deg): 142.5001
     latitude (deg): -37.2738
     elevation (m): .na.real
     notes: ''
-    PerSlope: 45.0
-    aspect: 238.388717
-    Soil Depth class: 15.0
-    Rock cover %: 90.0
-    Soil Type: sandy loam
+    slope angle (degrees): 45.0
+    slope aspect (degrees): 238.388717
+    soil depth class: 15.0
+    rock cover (%): 90.0
+    soil type: sandy loam
   GHAM5:
     longitude (deg): 142.498
     latitude (deg): -37.2739
     elevation (m): .na.real
     notes: ''
-    PerSlope: 43.0
-    aspect: 323.812591
-    Soil Depth class: 15.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 43.0
+    slope aspect (degrees): 323.812591
+    soil depth class: 15.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   GHEN1:
     longitude (deg): 142.4833
     latitude (deg): -37.3001
     elevation (m): .na.real
     notes: ''
-    PerSlope: 13.0
-    aspect: 260.920104
-    Soil Depth class: 25.0
-    Rock cover %: 5.0
-    Soil Type: loamy sand
+    slope angle (degrees): 13.0
+    slope aspect (degrees): 260.920104
+    soil depth class: 25.0
+    rock cover (%): 5.0
+    soil type: loamy sand
   GHEN7:
     longitude (deg): 142.4931
     latitude (deg): -37.2802
     elevation (m): .na.real
     notes: ''
-    PerSlope: 5.0
-    aspect: 223.921188
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 5.0
+    slope aspect (degrees): 223.921188
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GHOR1:
     longitude (deg): 142.4607
     latitude (deg): -37.2531
     elevation (m): .na.real
     notes: ''
-    PerSlope: 2.0
-    aspect: 204.996292
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 2.0
+    slope aspect (degrees): 204.996292
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GHUM1:
     longitude (deg): 142.3772
     latitude (deg): -37.3102
     elevation (m): .na.real
     notes: ''
-    PerSlope: 35.0
-    aspect: 40.359596
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 35.0
+    slope aspect (degrees): 40.359596
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   GHUM10:
     longitude (deg): 142.3724
     latitude (deg): -37.3087
     elevation (m): .na.real
     notes: ''
-    PerSlope: 14.0
-    aspect: 321.391632
-    Soil Depth class: 25.0
-    Rock cover %: 0.0
-    Soil Type: sandy loam
+    slope angle (degrees): 14.0
+    slope aspect (degrees): 321.391632
+    soil depth class: 25.0
+    rock cover (%): 0.0
+    soil type: sandy loam
   GHUM2:
     longitude (deg): 142.3766
     latitude (deg): -37.31
     elevation (m): .na.real
     notes: ''
-    PerSlope: 31.0
-    aspect: 356.028594
-    Soil Depth class: 5.0
-    Rock cover %: 95.0
-    Soil Type: sandy loam
+    slope angle (degrees): 31.0
+    slope aspect (degrees): 356.028594
+    soil depth class: 5.0
+    rock cover (%): 95.0
+    soil type: sandy loam
   GHUM5:
     longitude (deg): 142.375
     latitude (deg): -37.3096
     elevation (m): .na.real
     notes: ''
-    PerSlope: 28.0
-    aspect: 345.626831
-    Soil Depth class: 15.0
-    Rock cover %: 70.0
-    Soil Type: sandy loam
+    slope angle (degrees): 28.0
+    slope aspect (degrees): 345.626831
+    soil depth class: 15.0
+    rock cover (%): 70.0
+    soil type: sandy loam
   GHUM6:
     longitude (deg): 142.375
     latitude (deg): -37.3096
     elevation (m): .na.real
     notes: ''
-    PerSlope: 28.0
-    aspect: 345.626831
-    Soil Depth class: 70.0
-    Rock cover %: 40.0
-    Soil Type: sandy loam
+    slope angle (degrees): 28.0
+    slope aspect (degrees): 345.626831
+    soil depth class: 70.0
+    rock cover (%): 40.0
+    soil type: sandy loam
   GLEN1:
     longitude (deg): 142.4053
     latitude (deg): -37.2319
     elevation (m): .na.real
     notes: ''
-    PerSlope: 0.0
-    aspect: 232.232772
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 0.0
+    slope aspect (degrees): 232.232772
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GLSB1:
     longitude (deg): 142.4164
     latitude (deg): -37.2045
     elevation (m): .na.real
     notes: ''
-    PerSlope: 3.0
-    aspect: 213.235137
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 3.0
+    slope aspect (degrees): 213.235137
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GMNT1:
     longitude (deg): 142.5191
     latitude (deg): -37.3285
     elevation (m): .na.real
     notes: ''
-    PerSlope: 4.0
-    aspect: 275.87149
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy loam
+    slope angle (degrees): 4.0
+    slope aspect (degrees): 275.87149
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy loam
   GMOR1:
     longitude (deg): 142.4145
     latitude (deg): -37.1846
     elevation (m): .na.real
     notes: ''
-    PerSlope: 4.0
-    aspect: 339.348236
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 4.0
+    slope aspect (degrees): 339.348236
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GMOR3:
     longitude (deg): 142.414
     latitude (deg): -37.1835
     elevation (m): .na.real
     notes: ''
-    PerSlope: 2.0
-    aspect: 359.178527
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 2.0
+    slope aspect (degrees): 359.178527
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   GMTW1:
     longitude (deg): 142.5984
     latitude (deg): -37.3086
     elevation (m): .na.real
     notes: ''
-    PerSlope: 8.0
-    aspect: 8.65255
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 8.0
+    slope aspect (degrees): 8.65255
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   gold:
     longitude (deg): 142.55845
     latitude (deg): -37.328133
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Grampians National Park:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon; sites with location 'NA'
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Grampians multisite max:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon; max height measurements across sites
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   GRIFFITH:
     longitude (deg): 142.241769
     latitude (deg): -37.401557
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   GRIN2:
     longitude (deg): 142.3999
     latitude (deg): -37.4906
     elevation (m): .na.real
     notes: ''
-    PerSlope: 45.0
-    aspect: 258.616546
-    Soil Depth class: 5.0
-    Rock cover %: 85.0
-    Soil Type: sandy loam
+    slope angle (degrees): 45.0
+    slope aspect (degrees): 258.616546
+    soil depth class: 5.0
+    rock cover (%): 85.0
+    soil type: sandy loam
   GROC1:
     longitude (deg): 142.4855
     latitude (deg): -37.014
     elevation (m): .na.real
     notes: ''
-    PerSlope: 44.0
-    aspect: 29.499303
-    Soil Depth class: 25.0
-    Rock cover %: 90.0
-    Soil Type: loamy sand
+    slope angle (degrees): 44.0
+    slope aspect (degrees): 29.499303
+    soil depth class: 25.0
+    rock cover (%): 90.0
+    soil type: loamy sand
   GVICA:
     longitude (deg): 142.344792
     latitude (deg): -37.276878
     elevation (m): .na.real
     notes: ''
-    PerSlope: 53.0
-    aspect: 22.588748
-    Soil Depth class: 5.0
-    Rock cover %: 95.0
-    Soil Type: loamy sand
+    slope angle (degrees): 53.0
+    slope aspect (degrees): 22.588748
+    soil depth class: 5.0
+    rock cover (%): 95.0
+    soil type: loamy sand
   GWOND1:
     longitude (deg): 142.5147
     latitude (deg): -37.1606
     elevation (m): .na.real
     notes: ''
-    PerSlope: 3.0
-    aspect: 42.168235
-    Soil Depth class: 10.0
-    Rock cover %: 90.0
-    Soil Type: sandy loam
+    slope angle (degrees): 3.0
+    slope aspect (degrees): 42.168235
+    soil depth class: 10.0
+    rock cover (%): 90.0
+    soil type: sandy loam
   HGAP:
     longitude (deg): 142.544549
     latitude (deg): -37.189412
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   LaGhn:
     longitude (deg): 142.426446
     latitude (deg): -36.917014
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   LAKE:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Lake1:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Lake2:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Lake3:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Lake4:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Lake5:
     longitude (deg): 142.547808
     latitude (deg): -37.212438
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   LANG stop2:
     longitude (deg): 142.521443
     latitude (deg): -37.316286
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   M GapIntermediate:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   M Gappost fire:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MainRD:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGAP:
     longitude (deg): 142.4581
     latitude (deg): -37.4228
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGAP B:
     longitude (deg): 142.4581
     latitude (deg): -37.4228
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGAP T1:
     longitude (deg): 142.4581
     latitude (deg): -37.4228
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGAPbottom:
     longitude (deg): 142.4581
     latitude (deg): -37.4228
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGN1:
     longitude (deg): 142.459
     latitude (deg): -37.4224
     elevation (m): .na.real
     notes: ''
-    PerSlope: 40.0
-    aspect: 275.410125
-    Soil Depth class: 15.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 40.0
+    slope aspect (degrees): 275.410125
+    soil depth class: 15.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   MGN12:
     longitude (deg): 142.4574
     latitude (deg): -37.4269
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MGN2:
     longitude (deg): 142.4587
     latitude (deg): -37.4224
     elevation (m): .na.real
     notes: ''
-    PerSlope: 41.0
-    aspect: 84.757019
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 41.0
+    slope aspect (degrees): 84.757019
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   MGN3:
     longitude (deg): 142.4581
     latitude (deg): -37.4228
     elevation (m): .na.real
     notes: ''
-    PerSlope: 43.0
-    aspect: 346.013092
-    Soil Depth class: 20.0
-    Rock cover %: 40.0
-    Soil Type: sandy loam
+    slope angle (degrees): 43.0
+    slope aspect (degrees): 346.013092
+    soil depth class: 20.0
+    rock cover (%): 40.0
+    soil type: sandy loam
   MGN4:
     longitude (deg): 142.4578
     latitude (deg): -37.4236
     elevation (m): .na.real
     notes: ''
-    PerSlope: 38.0
-    aspect: 325.207336
-    Soil Depth class: 20.0
-    Rock cover %: 20.0
-    Soil Type: sandy loam
+    slope angle (degrees): 38.0
+    slope aspect (degrees): 325.207336
+    soil depth class: 20.0
+    rock cover (%): 20.0
+    soil type: sandy loam
   MGN5:
     longitude (deg): 142.4577
     latitude (deg): -37.4244
     elevation (m): .na.real
     notes: ''
-    PerSlope: 29.0
-    aspect: 180.90393
-    Soil Depth class: 20.0
-    Rock cover %: 10.0
-    Soil Type: sandy loam
+    slope angle (degrees): 29.0
+    slope aspect (degrees): 180.90393
+    soil depth class: 20.0
+    rock cover (%): 10.0
+    soil type: sandy loam
   MGS1:
     longitude (deg): 142.4574
     latitude (deg): -37.4269
     elevation (m): .na.real
     notes: ''
-    PerSlope: 34.0
-    aspect: 72.355957
-    Soil Depth class: 10.0
-    Rock cover %: 60.0
-    Soil Type: sandy loam
+    slope angle (degrees): 34.0
+    slope aspect (degrees): 72.355957
+    soil depth class: 10.0
+    rock cover (%): 60.0
+    soil type: sandy loam
   MGS2:
     longitude (deg): 142.4584
     latitude (deg): -37.4259
     elevation (m): .na.real
     notes: ''
-    PerSlope: 26.0
-    aspect: 158.983398
-    Soil Depth class: 15.0
-    Rock cover %: 15.0
-    Soil Type: sandy loam
+    slope angle (degrees): 26.0
+    slope aspect (degrees): 158.983398
+    soil depth class: 15.0
+    rock cover (%): 15.0
+    soil type: sandy loam
   MGS3:
     longitude (deg): 142.4574
     latitude (deg): -37.4621
     elevation (m): .na.real
     notes: ''
-    PerSlope: 24.0
-    aspect: 107.280342
-    Soil Depth class: 15.0
-    Rock cover %: 40.0
-    Soil Type: sandy loam
+    slope angle (degrees): 24.0
+    slope aspect (degrees): 107.280342
+    soil depth class: 15.0
+    rock cover (%): 40.0
+    soil type: sandy loam
   MGS4:
     longitude (deg): 142.4577
     latitude (deg): -37.4263
     elevation (m): .na.real
     notes: ''
-    PerSlope: 34.0
-    aspect: 107.280342
-    Soil Depth class: 10.0
-    Rock cover %: 70.0
-    Soil Type: sandy loam
+    slope angle (degrees): 34.0
+    slope aspect (degrees): 107.280342
+    soil depth class: 10.0
+    rock cover (%): 70.0
+    soil type: sandy loam
   MGS5:
     longitude (deg): 142.4574
     latitude (deg): -37.4269
     elevation (m): .na.real
     notes: ''
-    PerSlope: 30.0
-    aspect: 72.355957
-    Soil Depth class: 10.0
-    Rock cover %: 75.0
-    Soil Type: sandy loam
+    slope angle (degrees): 30.0
+    slope aspect (degrees): 72.355957
+    soil depth class: 10.0
+    rock cover (%): 75.0
+    soil type: sandy loam
   MT DIF:
     longitude (deg): 142.435565
     latitude (deg): -37.017898
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL1:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL2:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL3:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL4:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT HOL5:
     longitude (deg): 142.381343
     latitude (deg): -36.887848
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT LUB:
     longitude (deg): 142.511743
     latitude (deg): -37.269657
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT LUB summit:
     longitude (deg): 142.511743
     latitude (deg): -37.269657
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT THACK:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT ZERO:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT ZERO Trip 1:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT_TH1:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT_TH2:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MT_TH3:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   MTA1:
     longitude (deg): 142.3565
     latitude (deg): -37.5926
     elevation (m): .na.real
     notes: ''
-    PerSlope: 54.0
-    aspect: 74.53469
-    Soil Depth class: 10.0
-    Rock cover %: 40.0
-    Soil Type: sandy loam
+    slope angle (degrees): 54.0
+    slope aspect (degrees): 74.53469
+    soil depth class: 10.0
+    rock cover (%): 40.0
+    soil type: sandy loam
   MTA2:
     longitude (deg): 142.3564
     latitude (deg): -37.5925
     elevation (m): .na.real
     notes: ''
-    PerSlope: 29.0
-    aspect: 73.880714
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 29.0
+    slope aspect (degrees): 73.880714
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   MTA3:
     longitude (deg): 142.3565
     latitude (deg): -37.5923
     elevation (m): .na.real
     notes: ''
-    PerSlope: 26.0
-    aspect: 68.656532
-    Soil Depth class: 5.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 26.0
+    slope aspect (degrees): 68.656532
+    soil depth class: 5.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   MTA4:
     longitude (deg): 142.3565
     latitude (deg): -37.5923
     elevation (m): .na.real
     notes: ''
-    PerSlope: 29.0
-    aspect: 68.656532
-    Soil Depth class: 10.0
-    Rock cover %: 80.0
-    Soil Type: sandy loam
+    slope angle (degrees): 29.0
+    slope aspect (degrees): 68.656532
+    soil depth class: 10.0
+    rock cover (%): 80.0
+    soil type: sandy loam
   MtLub_Stop2:
     longitude (deg): 142.511743
     latitude (deg): -37.269657
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   N of LANG:
     longitude (deg): 142.521443
     latitude (deg): -37.316286
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Phillip's Island Tk:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   PIN_0.5:
     longitude (deg): 142.514331
     latitude (deg): -37.160098
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Q13:
     longitude (deg): 142.3858
     latitude (deg): -37.47935
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Q7:
     longitude (deg): 142.42393
     latitude (deg): -37.44278
     elevation (m): .na.real
     notes: ''
-    PerSlope: 21.0
-    aspect: 302.321228
-    Soil Depth class: 100.0
-    Rock cover %: 50.0
-    Soil Type: sandy loam
+    slope angle (degrees): 21.0
+    slope aspect (degrees): 302.321228
+    soil depth class: 100.0
+    rock cover (%): 50.0
+    soil type: sandy loam
   Reeds lookout:
     longitude (deg): 142.447647
     latitude (deg): -37.148007
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   ROS1:
     longitude (deg): 142.5065
     latitude (deg): -37.197
     elevation (m): .na.real
     notes: ''
-    PerSlope: 20.0
-    aspect: 20.516403
-    Soil Depth class: 10.0
-    Rock cover %: 95.0
-    Soil Type: sandy loam
+    slope angle (degrees): 20.0
+    slope aspect (degrees): 20.516403
+    soil depth class: 10.0
+    rock cover (%): 95.0
+    soil type: sandy loam
   Rosea Ldg:
     longitude (deg): 142.518972
     latitude (deg): -37.148174
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   S25:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Site M:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE21:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE22:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE23:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE24:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE25:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE26:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE27:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   SITE28:
     longitude (deg): 142.481762
     latitude (deg): -37.417372
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   STOP1:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   STOP11:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   STOP20:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   STOP3:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   T1:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   TBGecotone:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   TBGN2:
     longitude (deg): 142.4965
     latitude (deg): -37.3559
     elevation (m): .na.real
     notes: ''
-    PerSlope: 45.0
-    aspect: 95.72071
-    Soil Depth class: 15.0
-    Rock cover %: 70.0
-    Soil Type: sandy loam
+    slope angle (degrees): 45.0
+    slope aspect (degrees): 95.72071
+    soil depth class: 15.0
+    rock cover (%): 70.0
+    soil type: sandy loam
   THAK:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   THAK1:
     longitude (deg): 142.3295
     latitude (deg): -37.2916
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   TOP:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Trip1:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   VIC RANGE:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   VV:
     longitude (deg): 142.4223
     latitude (deg): -37.2581
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   VV1:
     longitude (deg): 142.4223
     latitude (deg): -37.2581
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   VVrd:
     longitude (deg): 142.4211
     latitude (deg): -37.2586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   X2:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   xr:
     longitude (deg): 142.4448611
     latitude (deg): -37.26125
     elevation (m): .na.real
     notes: generic Grampians lat/lon
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   Z10:
     longitude (deg): 142.4737
     latitude (deg): -37.3468
     elevation (m): .na.real
     notes: ''
-    PerSlope: 3.0
-    aspect: 310.879089
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay loam
+    slope angle (degrees): 3.0
+    slope aspect (degrees): 310.879089
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay loam
   Z21:
     longitude (deg): 142.4304
     latitude (deg): -37.2138
     elevation (m): .na.real
     notes: ''
-    PerSlope: 4.0
-    aspect: 239.744659
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy clay
+    slope angle (degrees): 4.0
+    slope aspect (degrees): 239.744659
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy clay
   Z31:
     longitude (deg): 142.5164
     latitude (deg): -37.3726
     elevation (m): .na.real
     notes: ''
-    PerSlope: 6.0
-    aspect: 184.019531
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: loamy sand
+    slope angle (degrees): 6.0
+    slope aspect (degrees): 184.019531
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: loamy sand
   Z5:
     longitude (deg): 142.3819
     latitude (deg): -37.1524
     elevation (m): .na.real
     notes: ''
-    PerSlope: 18.0
-    aspect: 180.550582
-    Soil Depth class: 100.0
-    Rock cover %: 0.0
-    Soil Type: sandy loam
+    slope angle (degrees): 18.0
+    slope aspect (degrees): 180.550582
+    soil depth class: 100.0
+    rock cover (%): 0.0
+    soil type: sandy loam
   ZER6:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   ZERO:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   ZERO10:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
   ZEROT1:
     longitude (deg): 142.370096
     latitude (deg): -36.885586
     elevation (m): .na.real
     notes: ''
-    PerSlope: .na.real
-    aspect: .na.real
-    Soil Depth class: .na.real
-    Rock cover %: .na.real
-    Soil Type: .na.character
+    slope angle (degrees): .na.real
+    slope aspect (degrees): .na.real
+    soil depth class: .na.real
+    rock cover (%): .na.real
+    soil type: .na.character
 contexts: .na
 config:
   data_is_long_format: no
@@ -1548,4 +1548,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: seed mass total, bark mass, stem volume, stem mass
-

--- a/data/Pollock_2018/metadata.yml
+++ b/data/Pollock_2018/metadata.yml
@@ -82,92 +82,92 @@ dataset:
   notes: .na
 sites:
   Boinka FFG:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Boinka FFG
     latitude (deg): -35.197892
     longitude (deg): 141.603043
   Crest Top:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.459908
     longitude (deg): 141.071919
   Dodgeshuns Rd:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: (not from a park)
     latitude (deg): -35.675311
     longitude (deg): 142.403068
   GS:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.582726
     longitude (deg): 141.754173
   Hattah:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Hattah-Kulkyne
     latitude (deg): -34.725953
     longitude (deg): 142.343272
   Hopepatch:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: (not from a park)
     latitude (deg): -35.506313
     longitude (deg): 142.293744
   Little Desert N:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Little Desert
     latitude (deg): -36.560832
     longitude (deg): 141.651596
   M08501:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.545508
     longitude (deg): 141.497328
   M08502:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.545508
     longitude (deg): 141.497328
   M0901:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.622469
     longitude (deg): 141.49771
   Mitre Rock:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Mount Arapiles
     latitude (deg): -36.763193
     longitude (deg): 141.818717
   Murrayville S Rd:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: (not from a park)
     latitude (deg): -35.286745
     longitude (deg): 141.337376
   No label:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.601152
     longitude (deg): 141.140784
   Old Growth:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.634473
     longitude (deg): 141.581899
   Shearer Quarters:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: Murray-Sunset
     latitude (deg): -34.563747
     longitude (deg): 141.07074
   Werners Rd:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: (not from a park)
     latitude (deg): -36.182621
     longitude (deg): 141.448254
   Unknown:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: ''
     latitude (deg): ''
     longitude (deg): ''
   multisite_mean:
-    collector: L.J. Pollock
+    recorded by: L.J. Pollock
     description: maximum plant height value across sites
     latitude (deg): ''
     longitude (deg): ''
@@ -262,4 +262,3 @@ taxonomic_updates:
   reason: Align to species by D Falster (2020-05-22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Prior_2016/metadata.yml
+++ b/data/Prior_2016/metadata.yml
@@ -46,7 +46,7 @@ sites:
     latitude (deg): -41.76
     longitude (deg): 147.35
     description: woodland and open forest
-    details: study sites were at an elevation of between 177 and 256 m, with a slope
+    notes: study sites were at an elevation of between 177 and 256 m, with a slope
       of <5 deg
 contexts: .na
 config:
@@ -96,4 +96,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Read_2005/metadata.yml
+++ b/data/Read_2005/metadata.yml
@@ -69,29 +69,29 @@ sites:
   Tutanning Nature Reserve on dolerite soils:
     latitude (deg): -32.55399
     longitude (deg): 117.335394
-    MAP (mm): 448
-    total N (%): 0.22
-    total P (mg/kg): 330
+    precipitation, MAP (mm): 448
+    soil N, total (%): 0.22
+    soil P, total (mg/kg): 330
     soil morphology: dark reddish brown loam
-    mean daily maximum temperature (degrees): 23.1
+    temperature, mean daily max (C): 23.1
     description: woodland dominated by Eucalyptus and/or Allocasuarina
   Tutanning Nature Reserve on laterite soils:
     latitude (deg): -32.55399
     longitude (deg): 117.335394
-    MAP (mm): 448
-    total N (%): 0.14
-    total P (mg/kg): 124
+    precipitation, MAP (mm): 448
+    soil N, total (%): 0.14
+    soil P, total (mg/kg): 124
     soil morphology: yellowish brown loamy sand to loam
-    mean daily maximum temperature (degrees): 23.1
+    temperature, mean daily max (C): 23.1
     description: shrublands dominated by Proteaceae
   Tutanning Nature Reserve on grey sand soils:
     latitude (deg): -32.55399
     longitude (deg): 117.335394
-    MAP (mm): 448
-    total N (%): 0.01
-    total P (mg/kg): 54
+    precipitation, MAP (mm): 448
+    soil N, total (%): 0.01
+    soil P, total (mg/kg): 54
     soil morphology: light gray sand
-    mean daily maximum temperature (degrees): 23.1
+    temperature, mean daily max (C): 23.1
     description: shrublands dominated by Myrtaceae, Proteaceae and Fabaceae
 contexts: .na
 config:
@@ -204,4 +204,3 @@ substitutions:
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Richards_2003/metadata.yml
+++ b/data/Richards_2003/metadata.yml
@@ -50,33 +50,33 @@ sites:
     longitude (deg): 145.433
     latitude (deg): -16.133
     description: Lowland tropical rainforest, Daintree National Park; creek edge
-    MAP (mm): 2009
+    precipitation, MAP (mm): 2009
     elevation (m): 5
   daintree_river_valley_flats:
     longitude (deg): 145.433
     latitude (deg): -16.133
     description: Lowland tropical rainforest, Daintree National Park; river valley
       flats
-    MAP (mm): 2009
+    precipitation, MAP (mm): 2009
     elevation (m): 20
   daintree_flats_above_creek:
     longitude (deg): 145.633
     latitude (deg): -17.283
     description: Tropical rainforest, Lake Eacham National Park; flats above creeks
-    MAP (mm): 1413
+    precipitation, MAP (mm): 1413
     elevation (m): 600
   daintree_creek_canopy_gap:
     longitude (deg): 145.433
     latitude (deg): -16.1
     description: Lowland tropical rainforest, Daintree National Park; canopy gaps
       on creek flats and hillsides
-    MAP (mm): 2009
+    precipitation, MAP (mm): 2009
     elevation (m): 190
   daintree_creek_edge2:
     longitude (deg): 145.4
     latitude (deg): -16.167
     description: Lowland tropical rainforest, Daintree National Park; creek edge
-    MAP (mm): 2009
+    precipitation, MAP (mm): 2009
     elevation (m): 80
 contexts: .na
 config:
@@ -381,4 +381,3 @@ substitutions:
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Richards_2008/metadata.yml
+++ b/data/Richards_2008/metadata.yml
@@ -244,7 +244,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): 1750.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Adams_1984
+    georeference remarks: Adams_1984
     soil type: dark reddish brown sandy loam A horizon, grading to a red clay loam
       B horizon and red light clay C horizon
     soil pH: 5-5.5
@@ -257,7 +257,7 @@ sites:
     description: spar and pole stage forests
     precipitation, MAP (mm): 1300.0
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Wallaby Creek at Road 4
+    georeference remarks: AusTraits, Wallaby Creek at Road 4
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -269,7 +269,7 @@ sites:
     description: tall open Eucalyptus forest
     precipitation, MAP (mm): 1400.0
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    georeference remarks: AusTraits, Tomahawk Gap on east Beenak Road
     soil type: range from krasnozems to red podzolic soils
     soil pH: 5.0-5.6
     geology (parent material): Upper Devonian granite
@@ -281,7 +281,7 @@ sites:
     description: Nothofagus closed forest
     precipitation, MAP (mm): 1400.0
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    georeference remarks: AusTraits, Tomahawk Gap on east Beenak Road
     soil type: vary from colluvial brown loams with water tables at 50-60 cm depth
       to alluvial humic gravels with water tables at or close to the surface for most
       of the y
@@ -295,7 +295,7 @@ sites:
     description: tall open Eucalyptus forest
     precipitation, MAP (mm): 1400.0
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    georeference remarks: AusTraits, Tomahawk Gap on east Beenak Road
     soil type: the krasnozem
     soil pH: 5.0-5.6
     geology (parent material): Upper Devonian granite
@@ -307,7 +307,7 @@ sites:
     description: plantation
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Mount Disappointment summit
+    georeference remarks: AusTraits, Mount Disappointment summit
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -319,7 +319,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -331,7 +331,7 @@ sites:
     description: calcareous dunes
     precipitation, MAP (mm): 1000.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Bennett_1996
+    georeference remarks: Bennett_1996
     soil type: calcareous dunes are uniform sands which vary according to the phase
       of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
@@ -345,7 +345,7 @@ sites:
     description: calcareous dunes
     precipitation, MAP (mm): 1000.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Bennett_1996
+    georeference remarks: Bennett_1996
     soil type: calcareous dunes are uniform sands which vary according to the phase
       of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
@@ -359,7 +359,7 @@ sites:
     description: calcareous dunes
     precipitation, MAP (mm): 1000.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Bennett_1996
+    georeference remarks: Bennett_1996
     soil type: calcareous dunes are uniform sands which vary according to the phase
       of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
@@ -373,7 +373,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -385,7 +385,7 @@ sites:
     description: plantation
     precipitation, MAP (mm): 1500.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Birk_1992
+    georeference remarks: Birk_1992
     soil type: Shallow (< 70 cm) brown earth soils were typical of the upper slope
       positions but changed to deep (> 2 m) red earths on the lower slopes
     soil pH: .na.character
@@ -399,7 +399,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -412,7 +412,7 @@ sites:
       species
     precipitation, MAP (mm): 1200.0
     temperature, MAT (C): 15.5
-    lat/lon notes: Feller_1980
+    georeference remarks: Feller_1980
     soil type: intermediate between krasnozems and podzolics designated as Gn 4.54
     soil pH: .na.character
     geology (parent material): quartz-biotite-dacite
@@ -425,7 +425,7 @@ sites:
       closed canopy and shrub understory
     precipitation, MAP (mm): 1660.0
     temperature, MAT (C): 10.7
-    lat/lon notes: Feller_1980
+    georeference remarks: Feller_1980
     soil type: krasnozem designated Gn 4.31
     soil pH: .na.character
     geology (parent material): igneous quartz-dacite with more biotite
@@ -437,7 +437,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -449,7 +449,7 @@ sites:
     description: uneven-aged sclerophyll forest 28-40 m tall
     precipitation, MAP (mm): 927.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Hopmans_1993
+    georeference remarks: Hopmans_1993
     soil type: yellow podzolic with a hard-setting loamy A horizon and a mottled yellow
       clayey B horizon
     soil pH: .na.character
@@ -462,7 +462,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -474,7 +474,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -486,7 +486,7 @@ sites:
     description: plantation with seeds from Coffs Harbour
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Leuning_1991
+    georeference remarks: Leuning_1991
     soil type: highly weathered and low in plant nutrients, particularly nitrogen,
       phosphorus, calcium and potassium
     soil pH: .na.character
@@ -500,7 +500,7 @@ sites:
       species
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Marsh_1995
+    georeference remarks: Marsh_1995
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -512,7 +512,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -524,7 +524,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -536,7 +536,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -548,7 +548,7 @@ sites:
     description: virgin, mature brigalow forest
     precipitation, MAP (mm): 560.0
     temperature, MAT (C): .na.real
-    lat/lon notes: Moore_1967
+    georeference remarks: Moore_1967
     soil type: gilgaied deep clay
     soil pH: .na.character
     geology (parent material): .na.character
@@ -561,7 +561,7 @@ sites:
       an uneven canopy height of 25-40 m
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: derived from basalt
     soil pH: .na.character
     geology (parent material): basalt
@@ -573,7 +573,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -585,7 +585,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -597,7 +597,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -609,7 +609,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -621,7 +621,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -633,7 +633,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -645,7 +645,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -657,7 +657,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -669,7 +669,7 @@ sites:
     description: Eucalyptus-dominated
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Soper_2014
+    georeference remarks: Soper_2014
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -681,7 +681,7 @@ sites:
     description: .na.character
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Soper_2014
+    georeference remarks: Soper_2014
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -693,7 +693,7 @@ sites:
     description: Acacia-dominated mulga woodland
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Soper_2014
+    georeference remarks: Soper_2014
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -705,7 +705,7 @@ sites:
     description: dominated by either Acacia or Eucalyptus
     precipitation, MAP (mm): .na.real
     temperature, MAT (C): .na.real
-    lat/lon notes: Soper_2014
+    georeference remarks: Soper_2014
     soil type: .na.character
     soil pH: .na.character
     geology (parent material): .na.character
@@ -717,7 +717,7 @@ sites:
     description: plantation where there was once subtropical rainforest
     precipitation, MAP (mm): 1760.0
     temperature, MAT (C): .na.real
-    lat/lon notes: AusTraits, Conglomerate State Forest location from GoogleEarth
+    georeference remarks: AusTraits, Conglomerate State Forest location from GoogleEarth
     soil type: derived from Lower Permian sediments with moderate to high fertility.
     soil pH: .na.character
     geology (parent material): Lower Permian sediments

--- a/data/Richards_2008/metadata.yml
+++ b/data/Richards_2008/metadata.yml
@@ -237,7 +237,6 @@ dataset:
   notes: none
 sites:
   Adams_1984_Big Creek Basin:
-    site_name_Richards: Adams1984_BigCkBasin
     latitude (deg): -37.867
     longitude (deg): 145.75
     description: .na.character
@@ -251,7 +250,6 @@ sites:
     elevation (m): '400'
     soil total P: .na.character
   Ashton_1975_Wallaby Creek:
-    site_name_Richards: Ashton1975_WallabyCk
     latitude (deg): -37.41
     longitude (deg): 145.226
     description: spar and pole stage forests
@@ -264,7 +262,6 @@ sites:
     elevation (m): 670-700
     soil total P: .na.character
   Ashton_1976_dry sclerophyll:
-    site_name_Richards: Ahton1976_DrySclerophyll
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: tall open Eucalyptus forest
@@ -277,7 +274,6 @@ sites:
     elevation (m): 500-550
     soil total P: '1'
   Ashton_1976_rainforest:
-    site_name_Richards: Ahton1976_Rainforest
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: Nothofagus closed forest
@@ -291,7 +287,6 @@ sites:
     elevation (m): 500-550
     soil total P: '2.2'
   Ashton_1976_wet sclerophyll:
-    site_name_Richards: Ahton1976_WetSclerophyll
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: tall open Eucalyptus forest
@@ -304,7 +299,6 @@ sites:
     elevation (m): 500-550
     soil total P: '1.8'
   Attiwill_1980_Mt Disappointment:
-    site_name_Richards: Attiwill1980_MtDisappointment
     latitude (deg): -37.426
     longitude (deg): 145.136
     description: plantation
@@ -317,7 +311,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Bell_1985_Weipa:
-    site_name_Richards: Bell1985_Weipa
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -330,7 +323,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Bennett_1996_Yanakie_Uc1.11:
-    site_name_Richards: Bennett1996_Yanakie
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
@@ -345,7 +337,6 @@ sites:
     elevation (m): 0-70
     soil total P: '12'
   Bennett_1996_Yanakie_Uc1.23_pH6:
-    site_name_Richards: Bennett1996_Yanakie
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
@@ -360,7 +351,6 @@ sites:
     elevation (m): 0-70
     soil total P: '5.6'
   Bennett_1996_Yanakie_Uc1.23_pH7:
-    site_name_Richards: Bennett1996_Yanakie
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
@@ -375,7 +365,6 @@ sites:
     elevation (m): 0-70
     soil total P: '13.3'
   Bevege_1978_Millmerran:
-    site_name_Richards: BevegeandJohnston1978 _Millmerran
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -388,7 +377,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Birk_1992_Wedding Bells:
-    site_name_Richards: BirkandTurner1992_WeddingBells
     latitude (deg): -30.133
     longitude (deg): 153.117
     description: plantation
@@ -402,7 +390,6 @@ sites:
     elevation (m): 110-140
     soil total P: .na.character
   Cromer_1975_Morwell:
-    site_name_Richards: Cromeretal1975_Morwell
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -415,7 +402,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Feller_1980_Maroondah_EO:
-    site_name_Richards: Feller1980_MaroondahEO
     latitude (deg): -37.633
     longitude (deg): 145.583
     description: "dry sclerophyll or open forest containing several dominant eucalypt
@@ -429,7 +415,6 @@ sites:
     elevation (m): '180'
     soil total P: 5.7-6.0
   Feller_1980_Maroondah_ER:
-    site_name_Richards: Feller1980_MaroondahER
     latitude (deg): -37.633
     longitude (deg): 145.583
     description: wet sclerophyll or tall open forest of Eucalyptus regnans with a
@@ -443,7 +428,6 @@ sites:
     elevation (m): '560'
     soil total P: 4.7-5.0
   Hatch_1955_Dwellingup:
-    site_name_Richards: Hatch1955_Dwellingup
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -456,7 +440,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Hopmans_1993_Maramingo:
-    site_name_Richards: Hopmansetal1993_Maramingo
     latitude (deg): -37.417
     longitude (deg): 149.55
     description: uneven-aged sclerophyll forest 28-40 m tall
@@ -470,7 +453,6 @@ sites:
     elevation (m): '927'
     soil total P: .na.character
   Lambert_1979_Bago State Forest:
-    site_name_Richards: Lambert1979thesis_BagoSF
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -483,7 +465,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Lambert_1979_Lidsdale State Forest:
-    site_name_Richards: Lambert1979thesis_LidsdaleSF
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -496,7 +477,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Leuning_1991_Toolara:
-    site_name_Richards: Leuningetal1991_Toolara
     latitude (deg): -26.2
     longitude (deg): 152.75
     description: plantation with seeds from Coffs Harbour
@@ -510,7 +490,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Marsh_1995_Moormung:
-    site_name_Richards: Marsh&Adams1995_Moormung
     latitude (deg): -37.817
     longitude (deg): 147.63
     description: undisturbed redgum forest with a grassy stratum dominated by Poa
@@ -524,7 +503,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Meakins_0000_Brindabella_1:
-    site_name_Richards: Meakinsunpub_Brindabella1
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -537,7 +515,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Meakins_0000_Brindabella_2:
-    site_name_Richards: Meakinsunpub_Brindabella2
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -550,7 +527,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Meakins_0000_Brindabella_3:
-    site_name_Richards: Meakinsunpub_Brindabella3
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -563,7 +539,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Moore_1967_Meandarra:
-    site_name_Richards: Mooreetal1967_Meandarra
     latitude (deg): -27.283
     longitude (deg): 149.75
     description: virgin, mature brigalow forest
@@ -576,7 +551,6 @@ sites:
     elevation (m): '940'
     soil total P: .na.character
   Pearcy_1987_Curtin_Fig:
-    site_name_Richards: Pearcy1987_CurtinFig
     latitude (deg): -17.0
     longitude (deg): 145.57
     description: complex notophyll vine forest with scattered deciduous trees and
@@ -590,7 +564,6 @@ sites:
     elevation (m): '730'
     soil total P: .na.character
   Richards_2008_2_Hooppine_plantation_25:
-    site_name_Richards: RichardsAustralia_Hooppineplantation25
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -603,7 +576,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_Hooppine_plantation_34:
-    site_name_Richards: RichardsAustralia_Hooppineplantation34
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -616,7 +588,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_Hooppine_plantation_50:
-    site_name_Richards: RichardsAustralia_Hooppineplantation50
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -629,7 +600,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_Hooppine_plantation_63:
-    site_name_Richards: RichardsAustralia_Hooppineplantation63
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -642,7 +612,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_Maleny:
-    site_name_Richards: RichardsAustralia_Maleny
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -655,7 +624,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_North_Queensland_1:
-    site_name_Richards: RichardsAustralia_NorthQueensland1
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -668,7 +636,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_North_Queensland_2:
-    site_name_Richards: RichardsAustralia_NorthQueensland2
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -681,7 +648,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Richards_2008_2_North_Queensland_3:
-    site_name_Richards: RichardsAustralia_NorthQueensland3
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
@@ -694,7 +660,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Schortemeyer_0000_NATT_Berrimah:
-    site_name_Richards: Schortemeyeretalunpub_NATT_Berrimah
     latitude (deg): -12.43389
     longitude (deg): 130.9228
     description: Eucalyptus-dominated
@@ -707,7 +672,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Schortemeyer_0000_NATT_Katherine:
-    site_name_Richards: Schortemeyeretalunpub_NATT_Katherine
     latitude (deg): -14.47306
     longitude (deg): 132.3031
     description: .na.character
@@ -720,7 +684,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Schortemeyer_0000_NATT_Kunoth Paddock:
-    site_name_Richards: Schortemeyeretalunpub_NATT_Kunoth Paddock
     latitude (deg): -23.51694
     longitude (deg): 133.6492
     description: Acacia-dominated mulga woodland
@@ -733,7 +696,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Schortemeyer_0000_NATT_Newcastle Waters:
-    site_name_Richards: Schortemeyeretalunpub_NATT_Newcastle Waters
     latitude (deg): -17.3775
     longitude (deg): 133.4097
     description: dominated by either Acacia or Eucalyptus
@@ -746,7 +708,6 @@ sites:
     elevation (m): .na.character
     soil total P: .na.character
   Turner_1983_Conglomerate:
-    site_name_Richards: TurnerandLambert1983_Conglomerate
     latitude (deg): -30.09
     longitude (deg): 153.07
     description: plantation where there was once subtropical rainforest

--- a/data/Richards_2008/metadata.yml
+++ b/data/Richards_2008/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     year: '2009'
     author: Anna Richards and Ian J. Wright
-    title: "Unpublished data: Transcription of Australian plant functional trait data from Ian Wright's collection of papers, Macquarie University"
+    title: 'Unpublished data: Transcription of Australian plant functional trait data
+      from Ian Wright''s collection of papers, Macquarie University'
   secondary_01:
     key: Adams_1984
     bibtype: Article
@@ -15,7 +16,7 @@ source:
       regnans F. Muell. forests. I. Temporal changes in biomass and nutrient content
     volume: '32'
     number: '2'
-    pages: '205--215'
+    pages: 205--215
     doi: 10.1071/bt9840205
   secondary_02:
     key: Ashton_1975
@@ -26,7 +27,7 @@ source:
     title: Studies of litter in Eucalyptus regnans forests
     volume: '23'
     number: '3'
-    pages: '413--433'
+    pages: 413--433
     doi: 10.1071/bt9750413
   secondary_03:
     key: Ashton_1976
@@ -37,7 +38,7 @@ source:
     title: Phosphorus in Forest Ecosystems at Beenak, Victoria
     volume: '64'
     number: '1'
-    pages: '171--186'
+    pages: 171--186
     doi: 10.2307/2258689
   secondary_04:
     key: Attiwill_1980
@@ -45,10 +46,11 @@ source:
     year: '1980'
     author: P. M. Attiwill
     journal: Australian Journal of Botany
-    title: "Nutrient cycling in a Eucalyptus obliqua (L'Herit.) forest IV: Nutrient uptake and nutrient return"
+    title: 'Nutrient cycling in a Eucalyptus obliqua (L''Herit.) forest IV: Nutrient
+      uptake and nutrient return'
     volume: '28'
     number: '2'
-    pages: '199--222'
+    pages: 199--222
     doi: 10.1071/bt9800199
   secondary_05:
     key: Bell_1985
@@ -70,7 +72,7 @@ source:
       on the Yanakie Isthmus, Victoria
     volume: '45'
     number: '1'
-    pages: '15 - 30'
+    pages: 15 - 30
     doi: 10.1071/bt96025
   secondary_07:
     key: Bevege_1978
@@ -171,7 +173,7 @@ source:
       and nitrogen fractions in sap and foliage'
     volume: '43'
     number: '1'
-    pages: '39--49'
+    pages: 39--49
     doi: 10.1071/bt9950039
   secondary_18:
     key: Meakins_0000
@@ -189,7 +191,7 @@ source:
       harpophylla F. Muell. (Brigalow)
     volume: '15'
     number: '1'
-    pages: '11--24'
+    pages: 11--24
     doi: 10.1071/bt9670011
   secondary_20:
     key: Pearcy_1987
@@ -201,7 +203,7 @@ source:
       in canopy, gap and understory micro-environments
     volume: '1'
     number: '3'
-    pages: '169--178'
+    pages: 169--178
     doi: 10.2307/2389419
   secondary_22:
     key: Turner_1983
@@ -240,485 +242,487 @@ sites:
     latitude (deg): -37.867
     longitude (deg): 145.75
     description: .na.character
-    MAP (mm): 1750.0
-    MAT (C): .na.real
-    source lat/lon: Adams_1984
-    soil: dark reddish brown sandy loam A horizon, grading to a red clay loam B horizon
-      and red light clay C horizon
-    soil_pH: 5-5.5
-    geology: granodiorite
+    precipitation, MAP (mm): 1750.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Adams_1984
+    soil type: dark reddish brown sandy loam A horizon, grading to a red clay loam
+      B horizon and red light clay C horizon
+    soil pH: 5-5.5
+    geology (parent material): granodiorite
     elevation (m): '400'
-    soil total P: .na.character
+    soil P, total: .na.character
   Ashton_1975_Wallaby Creek:
     latitude (deg): -37.41
     longitude (deg): 145.226
     description: spar and pole stage forests
-    MAP (mm): 1300.0
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Wallaby Creek at Road 4
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): 1300.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Wallaby Creek at Road 4
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): 670-700
-    soil total P: .na.character
+    soil P, total: .na.character
   Ashton_1976_dry sclerophyll:
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: tall open Eucalyptus forest
-    MAP (mm): 1400.0
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Tomahawk Gap on east Beenak Road
-    soil: range from krasnozems to red podzolic soils
-    soil_pH: 5.0-5.6
-    geology: Upper Devonian granite
+    precipitation, MAP (mm): 1400.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    soil type: range from krasnozems to red podzolic soils
+    soil pH: 5.0-5.6
+    geology (parent material): Upper Devonian granite
     elevation (m): 500-550
-    soil total P: '1'
+    soil P, total: '1'
   Ashton_1976_rainforest:
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: Nothofagus closed forest
-    MAP (mm): 1400.0
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Tomahawk Gap on east Beenak Road
-    soil: vary from colluvial brown loams with water tables at 50-60 cm depth to alluvial
-      humic gravels with water tables at or close to the surface for most of the y
-    soil_pH: 5.0-5.6
-    geology: Upper Devonian granite
+    precipitation, MAP (mm): 1400.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    soil type: vary from colluvial brown loams with water tables at 50-60 cm depth
+      to alluvial humic gravels with water tables at or close to the surface for most
+      of the y
+    soil pH: 5.0-5.6
+    geology (parent material): Upper Devonian granite
     elevation (m): 500-550
-    soil total P: '2.2'
+    soil P, total: '2.2'
   Ashton_1976_wet sclerophyll:
     latitude (deg): -37.907
     longitude (deg): 145.671
     description: tall open Eucalyptus forest
-    MAP (mm): 1400.0
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Tomahawk Gap on east Beenak Road
-    soil: the krasnozem
-    soil_pH: 5.0-5.6
-    geology: Upper Devonian granite
+    precipitation, MAP (mm): 1400.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Tomahawk Gap on east Beenak Road
+    soil type: the krasnozem
+    soil pH: 5.0-5.6
+    geology (parent material): Upper Devonian granite
     elevation (m): 500-550
-    soil total P: '1.8'
+    soil P, total: '1.8'
   Attiwill_1980_Mt Disappointment:
     latitude (deg): -37.426
     longitude (deg): 145.136
     description: plantation
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Mount Disappointment summit
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Mount Disappointment summit
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Bell_1985_Weipa:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Bennett_1996_Yanakie_Uc1.11:
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
-    MAP (mm): 1000.0
-    MAT (C): .na.real
-    source lat/lon: Bennett_1996
-    soil: calcareous dunes are uniform sands which vary according to the phase of
-      dune accretion, differing in colour (grading from yellowish grey to red-brown
+    precipitation, MAP (mm): 1000.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Bennett_1996
+    soil type: calcareous dunes are uniform sands which vary according to the phase
+      of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
-    soil_pH: '8.1'
-    geology: Holocene calcareous sediments
+    soil pH: '8.1'
+    geology (parent material): Holocene calcareous sediments
     elevation (m): 0-70
-    soil total P: '12'
+    soil P, total: '12'
   Bennett_1996_Yanakie_Uc1.23_pH6:
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
-    MAP (mm): 1000.0
-    MAT (C): .na.real
-    source lat/lon: Bennett_1996
-    soil: calcareous dunes are uniform sands which vary according to the phase of
-      dune accretion, differing in colour (grading from yellowish grey to red-brown
+    precipitation, MAP (mm): 1000.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Bennett_1996
+    soil type: calcareous dunes are uniform sands which vary according to the phase
+      of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
-    soil_pH: '6.5'
-    geology: Mid-Pleistocene calcareous sediments
+    soil pH: '6.5'
+    geology (parent material): Mid-Pleistocene calcareous sediments
     elevation (m): 0-70
-    soil total P: '5.6'
+    soil P, total: '5.6'
   Bennett_1996_Yanakie_Uc1.23_pH7:
     latitude (deg): -38.933
     longitude (deg): 146.267
     description: calcareous dunes
-    MAP (mm): 1000.0
-    MAT (C): .na.real
-    source lat/lon: Bennett_1996
-    soil: calcareous dunes are uniform sands which vary according to the phase of
-      dune accretion, differing in colour (grading from yellowish grey to red-brown
+    precipitation, MAP (mm): 1000.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Bennett_1996
+    soil type: calcareous dunes are uniform sands which vary according to the phase
+      of dune accretion, differing in colour (grading from yellowish grey to red-brown
       or red with soil age
-    soil_pH: '7.5'
-    geology: Late-Pleistocene calcareous sediments
+    soil pH: '7.5'
+    geology (parent material): Late-Pleistocene calcareous sediments
     elevation (m): 0-70
-    soil total P: '13.3'
+    soil P, total: '13.3'
   Bevege_1978_Millmerran:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Birk_1992_Wedding Bells:
     latitude (deg): -30.133
     longitude (deg): 153.117
     description: plantation
-    MAP (mm): 1500.0
-    MAT (C): .na.real
-    source lat/lon: Birk_1992
-    soil: Shallow (< 70 cm) brown earth soils were typical of the upper slope positions
-      but changed to deep (> 2 m) red earths on the lower slopes
-    soil_pH: .na.character
-    geology: massive Greywacke parent material ofthe Lower Permian Coromba Beds
+    precipitation, MAP (mm): 1500.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Birk_1992
+    soil type: Shallow (< 70 cm) brown earth soils were typical of the upper slope
+      positions but changed to deep (> 2 m) red earths on the lower slopes
+    soil pH: .na.character
+    geology (parent material): massive Greywacke parent material ofthe Lower Permian
+      Coromba Beds
     elevation (m): 110-140
-    soil total P: .na.character
+    soil P, total: .na.character
   Cromer_1975_Morwell:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Feller_1980_Maroondah_EO:
     latitude (deg): -37.633
     longitude (deg): 145.583
-    description: "dry sclerophyll or open forest containing several dominant eucalypt
-      species"
-    MAP (mm): 1200.0
-    MAT (C): 15.5
-    source lat/lon: Feller_1980
-    soil: intermediate between krasnozems and podzolics designated as Gn 4.54
-    soil_pH: .na.character
-    geology: quartz-biotite-dacite
+    description: dry sclerophyll or open forest containing several dominant eucalypt
+      species
+    precipitation, MAP (mm): 1200.0
+    temperature, MAT (C): 15.5
+    lat/lon notes: Feller_1980
+    soil type: intermediate between krasnozems and podzolics designated as Gn 4.54
+    soil pH: .na.character
+    geology (parent material): quartz-biotite-dacite
     elevation (m): '180'
-    soil total P: 5.7-6.0
+    soil P, total: 5.7-6.0
   Feller_1980_Maroondah_ER:
     latitude (deg): -37.633
     longitude (deg): 145.583
     description: wet sclerophyll or tall open forest of Eucalyptus regnans with a
       closed canopy and shrub understory
-    MAP (mm): 1660.0
-    MAT (C): 10.7
-    source lat/lon: Feller_1980
-    soil: krasnozem designated Gn 4.31
-    soil_pH: .na.character
-    geology: igneous quartz-dacite with more biotite
+    precipitation, MAP (mm): 1660.0
+    temperature, MAT (C): 10.7
+    lat/lon notes: Feller_1980
+    soil type: krasnozem designated Gn 4.31
+    soil pH: .na.character
+    geology (parent material): igneous quartz-dacite with more biotite
     elevation (m): '560'
-    soil total P: 4.7-5.0
+    soil P, total: 4.7-5.0
   Hatch_1955_Dwellingup:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Hopmans_1993_Maramingo:
     latitude (deg): -37.417
     longitude (deg): 149.55
     description: uneven-aged sclerophyll forest 28-40 m tall
-    MAP (mm): 927.0
-    MAT (C): .na.real
-    source lat/lon: Hopmans_1993
-    soil: yellow podzolic with a hard-setting loamy A horizon and a mottled yellow
+    precipitation, MAP (mm): 927.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Hopmans_1993
+    soil type: yellow podzolic with a hard-setting loamy A horizon and a mottled yellow
       clayey B horizon
-    soil_pH: .na.character
-    geology: "biotite adamellite, one of the Bega Batholith granitoids"
+    soil pH: .na.character
+    geology (parent material): biotite adamellite, one of the Bega Batholith granitoids
     elevation (m): '927'
-    soil total P: .na.character
+    soil P, total: .na.character
   Lambert_1979_Bago State Forest:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Lambert_1979_Lidsdale State Forest:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Leuning_1991_Toolara:
     latitude (deg): -26.2
     longitude (deg): 152.75
     description: plantation with seeds from Coffs Harbour
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Leuning_1991
-    soil: highly weathered and low in plant nutrients, particularly nitrogen, phosphorus,
-      calcium and potassium
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Leuning_1991
+    soil type: highly weathered and low in plant nutrients, particularly nitrogen,
+      phosphorus, calcium and potassium
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Marsh_1995_Moormung:
     latitude (deg): -37.817
     longitude (deg): 147.63
     description: undisturbed redgum forest with a grassy stratum dominated by Poa
       species
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Marsh_1995
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Marsh_1995
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Meakins_0000_Brindabella_1:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Meakins_0000_Brindabella_2:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Meakins_0000_Brindabella_3:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Moore_1967_Meandarra:
     latitude (deg): -27.283
     longitude (deg): 149.75
     description: virgin, mature brigalow forest
-    MAP (mm): 560.0
-    MAT (C): .na.real
-    source lat/lon: Moore_1967
-    soil: gilgaied deep clay
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): 560.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: Moore_1967
+    soil type: gilgaied deep clay
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): '940'
-    soil total P: .na.character
+    soil P, total: .na.character
   Pearcy_1987_Curtin_Fig:
     latitude (deg): -17.0
     longitude (deg): 145.57
     description: complex notophyll vine forest with scattered deciduous trees and
       an uneven canopy height of 25-40 m
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: derived from basalt
-    soil_pH: .na.character
-    geology: basalt
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: derived from basalt
+    soil pH: .na.character
+    geology (parent material): basalt
     elevation (m): '730'
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_Hooppine_plantation_25:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_Hooppine_plantation_34:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_Hooppine_plantation_50:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_Hooppine_plantation_63:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_Maleny:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_North_Queensland_1:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_North_Queensland_2:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Richards_2008_2_North_Queensland_3:
     latitude (deg): .na.real
     longitude (deg): .na.real
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: .na.character
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: .na.character
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Schortemeyer_0000_NATT_Berrimah:
     latitude (deg): -12.43389
     longitude (deg): 130.9228
     description: Eucalyptus-dominated
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Soper_2014
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Soper_2014
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Schortemeyer_0000_NATT_Katherine:
     latitude (deg): -14.47306
     longitude (deg): 132.3031
     description: .na.character
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Soper_2014
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Soper_2014
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Schortemeyer_0000_NATT_Kunoth Paddock:
     latitude (deg): -23.51694
     longitude (deg): 133.6492
     description: Acacia-dominated mulga woodland
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Soper_2014
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Soper_2014
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Schortemeyer_0000_NATT_Newcastle Waters:
     latitude (deg): -17.3775
     longitude (deg): 133.4097
     description: dominated by either Acacia or Eucalyptus
-    MAP (mm): .na.real
-    MAT (C): .na.real
-    source lat/lon: Soper_2014
-    soil: .na.character
-    soil_pH: .na.character
-    geology: .na.character
+    precipitation, MAP (mm): .na.real
+    temperature, MAT (C): .na.real
+    lat/lon notes: Soper_2014
+    soil type: .na.character
+    soil pH: .na.character
+    geology (parent material): .na.character
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
   Turner_1983_Conglomerate:
     latitude (deg): -30.09
     longitude (deg): 153.07
     description: plantation where there was once subtropical rainforest
-    MAP (mm): 1760.0
-    MAT (C): .na.real
-    source lat/lon: AusTraits, Conglomerate State Forest location from GoogleEarth
-    soil: derived from Lower Permian sediments with moderate to high fertility.
-    soil_pH: .na.character
-    geology: Lower Permian sediments
+    precipitation, MAP (mm): 1760.0
+    temperature, MAT (C): .na.real
+    lat/lon notes: AusTraits, Conglomerate State Forest location from GoogleEarth
+    soil type: derived from Lower Permian sediments with moderate to high fertility.
+    soil pH: .na.character
+    geology (parent material): Lower Permian sediments
     elevation (m): .na.character
-    soil total P: .na.character
+    soil P, total: .na.character
 contexts:
   branch:
     type: field
@@ -1205,4 +1209,3 @@ questions:
     if we get hold of the author; Leigh_2006 - lots of additional data if we contact
     author; Leuning_1991 - lots of gas exchanges, Jmax, Vcmax, detailed leaf N & P
     data if we contact author
-

--- a/data/Roderick_1999/metadata.yml
+++ b/data/Roderick_1999/metadata.yml
@@ -113,7 +113,7 @@ sites:
     longitude (deg): 148.47
     latitude (deg): -36.37
     soil type: .na.character
-    lat/lon notes: AusTraits
+    georeference remarks: AusTraits
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): 1645.0
@@ -122,7 +122,7 @@ sites:
     longitude (deg): 148.39
     latitude (deg): -36.41
     soil type: .na.character
-    lat/lon notes: AusTraits
+    georeference remarks: AusTraits
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): 2040.0
@@ -131,7 +131,7 @@ sites:
     longitude (deg): 148.56
     latitude (deg): -36.35
     soil type: .na.character
-    lat/lon notes: AusTraits
+    georeference remarks: AusTraits
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): 1215.0
@@ -140,7 +140,7 @@ sites:
     longitude (deg): 148.59
     latitude (deg): -36.34
     soil type: .na.character
-    lat/lon notes: AusTraits
+    georeference remarks: AusTraits
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): 940.0
@@ -149,7 +149,7 @@ sites:
     longitude (deg): 149.2
     latitude (deg): -35.3
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -158,7 +158,7 @@ sites:
     longitude (deg): 144.2
     latitude (deg): -37.9
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -167,7 +167,7 @@ sites:
     longitude (deg): 147.5
     latitude (deg): -34.4
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -176,7 +176,7 @@ sites:
     longitude (deg): 143.0
     latitude (deg): -33.7
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -185,7 +185,7 @@ sites:
     longitude (deg): 146.8
     latitude (deg): -36.7
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -194,7 +194,7 @@ sites:
     longitude (deg): 149.1
     latitude (deg): -34.8
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -203,7 +203,7 @@ sites:
     longitude (deg): 146.8
     latitude (deg): -36.5
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -212,7 +212,7 @@ sites:
     longitude (deg): 142.0
     latitude (deg): -35.5
     soil type: rich
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -221,7 +221,7 @@ sites:
     longitude (deg): 150.2
     latitude (deg): -35.7
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): 900.0
     elevation (m): .na.real
@@ -230,7 +230,7 @@ sites:
     longitude (deg): 149.2
     latitude (deg): -35.3
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): 590.0
     elevation (m): .na.real
@@ -239,7 +239,7 @@ sites:
     longitude (deg): 146.1
     latitude (deg): -35.2
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): 400.0
     elevation (m): .na.real
@@ -248,7 +248,7 @@ sites:
     longitude (deg): .na.real
     latitude (deg): .na.real
     soil type: .na.character
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -257,7 +257,7 @@ sites:
     longitude (deg): 153.0
     latitude (deg): -26.9
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: emergent stratum
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -266,7 +266,7 @@ sites:
     longitude (deg): 140.5
     latitude (deg): -36.1
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: mid-stratum
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -275,7 +275,7 @@ sites:
     longitude (deg): 147.2
     latitude (deg): -33.9
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: upper statum
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -284,7 +284,7 @@ sites:
     longitude (deg): 139.3
     latitude (deg): -34.4
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -293,7 +293,7 @@ sites:
     longitude (deg): 140.5
     latitude (deg): -36.1
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -302,7 +302,7 @@ sites:
     longitude (deg): 145.7
     latitude (deg): -34.0
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -311,7 +311,7 @@ sites:
     longitude (deg): 138.6
     latitude (deg): -35.0
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -320,7 +320,7 @@ sites:
     longitude (deg): 139.8
     latitude (deg): -35.6
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -329,7 +329,7 @@ sites:
     longitude (deg): 141.2
     latitude (deg): -34.3
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -338,7 +338,7 @@ sites:
     longitude (deg): 138.7
     latitude (deg): -35.0
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -347,7 +347,7 @@ sites:
     longitude (deg): 140.0
     latitude (deg): -34.2
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real
@@ -356,7 +356,7 @@ sites:
     longitude (deg): 147.2
     latitude (deg): -33.9
     soil type: .na.character
-    lat/lon notes: author
+    georeference remarks: author
     vegetation stratum: .na.character
     precipitation, MAP (mm): .na.real
     elevation (m): .na.real

--- a/data/Roderick_1999/metadata.yml
+++ b/data/Roderick_1999/metadata.yml
@@ -91,7 +91,7 @@ source:
       communities in southern Australia
     volume: '38'
     number: '5'
-    pages: '459--474'
+    pages: 459--474
     doi: 10.1071/bt9900459
 people:
 - name: Michael Roderick
@@ -113,252 +113,252 @@ sites:
     longitude (deg): 148.47
     latitude (deg): -36.37
     soil type: .na.character
-    lat/lon source: AusTraits
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: AusTraits
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): 1645.0
     description: subalpine shrub and tussock grassland
   Koerner_1985 Mount Perisher:
     longitude (deg): 148.39
     latitude (deg): -36.41
     soil type: .na.character
-    lat/lon source: AusTraits
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: AusTraits
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): 2040.0
     description: alpine boundary
   Koerner_1985 Sawpit Creek:
     longitude (deg): 148.56
     latitude (deg): -36.35
     soil type: .na.character
-    lat/lon source: AusTraits
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: AusTraits
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): 1215.0
     description: sclerophyll fores
   Koerner_1985 Waste Point:
     longitude (deg): 148.59
     latitude (deg): -36.34
     soil type: .na.character
-    lat/lon source: AusTraits
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: AusTraits
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): 940.0
     description: dry, open, sclerophyll woodland
   Landsberg_1990 Hall, ACT:
     longitude (deg): 149.2
     latitude (deg): -35.3
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: pastoral property
   Landsberg_1995 Brisbane Ranges:
     longitude (deg): 144.2
     latitude (deg): -37.9
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Ingalba:
     longitude (deg): 147.5
     latitude (deg): -34.4
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Lake Mungo:
     longitude (deg): 143.0
     latitude (deg): -33.7
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Mt Buffalo:
     longitude (deg): 146.8
     latitude (deg): -36.7
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Mundoonen:
     longitude (deg): 149.1
     latitude (deg): -34.8
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Stanley Plateau:
     longitude (deg): 146.8
     latitude (deg): -36.5
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Landsberg_1995 Wyperfield:
     longitude (deg): 142.0
     latitude (deg): -35.5
     soil type: rich
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Mooney_1978 Batemans Bay:
     longitude (deg): 150.2
     latitude (deg): -35.7
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): 900.0
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): 900.0
     elevation (m): .na.real
     description: tall forest
   Mooney_1978 Canberra:
     longitude (deg): 149.2
     latitude (deg): -35.3
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): 590.0
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): 590.0
     elevation (m): .na.real
     description: woodland
   Mooney_1978 Rankin Spring:
     longitude (deg): 146.1
     latitude (deg): -35.2
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): 400.0
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): 400.0
     elevation (m): .na.real
     description: mallee
   Schulze_1994 NA:
     longitude (deg): .na.real
     latitude (deg): .na.real
     soil type: .na.character
-    lat/lon source: .na.character
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: .na.character
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1988 Beerwah:
     longitude (deg): 153.0
     latitude (deg): -26.9
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: emergent stratum
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: emergent stratum
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1988 Dark Island Soak:
     longitude (deg): 140.5
     latitude (deg): -36.1
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: mid-stratum
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: mid-stratum
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1988 West Wyalong:
     longitude (deg): 147.2
     latitude (deg): -33.9
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: upper statum
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: upper statum
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: mallee
   Specht_1990 Blanchedown-Truro:
     longitude (deg): 139.3
     latitude (deg): -34.4
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Dark Island Soak:
     longitude (deg): 140.5
     latitude (deg): -36.1
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Goolgowi:
     longitude (deg): 145.7
     latitude (deg): -34.0
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Green Hill:
     longitude (deg): 138.6
     latitude (deg): -35.0
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Ki Ki:
     longitude (deg): 139.8
     latitude (deg): -35.6
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Mildura:
     longitude (deg): 141.2
     latitude (deg): -34.3
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Mt Lofty:
     longitude (deg): 138.7
     latitude (deg): -35.0
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 Waikerie:
     longitude (deg): 140.0
     latitude (deg): -34.2
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
   Specht_1990 West Wyalong:
     longitude (deg): 147.2
     latitude (deg): -33.9
     soil type: .na.character
-    lat/lon source: author
-    veg_stratum: .na.character
-    MAP (mm): .na.real
+    lat/lon notes: author
+    vegetation stratum: .na.character
+    precipitation, MAP (mm): .na.real
     elevation (m): .na.real
     description: .na.character
 contexts: .na
@@ -472,4 +472,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Rosell_2014/metadata.yml
+++ b/data/Rosell_2014/metadata.yml
@@ -56,37 +56,37 @@ sites:
     latitude (deg): -42.4
     longitude (deg): 147.0
     description: cool temperate woodland
-    MAP (mm): 547.0
-    MAT (C): 10.0
+    precipitation, MAP (mm): 547.0
+    temperature, MAT (C): 10.0
     fire intensity (kW m-1): 1000-5000
-    fire interval (yr): 5-20
+    fire interval (years): 5-20
     crown fire: facultative
   Daintree National Park:
     latitude (deg): -16.1
     longitude (deg): 145.4
     description: tropical rainforest
-    MAP (mm): 3500.0
-    MAT (C): 25.1
+    precipitation, MAP (mm): 3500.0
+    temperature, MAT (C): 25.1
     fire intensity (kW m-1): 0-100
-    fire interval (yr): '>100'
+    fire interval (years): '>100'
     crown fire: none
   Howard Springs Nature Park:
     latitude (deg): -12.5
     longitude (deg): 131.1
     description: savanna
-    MAP (mm): 1714.0
-    MAT (C): 27.8
+    precipitation, MAP (mm): 1714.0
+    temperature, MAT (C): 27.8
     fire intensity (kW m-1): 100-1000
-    fire interval (yr): 2-5
+    fire interval (years): 2-5
     crown fire: none
   Yengo National Park:
     latitude (deg): -32.8
     longitude (deg): 150.9
     description: temperate woodland
-    MAP (mm): 802.0
-    MAT (C): 16.6
+    precipitation, MAP (mm): 802.0
+    temperature, MAT (C): 16.6
     fire intensity (kW m-1): 1000-5000
-    fire interval (yr): 5-20
+    fire interval (years): 5-20
     crown fire: facultative
 contexts:
   Twig:
@@ -350,4 +350,3 @@ exclude_observations: .na
 questions:
   additional_traits: many traits, including inner bark density, which includes the
     inner living portion of bark only
-

--- a/data/Sams_2017/metadata.yml
+++ b/data/Sams_2017/metadata.yml
@@ -100,59 +100,59 @@ dataset:
     sites for all species are recorded in the data.csv file.
 sites:
   BorderRangesNP:
-    Location.n: 2
-    Quadrat Names: RN1:3,RR1:3
+    site code: 2
+    plot code: RN1:3,RR1:3
     latitude (deg): -28.3885
     longitude (deg): 153.0513
     description: mesic warm subtropical rain forest
     notes: site used only for plot censuses; samples for SLA were collected in nearby
       Lamington NP
   BunyaMtNP:
-    Location.n: 3
-    Quadrat Names: BN1:3,BR1:3
+    site code: 3
+    plot code: BN1:3,BR1:3
     latitude (deg): -26.886047
     longitude (deg): 151.605447
     description: dry subtropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
   Curtain FigNP:
-    Location.n: 5
-    Quadrat Names: unknown
+    site code: 5
+    plot code: unknown
     latitude (deg): -17.283918
     longitude (deg): 145.57121
     description: mesic upland tropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
   DorrigoNP:
-    Location.n: 1
-    Quadrat Names: DN1:3,DR1:3
+    site code: 1
+    plot code: DN1:3,DR1:3
     latitude (deg): -30.359054
     longitude (deg): 152.735787
     description: dry upland tropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
   LamingtonNP:
-    Location.n: 2
-    Quadrat Names: DN1:3,DR1:3
+    site code: 2
+    plot code: DN1:3,DR1:3
     latitude (deg): -28.196897
     longitude (deg): 153.183639
     description: dry upland tropical rain forest
     notes: site used only for SLA leaf collections; plots censused were in nearby
       Border Ranges NP at -28.3885, 153.0513
   MairyCairncross:
-    Location.n: 4
-    Quadrat Names: MN1:3,MR1:3
+    site code: 4
+    plot code: MN1:3,MR1:3
     latitude (deg): -26.778623
     longitude (deg): 152.882047
     description: mesic warm subtropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
   Quinkin:
-    Location.n: 5
-    Quadrat Names: Q1:3
+    site code: 5
+    plot code: Q1:3
     latitude (deg): -17.301913
     longitude (deg): 145.580348
     description: mesic upland tropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
   WooroonoranNP:
-    Location.n: 6
-    Quadrat Names: WN1:3,WR1:9
+    site code: 6
+    plot code: WN1:3,WR1:9
     latitude (deg): -17.369926
     longitude (deg): 145.739885
     description: dry upland tropical rain forest
@@ -505,4 +505,3 @@ taxonomic_updates:
   reason: Align to APC accepted spelling (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schmidt_1997/metadata.yml
+++ b/data/Schmidt_1997/metadata.yml
@@ -55,19 +55,19 @@ sites:
   Beerwah:
     latitude (deg): -26.9
     longitude (deg): 152.9
-    5-yr-rainfall (mm): 1674.0
-    rain day (per annum): 131.0
+    precipitation, 5 year total (mm): 1674.0
+    precipitation, rain days (per year): 131.0
     moisture balance (mm per annum): 151.0
-    Jan-Mar rain: 698.0
-    description: Beerwah Scientific Area no. 1, in southeastern Australia, 80 km north
+    precipitation, Jan-Mar (mm): 698.0
+    locality: Beerwah Scientific Area no. 1, in southeastern Australia, 80 km north
       of Brisbane.
-    vegetation: wet coastal subtropical heathland (wallum)
-    MAP (mm): 1286
-    MAT (C): 20.5
-    soil: sandy ground-water podsol with very low cation exchange capacity (1.5 mmol
-      100 g-1 dry soil) (Specht 1979, Specht et al. 1991)
-    fire regime: The study area is subject to a fire regime under white subsites are
-      burnt at intervals of 6-7 years with alternating 'hot' fires *burning during
+    description: wet coastal subtropical heathland (wallum)
+    precipitation, MAP (mm): 1286
+    temperature, MAT (C): 20.5
+    soil type: sandy ground-water podsol with very low cation exchange capacity (1.5
+      mmol 100 g-1 dry soil) (Specht 1979, Specht et al. 1991)
+    fire history: The study area is subject to a fire regime under white subsites
+      are burnt at intervals of 6-7 years with alternating 'hot' fires *burning during
       periods of prolonged dry conditions) and 'cold' fires (burning after rain).
 contexts: .na
 config:
@@ -260,4 +260,3 @@ taxonomic_updates:
     Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schmidt_1997/metadata.yml
+++ b/data/Schmidt_1997/metadata.yml
@@ -55,7 +55,6 @@ sites:
   Beerwah:
     latitude (deg): -26.9
     longitude (deg): 152.9
-    year collected: .na.character
     5-yr-rainfall (mm): 1674.0
     rain day (per annum): 131.0
     moisture balance (mm per annum): 151.0

--- a/data/Schmidt_2003/metadata.yml
+++ b/data/Schmidt_2003/metadata.yml
@@ -89,253 +89,249 @@ dataset:
 sites:
   Kakadu1:
     description: waste rock dump
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): 1.51
-    soil total N (mg/g): 0.03
-    longer description: Ranger uranium mine is an open-cut mine, processing ore from
-      up to about 40 m depth. Mine spoil material was piled into waste rock dumps
-      and two waste rock dumps were reforested with woodland species in 1987 and 1984
-      (referred to as WRD I and II, respectively). Acacia species represent the main
-      woody species at both WRDs. The parent rock material was a loamy clayey chloritic
-      weathered schist (WRD I) and a clayey highly weathered schist (WRD II).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): 1.51
+    soil N, total (mg/g): 0.03
+    notes: Ranger uranium mine is an open-cut mine, processing ore from up to about
+      40 m depth. Mine spoil material was piled into waste rock dumps and two waste
+      rock dumps were reforested with woodland species in 1987 and 1984 (referred
+      to as WRD I and II, respectively). Acacia species represent the main woody species
+      at both WRDs. The parent rock material was a loamy clayey chloritic weathered
+      schist (WRD I) and a clayey highly weathered schist (WRD II).
   Kakadu10:
     description: evergreen monsoon forest
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: The monsoon forests occur as isolated patches established
-      in less fire-prone regions and are rarely burnt (Bowman 1992). Two monsoon forest
-      communities were studied, a deciduous monsoon forest and a closed wet evergreen
-      monsoon forest; the latter is provided with constant moisture by a permanent
-      spring. The deciduous monsoon forest grew on a moderately drained clayey red
-      soil close to the floodplain. Species at the deciduous monsoon forest site included
-      perennial, deciduous, annual, and geophyte species. The evergreen monsoon forest
-      grew on grey loamy soil and is seasonally flooded with running water. The vegetation
-      consists mainly of perennial trees and a very sparse ground cover.
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: The monsoon forests occur as isolated patches established in less fire-prone
+      regions and are rarely burnt (Bowman 1992). Two monsoon forest communities were
+      studied, a deciduous monsoon forest and a closed wet evergreen monsoon forest;
+      the latter is provided with constant moisture by a permanent spring. The deciduous
+      monsoon forest grew on a moderately drained clayey red soil close to the floodplain.
+      Species at the deciduous monsoon forest site included perennial, deciduous,
+      annual, and geophyte species. The evergreen monsoon forest grew on grey loamy
+      soil and is seasonally flooded with running water. The vegetation consists mainly
+      of perennial trees and a very sparse ground cover.
   Kakadu11:
     description: .na.character
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: unknown
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: unknown
   Kakadu12:
     description: disturbed wetland
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: The lowland wetlands are treeless flood plains with trees
-      along river channels, billabongs (waterholes) or swamps (Brock 1988). They are
-      inundated during the wet season and support a comparatively low number of species
-      dominated by members of the Cyperaceae and Poaceae, and a range of aquatic plants.
-      For this study, two wetlands, one disturbed (near the Kakadu highway) and one
-      un- disturbed (near Radon Spring), were sampled. The disturbed wet- land site
-      was a clayey loam flooded with running fresh water during the wet season. This
-      site was affected by wallowing and grazing of feral pigs and water buffaloes.
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: The lowland wetlands are treeless flood plains with trees along river channels,
+      billabongs (waterholes) or swamps (Brock 1988). They are inundated during the
+      wet season and support a comparatively low number of species dominated by members
+      of the Cyperaceae and Poaceae, and a range of aquatic plants. For this study,
+      two wetlands, one disturbed (near the Kakadu highway) and one un- disturbed
+      (near Radon Spring), were sampled. The disturbed wet- land site was a clayey
+      loam flooded with running fresh water during the wet season. This site was affected
+      by wallowing and grazing of feral pigs and water buffaloes.
   Kakadu13:
     description: undisturbed wetland
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: The lowland wetlands are treeless flood plains with trees
-      along river channels, billabongs (waterholes) or swamps (Brock 1988). They are
-      inundated during the wet season and support a comparatively low number of species
-      dominated by members of the Cyperaceae and Poaceae, and a range of aquatic plants.
-      For this study, two wetlands, one disturbed (near the Kakadu highway) and one
-      un- disturbed (near Radon Spring), were sampled. The disturbed wet- land site
-      was a clayey loam flooded with running fresh water during the wet season. This
-      site was affected by wallowing and grazing of feral pigs and water buffaloes.
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: The lowland wetlands are treeless flood plains with trees along river channels,
+      billabongs (waterholes) or swamps (Brock 1988). They are inundated during the
+      wet season and support a comparatively low number of species dominated by members
+      of the Cyperaceae and Poaceae, and a range of aquatic plants. For this study,
+      two wetlands, one disturbed (near the Kakadu highway) and one un- disturbed
+      (near Radon Spring), were sampled. The disturbed wet- land site was a clayey
+      loam flooded with running fresh water during the wet season. This site was affected
+      by wallowing and grazing of feral pigs and water buffaloes.
   Kakadu2:
     description: burnt site
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): 0.13
-    soil total N (mg/g): 1.2
-    longer description: The most distinctive eucalypt community in Northern Australia
-      is dominated by two species, Eucalyptus tetrodonta and E. miniata, which occur
-      either singly or in combination (Brock 1988). The non- eucalypt understorey
-      includes evergreen species as well as obligate and facultative deciduous species.
-      There is a moderate vegetation cover with annual and perennial grasses, herbs,
-      and vines during the wet season. Two natural eucalypt woodland sites, located
-      near the Ranger uranium mine and at Kapalga, had not been subjected to are for
-      3-4 years prior to sampling. Soils are well-draining sandy loams or loams, and
-      during the wet season both sites are temporarily flooded. Results obtained for
-      the two locations were combined. Disturbed eucalypt woodlands included a site
-      at Kapalga which had been burnt annually since 1990 (burnt woodland) in the
-      late dry season. Another eucalypt woodland located near the Ranger uranium mine,
-      which received irrigation with excess mine waste water in the wet season, was
-      studied (irrigated eucalypt woodland). Waste water from the ore-leaching process
-      was applied to the site in 1985, 1987, 1989, and 1991. During those five years
-      the site received a substantial input of mineral elements, in particular sulfate
-      (26,000 kg ha)1), magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium
-      (1,100 kg ha)1). In contrast, the content of P and N (as NO3 ) in the waste
-      water was low (Ashwath personal communication). MgSO4 salt crusts partly cover
-      the soil surface and the water table is high (within 1 m). Some species have
-      been dying as a result of either high salinity and/or high water table (N. Ashwath,
-      personal communication).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): 0.13
+    soil N, total (mg/g): 1.2
+    notes: The most distinctive eucalypt community in Northern Australia is dominated
+      by two species, Eucalyptus tetrodonta and E. miniata, which occur either singly
+      or in combination (Brock 1988). The non- eucalypt understorey includes evergreen
+      species as well as obligate and facultative deciduous species. There is a moderate
+      vegetation cover with annual and perennial grasses, herbs, and vines during
+      the wet season. Two natural eucalypt woodland sites, located near the Ranger
+      uranium mine and at Kapalga, had not been subjected to are for 3-4 years prior
+      to sampling. Soils are well-draining sandy loams or loams, and during the wet
+      season both sites are temporarily flooded. Results obtained for the two locations
+      were combined. Disturbed eucalypt woodlands included a site at Kapalga which
+      had been burnt annually since 1990 (burnt woodland) in the late dry season.
+      Another eucalypt woodland located near the Ranger uranium mine, which received
+      irrigation with excess mine waste water in the wet season, was studied (irrigated
+      eucalypt woodland). Waste water from the ore-leaching process was applied to
+      the site in 1985, 1987, 1989, and 1991. During those five years the site received
+      a substantial input of mineral elements, in particular sulfate (26,000 kg ha)1),
+      magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium (1,100 kg ha)1).
+      In contrast, the content of P and N (as NO3 ) in the waste water was low (Ashwath
+      personal communication). MgSO4 salt crusts partly cover the soil surface and
+      the water table is high (within 1 m). Some species have been dying as a result
+      of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu3:
     description: waste rock dump
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): 1.4
-    longer description: Ranger uranium mine is an open-cut mine, processing ore from
-      up to about 40 m depth. Mine spoil material was piled into waste rock dumps
-      and two waste rock dumps were reforested with woodland species in 1987 and 1984
-      (referred to as WRD I and II, respectively). Acacia species represent the main
-      woody species at both WRDs. The parent rock material was a loamy clayey chloritic
-      weathered schist (WRD I) and a clayey highly weathered schist (WRD II).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): 1.4
+    notes: Ranger uranium mine is an open-cut mine, processing ore from up to about
+      40 m depth. Mine spoil material was piled into waste rock dumps and two waste
+      rock dumps were reforested with woodland species in 1987 and 1984 (referred
+      to as WRD I and II, respectively). Acacia species represent the main woody species
+      at both WRDs. The parent rock material was a loamy clayey chloritic weathered
+      schist (WRD I) and a clayey highly weathered schist (WRD II).
   Kakadu4:
     description: irrigated woodland
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): 4.3
-    longer description: The most distinctive eucalypt community in Northern Australia
-      is dominated by two species, Eucalyptus tetrodonta and E. miniata, which occur
-      either singly or in combination (Brock 1988). The non- eucalypt understorey
-      includes evergreen species as well as obligate and facultative deciduous species.
-      There is a moderate vegetation cover with annual and perennial grasses, herbs,
-      and vines during the wet season. Two natural eucalypt woodland sites, located
-      near the Ranger uranium mine and at Kapalga, had not been subjected to fire
-      for 3-4 years prior to sampling. Soils are well-draining sandy loams or loams,
-      and during the wet season both sites are temporarily flooded. Results obtained
-      for the two locations were combined. Disturbed eucalypt woodlands included a
-      site at Kapalga which had been burnt annually since 1990 (burnt woodland) in
-      the late dry season. Another eucalypt woodland located near the Ranger uranium
-      mine, which received irrigation with excess mine waste water in the wet season,
-      was studied (irrigated eucalypt woodland). Waste water from the ore-leaching
-      process was applied to the site in 1985, 1987, 1989, and 1991. During those
-      five years the site received a substantial input of mineral elements, in particular
-      sulfate (26,000 kg ha)1), magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and
-      calcium (1,100 kg ha)1). In contrast, the content of P and N (as NO3 ) in the
-      waste water was low (Ashwath personal communication). MgSO4 salt crusts partly
-      cover the soil surface and the water table is high (within 1 m). Some species
-      have been dying as a result of either high salinity and/or high water table
-      (N. Ashwath, personal communication).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): 4.3
+    notes: The most distinctive eucalypt community in Northern Australia is dominated
+      by two species, Eucalyptus tetrodonta and E. miniata, which occur either singly
+      or in combination (Brock 1988). The non- eucalypt understorey includes evergreen
+      species as well as obligate and facultative deciduous species. There is a moderate
+      vegetation cover with annual and perennial grasses, herbs, and vines during
+      the wet season. Two natural eucalypt woodland sites, located near the Ranger
+      uranium mine and at Kapalga, had not been subjected to fire for 3-4 years prior
+      to sampling. Soils are well-draining sandy loams or loams, and during the wet
+      season both sites are temporarily flooded. Results obtained for the two locations
+      were combined. Disturbed eucalypt woodlands included a site at Kapalga which
+      had been burnt annually since 1990 (burnt woodland) in the late dry season.
+      Another eucalypt woodland located near the Ranger uranium mine, which received
+      irrigation with excess mine waste water in the wet season, was studied (irrigated
+      eucalypt woodland). Waste water from the ore-leaching process was applied to
+      the site in 1985, 1987, 1989, and 1991. During those five years the site received
+      a substantial input of mineral elements, in particular sulfate (26,000 kg ha)1),
+      magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium (1,100 kg ha)1).
+      In contrast, the content of P and N (as NO3 ) in the waste water was low (Ashwath
+      personal communication). MgSO4 salt crusts partly cover the soil surface and
+      the water table is high (within 1 m). Some species have been dying as a result
+      of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu5:
     description: escarpment woodland
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): 0.6
-    longer description: The most distinctive eucalypt community in Northern Australia
-      is dominated by two species, Eucalyptus tetrodonta and E. miniata, which occur
-      either singly or in combination (Brock 1988). The non- eucalypt understorey
-      includes evergreen species as well as obligate and facultative deciduous species.
-      There is a moderate vegetation cover with annual and perennial grasses, herbs,
-      and vines during the wet season. Two natural eucalypt woodland sites, located
-      near the Ranger uranium mine and at Kapalga, had not been subjected to fire
-      for 3-4 years prior to sampling. Soils are well-draining sandy loams or loams,
-      and during the wet season both sites are temporarily flooded. Results obtained
-      for the two locations were combined. Disturbed eucalypt woodlands included a
-      site at Kapalga which had been burnt annually since 1990 (burnt woodland) in
-      the late dry season. Another eucalypt woodland located near the Ranger uranium
-      mine, which received irrigation with excess mine waste water in the wet season,
-      was studied (irrigated eucalypt woodland). Waste water from the ore-leaching
-      process was applied to the site in 1985, 1987, 1989, and 1991. During those
-      five years the site received a substantial input of mineral elements, in particular
-      sulfate (26,000 kg ha)1), magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and
-      calcium (1,100 kg ha)1). In contrast, the content of P and N (as NO3 ) in the
-      waste water was low (Ashwath personal communication). MgSO4 salt crusts partly
-      cover the soil surface and the water table is high (within 1 m). Some species
-      have been dying as a result of either high salinity and/or high water table
-      (N. Ashwath, personal communication).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): 0.6
+    notes: The most distinctive eucalypt community in Northern Australia is dominated
+      by two species, Eucalyptus tetrodonta and E. miniata, which occur either singly
+      or in combination (Brock 1988). The non- eucalypt understorey includes evergreen
+      species as well as obligate and facultative deciduous species. There is a moderate
+      vegetation cover with annual and perennial grasses, herbs, and vines during
+      the wet season. Two natural eucalypt woodland sites, located near the Ranger
+      uranium mine and at Kapalga, had not been subjected to fire for 3-4 years prior
+      to sampling. Soils are well-draining sandy loams or loams, and during the wet
+      season both sites are temporarily flooded. Results obtained for the two locations
+      were combined. Disturbed eucalypt woodlands included a site at Kapalga which
+      had been burnt annually since 1990 (burnt woodland) in the late dry season.
+      Another eucalypt woodland located near the Ranger uranium mine, which received
+      irrigation with excess mine waste water in the wet season, was studied (irrigated
+      eucalypt woodland). Waste water from the ore-leaching process was applied to
+      the site in 1985, 1987, 1989, and 1991. During those five years the site received
+      a substantial input of mineral elements, in particular sulfate (26,000 kg ha)1),
+      magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium (1,100 kg ha)1).
+      In contrast, the content of P and N (as NO3 ) in the waste water was low (Ashwath
+      personal communication). MgSO4 salt crusts partly cover the soil surface and
+      the water table is high (within 1 m). Some species have been dying as a result
+      of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu6:
     description: deciduous monsoon forest
-    date collected: Data collected in dry (July 1994) and wet (Feb 1995)
+    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): 1.5
-    longer description: The monsoon forests occur as isolated patches established
-      in less fire-prone regions and are rarely burnt (Bowman 1992). Two monsoon forest
-      communities were studied, a deciduous monsoon forest and a closed wet evergreen
-      monsoon forest; the latter is provided with constant moisture by a permanent
-      spring. The deciduous monsoon forest grew on a moderately drained clayey red
-      soil close to the floodplain. Species at the deciduous monsoon forest site included
-      perennial, deciduous, annual, and geophyte species. The evergreen monsoon forest
-      grew on grey loamy soil and is seasonally flooded with running water. The vegetation
-      consists mainly of perennial trees and a very sparse ground cover.
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): 1.5
+    notes: The monsoon forests occur as isolated patches established in less fire-prone
+      regions and are rarely burnt (Bowman 1992). Two monsoon forest communities were
+      studied, a deciduous monsoon forest and a closed wet evergreen monsoon forest;
+      the latter is provided with constant moisture by a permanent spring. The deciduous
+      monsoon forest grew on a moderately drained clayey red soil close to the floodplain.
+      Species at the deciduous monsoon forest site included perennial, deciduous,
+      annual, and geophyte species. The evergreen monsoon forest grew on grey loamy
+      soil and is seasonally flooded with running water. The vegetation consists mainly
+      of perennial trees and a very sparse ground cover.
   Kakadu7:
     description: burnt site
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: The most distinctive eucalypt community in Northern Australia
-      is dominated by two species, Eucalyptus tetrodonta and E. miniata, which occur
-      either singly or in combination (Brock 1988). The non- eucalypt understorey
-      includes evergreen species as well as obligate and facultative deciduous species.
-      There is a moderate vegetation cover with annual and perennial grasses, herbs,
-      and vines during the wet season. Two natural eucalypt woodland sites, located
-      near the Ranger uranium mine and at Kapalga, had not been subjected to are for
-      3-4 years prior to sampling. Soils are well-draining sandy loams or loams, and
-      during the wet season both sites are temporarily flooded. Results obtained for
-      the two locations were combined. Disturbed eucalypt woodlands included a site
-      at Kapalga which had been burnt annually since 1990 (burnt woodland) in the
-      late dry season. Another eucalypt woodland located near the Ranger uranium mine,
-      which received irrigation with excess mine waste water in the wet season, was
-      studied (irrigated eucalypt woodland). Waste water from the ore-leaching process
-      was applied to the site in 1985, 1987, 1989, and 1991. During those five years
-      the site received a substantial input of mineral elements, in particular sulfate
-      (26,000 kg ha)1), magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium
-      (1,100 kg ha)1). In contrast, the content of P and N (as NO3 ) in the waste
-      water was low (Ashwath personal communication). MgSO4 salt crusts partly cover
-      the soil surface and the water table is high (within 1 m). Some species have
-      been dying as a result of either high salinity and/or high water table (N. Ashwath,
-      personal communication).
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: The most distinctive eucalypt community in Northern Australia is dominated
+      by two species, Eucalyptus tetrodonta and E. miniata, which occur either singly
+      or in combination (Brock 1988). The non- eucalypt understorey includes evergreen
+      species as well as obligate and facultative deciduous species. There is a moderate
+      vegetation cover with annual and perennial grasses, herbs, and vines during
+      the wet season. Two natural eucalypt woodland sites, located near the Ranger
+      uranium mine and at Kapalga, had not been subjected to are for 3-4 years prior
+      to sampling. Soils are well-draining sandy loams or loams, and during the wet
+      season both sites are temporarily flooded. Results obtained for the two locations
+      were combined. Disturbed eucalypt woodlands included a site at Kapalga which
+      had been burnt annually since 1990 (burnt woodland) in the late dry season.
+      Another eucalypt woodland located near the Ranger uranium mine, which received
+      irrigation with excess mine waste water in the wet season, was studied (irrigated
+      eucalypt woodland). Waste water from the ore-leaching process was applied to
+      the site in 1985, 1987, 1989, and 1991. During those five years the site received
+      a substantial input of mineral elements, in particular sulfate (26,000 kg ha)1),
+      magnesium (5500 kg ha)1), sodium (1600 kg ha)1) and calcium (1,100 kg ha)1).
+      In contrast, the content of P and N (as NO3 ) in the waste water was low (Ashwath
+      personal communication). MgSO4 salt crusts partly cover the soil surface and
+      the water table is high (within 1 m). Some species have been dying as a result
+      of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu8:
     description: woodlands
     latitude (deg): -12.65
     longitude (deg): 132.9166667
-    MAP (mm): 1475.0
-    soil total P (mg/g): .na.real
-    soil total N (mg/g): .na.real
-    longer description: The sandstone escarpment is a rocky terrain with vegetation
-      established in crevices or in small catchments where soil has accumulated. The
-      vegetation is open eucalypt woodland dominated by typical Australian families
-      including Myrtaceae, Proteaceae and Mimosaceae with evergreen scleromorphous
-      and often highly reduced foliage. The vegetation is characterised by a sparse
-      canopy and ground cover (Brock 1988). Samples were taken from Koongarra Saddle.
+    precipitation, MAP (mm): 1475.0
+    soil P, total (mg/kg): .na.real
+    soil N, total (mg/g): .na.real
+    notes: The sandstone escarpment is a rocky terrain with vegetation established
+      in crevices or in small catchments where soil has accumulated. The vegetation
+      is open eucalypt woodland dominated by typical Australian families including
+      Myrtaceae, Proteaceae and Mimosaceae with evergreen scleromorphous and often
+      highly reduced foliage. The vegetation is characterised by a sparse canopy and
+      ground cover (Brock 1988). Samples were taken from Koongarra Saddle.
   Bukbukluk spring:
     description: evergreen "jungle" (spring), Kakadu
-    date collected: 1992
+    data sampled: 1992
     latitude (deg): -13.485
     longitude (deg): 132.249
   near Ubirr:
     description: gallery forest, Kakadu
-    date collected: 1992
+    data sampled: 1992
     latitude (deg): -12.408
     longitude (deg): 132.956
   Kunwardeh lookout at Nurlangi rock:
     description: sandstone woodland, Kakadu
-    date collected: 1992
+    data sampled: 1992
     latitude (deg): -12.86
     longitude (deg): 132.793
   path to Jim Jim falls:
     description: Allosyncarpia woodland, Kakadu
-    date collected: 1992
+    data sampled: 1992
     latitude (deg): -13.272
     longitude (deg): 132.829
 contexts:
@@ -673,4 +669,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: NRA
-

--- a/data/Schmidt_2003/metadata.yml
+++ b/data/Schmidt_2003/metadata.yml
@@ -89,7 +89,7 @@ dataset:
 sites:
   Kakadu1:
     description: waste rock dump
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -157,7 +157,7 @@ sites:
       by wallowing and grazing of feral pigs and water buffaloes.
   Kakadu2:
     description: burnt site
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -186,7 +186,7 @@ sites:
       of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu3:
     description: waste rock dump
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -200,7 +200,7 @@ sites:
       schist (WRD I) and a clayey highly weathered schist (WRD II).
   Kakadu4:
     description: irrigated woodland
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -229,7 +229,7 @@ sites:
       of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu5:
     description: escarpment woodland
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -258,7 +258,7 @@ sites:
       of either high salinity and/or high water table (N. Ashwath, personal communication).
   Kakadu6:
     description: deciduous monsoon forest
-    data sampled: Data collected in dry (July 1994) and wet (Feb 1995)
+    date sampled: Data collected in dry (July 1994) and wet (Feb 1995)
     latitude (deg): -12.65
     longitude (deg): 132.9166667
     precipitation, MAP (mm): 1475.0
@@ -316,22 +316,22 @@ sites:
       ground cover (Brock 1988). Samples were taken from Koongarra Saddle.
   Bukbukluk spring:
     description: evergreen "jungle" (spring), Kakadu
-    data sampled: 1992
+    date sampled: 1992
     latitude (deg): -13.485
     longitude (deg): 132.249
   near Ubirr:
     description: gallery forest, Kakadu
-    data sampled: 1992
+    date sampled: 1992
     latitude (deg): -12.408
     longitude (deg): 132.956
   Kunwardeh lookout at Nurlangi rock:
     description: sandstone woodland, Kakadu
-    data sampled: 1992
+    date sampled: 1992
     latitude (deg): -12.86
     longitude (deg): 132.793
   path to Jim Jim falls:
     description: Allosyncarpia woodland, Kakadu
-    data sampled: 1992
+    date sampled: 1992
     latitude (deg): -13.272
     longitude (deg): 132.829
 contexts:

--- a/data/Schmidt_2010/metadata.yml
+++ b/data/Schmidt_2010/metadata.yml
@@ -71,7 +71,7 @@ sites:
       and 30-year cleared sites (23deg26'S, 146deg30'E) were situated on grazing property
       Monklands (Fig. 1). Buffelgrass was present at cleared sites but was not the
       dominant grass species.
-    MAP (mm): 516
+    precipitation, MAP (mm): 516
   Summerdell:
     longitude (deg): 146.12
     latitude (deg): -23.87
@@ -82,7 +82,7 @@ sites:
       and 30-year cleared sites (23deg26'S, 146deg30'E) were situated on grazing property
       Monklands (Fig. 1). Buffelgrass was present at cleared sites but was not the
       dominant grass species.
-    MAP (mm): 516
+    precipitation, MAP (mm): 516
 contexts:
   Cleared:
     description: Measurements made in previously cleared sites
@@ -353,4 +353,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schulze_1998/metadata.yml
+++ b/data/Schulze_1998/metadata.yml
@@ -67,141 +67,141 @@ sites:
   Ayers Rock:
     latitude (deg): -25.345556
     longitude (deg): 131.032222
-    MAP (mm): 310.0
+    precipitation, MAP (mm): 310.0
     description: shallow depression in sandstone
   Giles:
     latitude (deg): -25.046389
     longitude (deg): 128.310833
-    MAP (mm): 245.0
+    precipitation, MAP (mm): 245.0
     description: floodplain near creek
   Giles Jct:
     latitude (deg): -25.146667
     longitude (deg): 128.565278
-    MAP (mm): 245.0
+    precipitation, MAP (mm): 245.0
     description: spinifex sandplain
   Kapalga B:
     latitude (deg): -11.767222
     longitude (deg): 130.880278
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Burnt annually. Closed forest.
   Kapalga C:
     latitude (deg): -12.692778
     longitude (deg): 132.384722
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Unburnt for 15 years.
   Kapalga K:
     latitude (deg): -12.693
     longitude (deg): 132.385
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Burnt plot.
   Kapalga M:
     latitude (deg): -12.693
     longitude (deg): 132.385
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Unburnt.
   Kapalga P:
     latitude (deg): -12.693
     longitude (deg): 132.385
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Burnt.
   Kapalga Q:
     latitude (deg): -12.563611
     longitude (deg): 132.3075
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Unburnt dry slope. Open forest.
   Kapalga S:
     latitude (deg): -12.564
     longitude (deg): 132.308
-    MAP (mm): 1344.0
+    precipitation, MAP (mm): 1344.0
     description: Tall forest with grass understory. Unburnt.
   Katherine 1:
     latitude (deg): -14.3
     longitude (deg): 132.091389
-    MAP (mm): 970.0
+    precipitation, MAP (mm): 970.0
     description: open forest with grass understory
   Katherine 2:
     latitude (deg): -14.586389
     longitude (deg): 132.160556
-    MAP (mm): 970.0
+    precipitation, MAP (mm): 970.0
     description: open forest with grass groundcover
   Kidman Springs 1:
     latitude (deg): -16.13
     longitude (deg): 130.933056
-    MAP (mm): 590.0
+    precipitation, MAP (mm): 590.0
     description: open savanna, clay, grazed
   Kidman Springs 2:
     latitude (deg): -16.096667
     longitude (deg): 130.890556
-    MAP (mm): 590.0
+    precipitation, MAP (mm): 590.0
     description: sand, open forest, grass
   Kidman Springs 3:
     latitude (deg): -16.097
     longitude (deg): 130.891
-    MAP (mm): 590.0
+    precipitation, MAP (mm): 590.0
     description: spinifex laterite savanna
   Kintore:
     latitude (deg): -23.376667
     longitude (deg): 129.378889
-    MAP (mm): 329.0
+    precipitation, MAP (mm): 329.0
     description: spinifex floodplain near creek
   Lake Hopkins:
     latitude (deg): -23.376667
     longitude (deg): 129.378889
-    MAP (mm): 245.0
+    precipitation, MAP (mm): 245.0
     description: spinifex sanddunes
   Melville Island 1:
     latitude (deg): -11.767222
     longitude (deg): 130.880278
-    MAP (mm): 1801.0
+    precipitation, MAP (mm): 1801.0
     description: closed E.nesophila forest
   Mt. Miller:
     latitude (deg): -25.071389
     longitude (deg): 129.578611
-    MAP (mm): 310.0
+    precipitation, MAP (mm): 310.0
     description: sandplain, spinifex
   Mt. Sanford 1:
     latitude (deg): -17.300833
     longitude (deg): 130.756111
-    MAP (mm): 472.0
+    precipitation, MAP (mm): 472.0
     description: red soil, clay+laterite
   Mt. Sanford 2:
     latitude (deg): -17.300556
     longitude (deg): 130.756111
-    MAP (mm): 472.0
+    precipitation, MAP (mm): 472.0
     description: spinifex sandplain
   Olgas:
     latitude (deg): -25.303056
     longitude (deg): 130.697222
-    MAP (mm): 310.0
+    precipitation, MAP (mm): 310.0
     description: sanddunes and floodplain
   Sandy Blight Jct:
     latitude (deg): -23.221944
     longitude (deg): 129.8925
-    MAP (mm): 329.0
+    precipitation, MAP (mm): 329.0
     description: spinifex sandplain
   Tennant Creek 1:
     latitude (deg): -17.741667
     longitude (deg): 133.638611
-    MAP (mm): 485.0
+    precipitation, MAP (mm): 485.0
     description: spinifex sandplain
   Tennant Creek 2:
     latitude (deg): -20.351111
     longitude (deg): 134.237222
-    MAP (mm): 342.0
+    precipitation, MAP (mm): 342.0
     description: clay floodplain
   Tennant Creek 3:
     latitude (deg): -21.145278
     longitude (deg): 134.15583
-    MAP (mm): 342.0
+    precipitation, MAP (mm): 342.0
   Tylers Pass:
     latitude (deg): -23.671667
     longitude (deg): 132.365278
-    MAP (mm): 216.0
+    precipitation, MAP (mm): 216.0
     description: spinifex grassland with few trees hilltop
   Victoria River:
     latitude (deg): -15.586667
     longitude (deg): 131.116111
-    MAP (mm): 803.0
+    precipitation, MAP (mm): 803.0
     description: rocky slope and slopebase savanna
 contexts: .na
 config:
@@ -493,4 +493,3 @@ taxonomic_updates:
   reason: Aign to first of two names given (E. Wenk, 2020-05-26)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schulze_2006/metadata.yml
+++ b/data/Schulze_2006/metadata.yml
@@ -57,7 +57,7 @@ dataset:
   notes: .na
 sites:
   Currency Creek Arboretum:
-    rainfall (mm): 400
+    precipitation, MAP (mm): 400
     latitude (deg): -35.4333333
     longitude (deg): 138.7666667
     description: The arboretum is a private collection of Dean Nicolle (2003), who
@@ -161,4 +161,3 @@ taxonomic_updates:
   reason: Align to APC accepted hybrid (E. Wenk, 2020-05-22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schulze_2006_2/metadata.yml
+++ b/data/Schulze_2006_2/metadata.yml
@@ -64,299 +64,299 @@ sites:
   Adam Range:
     latitude (deg): -28.4008333
     longitude (deg): 122.5677778
-    elevation: 499.0
+    elevation (m): 499.0
   Admuro flat:
     latitude (deg): -28.5652778
     longitude (deg): 120.4822222
-    elevation: 511.0
+    elevation (m): 511.0
   Amelup:
     latitude (deg): -34.1494444
     longitude (deg): 118.235
-    elevation: 195.0
+    elevation (m): 195.0
   Bordon:
     latitude (deg): -33.9194444
     longitude (deg): 118.3288889
-    elevation: 327.0
+    elevation (m): 327.0
   Bore Brakeaway:
     latitude (deg): -29.2427778
     longitude (deg): 121.2561111
-    elevation: 465.0
+    elevation (m): 465.0
   Breakaway:
     latitude (deg): -26.9794444
     longitude (deg): 126.0525
-    elevation: 445.0
+    elevation (m): 445.0
   Bushfire Rock:
     latitude (deg): -32.4258333
     longitude (deg): 119.3563889
-    elevation: 349.0
+    elevation (m): 349.0
   Chinocup:
     latitude (deg): -33.5480556
     longitude (deg): 118.3775
-    elevation: 315.0
+    elevation (m): 315.0
   ConneySue Hwy:
     latitude (deg): -26.5427778
     longitude (deg): 126.4016667
-    elevation: 431.0
+    elevation (m): 431.0
   ConneySueCamp:
     latitude (deg): -26.4272222
     longitude (deg): 126.4127778
-    elevation: 393.0
+    elevation (m): 393.0
   Cosmo Newberry:
     latitude (deg): -28.2272222
     longitude (deg): 122.7319444
-    elevation: 449.0
+    elevation (m): 449.0
   Creek:
     latitude (deg): -26.985
     longitude (deg): 125.7013889
-    elevation: 443.0
+    elevation (m): 443.0
   Denmark:
     latitude (deg): -34.9655556
     longitude (deg): 117.2894444
-    elevation: 169.0
+    elevation (m): 169.0
   Docker River:
     latitude (deg): -24.8711111
     longitude (deg): 129.0569444
-    elevation: 602.0
+    elevation (m): 602.0
   Docker River E:
     latitude (deg): -25.0555556
     longitude (deg): 129.6783333
-    elevation: 643.0
+    elevation (m): 643.0
   Dragon North:
     latitude (deg): -32.6713889
     longitude (deg): 118.9988889
-    elevation: 378.0
+    elevation (m): 378.0
   Dragon Rock:
     latitude (deg): -32.7297222
     longitude (deg): 119.0047222
-    elevation: 406.0
+    elevation (m): 406.0
   Frankland:
     latitude (deg): -34.9105556
     longitude (deg): 116.6888889
-    elevation: 111.0
+    elevation (m): 111.0
   Giles:
     latitude (deg): -25.0611111
     longitude (deg): 128.3294444
-    elevation: 596.0
+    elevation (m): 596.0
   Giles West:
     latitude (deg): -25.0738889
     longitude (deg): 128.1694444
-    elevation: 561.0
+    elevation (m): 561.0
   Grace camp:
     latitude (deg): -33.165
     longitude (deg): 118.4727778
-    elevation: 311.0
+    elevation (m): 311.0
   Halfway Giles:
     latitude (deg): -25.4194444
     longitude (deg): 127.5536111
-    elevation: 590.0
+    elevation (m): 590.0
   Holland 107:
     latitude (deg): -31.8772222
     longitude (deg): 120.1891667
-    elevation: 397.0
+    elevation (m): 397.0
   Holland 128:
     latitude (deg): -31.7802778
     longitude (deg): 120.3433333
-    elevation: 462.0
+    elevation (m): 462.0
   Holland 148:
     latitude (deg): -31.6702778
     longitude (deg): 120.4769444
-    elevation: 454.0
+    elevation (m): 454.0
   Holland 164:
     latitude (deg): -31.5761111
     longitude (deg): 120.5786111
-    elevation: 438.0
+    elevation (m): 438.0
   Holland 21km:
     latitude (deg): -32.2777778
     longitude (deg): 119.5808333
-    elevation: 414.0
+    elevation (m): 414.0
   Holland 23km:
     latitude (deg): -32.2777778
     longitude (deg): 119.5808333
-    elevation: 414.0
+    elevation (m): 414.0
   Holland 69:
     latitude (deg): -32.0497222
     longitude (deg): 119.9027778
-    elevation: 392.0
+    elevation (m): 392.0
   Irving River:
     latitude (deg): -25.0672222
     longitude (deg): 129.8394444
-    elevation: 614.0
+    elevation (m): 614.0
   Jilakin Rock:
     latitude (deg): -32.6647222
     longitude (deg): 118.3258333
-    elevation: 285.0
+    elevation (m): 285.0
   Jutson well:
     latitude (deg): -27.8986111
     longitude (deg): 123.3783333
-    elevation: 454.0
+    elevation (m): 454.0
   Kalcup Rd:
     latitude (deg): -34.5302778
     longitude (deg): 116.01
-    elevation: 7.0
+    elevation (m): 7.0
   Kalgoorlie:
     latitude (deg): -30.6430556
     longitude (deg): 121.4536111
-    elevation: 350.0
+    elevation (m): 350.0
   Lake Ballard:
     latitude (deg): -29.4952778
     longitude (deg): 121.2522222
-    elevation: 370.0
+    elevation (m): 370.0
   Lake Grace:
     latitude (deg): -33.3816667
     longitude (deg): 118.51
-    elevation: 311.0
+    elevation (m): 311.0
   Lake Throssel:
     latitude (deg): -27.9183333
     longitude (deg): 123.6158333
-    elevation: 400.0
+    elevation (m): 400.0
   Ludlow:
     latitude (deg): -33.5813889
     longitude (deg): 115.4991667
-    elevation: 7.0
+    elevation (m): 7.0
   Lunchplace:
     latitude (deg): -27.0002778
     longitude (deg): 126.2269444
-    elevation: 415.0
+    elevation (m): 415.0
   MenzeesII:
     latitude (deg): -29.7613889
     longitude (deg): 121.0627778
-    elevation: 412.0
+    elevation (m): 412.0
   Menzies:
     latitude (deg): -29.905
     longitude (deg): 121.1188889
-    elevation: 391.0
+    elevation (m): 391.0
   Mt Holland:
     latitude (deg): -32.1647222
     longitude (deg): 119.7488889
-    elevation: 442.0
+    elevation (m): 442.0
   Mt. Baker:
     latitude (deg): -34.7441667
     longitude (deg): 117.5061111
-    elevation: 108.0
+    elevation (m): 108.0
   Mt. Morrains:
     latitude (deg): -28.7641667
     longitude (deg): 121.9683333
-    elevation: 434.0
+    elevation (m): 434.0
   Mundaring:
     latitude (deg): -31.8908333
     longitude (deg): 116.2491667
-    elevation: 278.0
+    elevation (m): 278.0
   Myalup:
     latitude (deg): -33.0069444
     longitude (deg): 115.7430556
-    elevation: 27.0
+    elevation (m): 27.0
   Nanicup:
     latitude (deg): -33.7111111
     longitude (deg): 118.365
-    elevation: 341.0
+    elevation (m): 341.0
   Near Giles:
     latitude (deg): -25.2980556
     longitude (deg): 127.86
-    elevation: 522.0
+    elevation (m): 522.0
   Near Mt. Olga:
     latitude (deg): -25.2280556
     longitude (deg): 130.5797222
-    elevation: 572.0
+    elevation (m): 572.0
   Neili Jucn:
     latitude (deg): -26.3677778
     longitude (deg): 126.285
-    elevation: 468.0
+    elevation (m): 468.0
   On Road:
     latitude (deg): -27.0077778
     longitude (deg): 126.2497222
-    elevation: 428.0
+    elevation (m): 428.0
   Parallel Rd:
     latitude (deg): -27.0377778
     longitude (deg): 125.2405556
-    elevation: 439.0
+    elevation (m): 439.0
   Peterman Range:
     latitude (deg): -24.8369444
     longitude (deg): 128.9336111
-    elevation: 608.0
+    elevation (m): 608.0
   Pingrup:
     latitude (deg): -33.5983333
     longitude (deg): 118.4413889
-    elevation: 298.0
+    elevation (m): 298.0
   Quarzripe:
     latitude (deg): -29.2422222
     longitude (deg): 121.2522222
-    elevation: 465.0
+    elevation (m): 465.0
   Queen Victoria Rock:
     latitude (deg): -31.1913889
     longitude (deg): 120.9422222
-    elevation: 429.0
+    elevation (m): 429.0
   Rd Warburton:
     latitude (deg): -26.2347222
     longitude (deg): 126.2763889
-    elevation: 431.0
+    elevation (m): 431.0
   Rifle range:
     latitude (deg): -31.8844444
     longitude (deg): 116.2619444
-    elevation: 278.0
+    elevation (m): 278.0
   Sanddune II:
     latitude (deg): -26.9958333
     longitude (deg): 125.5588889
-    elevation: 396.0
+    elevation (m): 396.0
   Sanddune III:
     latitude (deg): -26.9961111
     longitude (deg): 125.5938889
-    elevation: 399.0
+    elevation (m): 399.0
   Sanddunes:
     latitude (deg): -26.9986111
     longitude (deg): 125.5338889
-    elevation: 419.0
+    elevation (m): 419.0
   Sideroad I:
     latitude (deg): -27.0375
     longitude (deg): 125.2361111
-    elevation: 449.0
+    elevation (m): 449.0
   Stirling Range:
     latitude (deg): -34.3788889
     longitude (deg): 117.7797222
-    elevation: 264.0
+    elevation (m): 264.0
   Thursday Rock:
     latitude (deg): -31.5111111
     longitude (deg): 120.8163889
-    elevation: 434.0
+    elevation (m): 434.0
   Tjukayiria Roadhouse:
     latitude (deg): -27.0525
     longitude (deg): 125.1491667
-    elevation: 459.0
+    elevation (m): 459.0
   Twin Rock:
     latitude (deg): -32.1102778
     longitude (deg): 118.7933333
-    elevation: 374.0
+    elevation (m): 374.0
   Walpole:
     latitude (deg): -34.9697222
     longitude (deg): 116.7913889
-    elevation: 169.0
+    elevation (m): 169.0
   Warburton:
     latitude (deg): -25.8808333
     longitude (deg): 126.9127778
-    elevation: 496.0
+    elevation (m): 496.0
   Warburton Camp:
     latitude (deg): -28.3847222
     longitude (deg): 122.5852778
-    elevation: 509.0
+    elevation (m): 509.0
   Warburton II:
     latitude (deg): -25.8272222
     longitude (deg): 127.0111111
-    elevation: 519.0
+    elevation (m): 519.0
   Warburton W:
     latitude (deg): -28.2272222
     longitude (deg): 122.7319444
-    elevation: 484.0
+    elevation (m): 484.0
   Warren:
     latitude (deg): -34.4919444
     longitude (deg): 115.9516667
-    elevation: 7.0
+    elevation (m): 7.0
   Yanchep:
     latitude (deg): -31.545
     longitude (deg): 115.6747222
-    elevation: 26.0
+    elevation (m): 26.0
   York:
     latitude (deg): -31.8952778
     longitude (deg): 116.5586111
-    elevation: 351.0
+    elevation (m): 351.0
 contexts: .na
 config:
   data_is_long_format: no
@@ -514,4 +514,3 @@ taxonomic_updates:
   reason: Align to genus, because unrecognised hybrid (E. Wenk, 2020-05-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Schulze_2014/metadata.yml
+++ b/data/Schulze_2014/metadata.yml
@@ -47,676 +47,676 @@ dataset:
   notes: none
 sites:
   Currency Creek Arboretum:
-    description: Currency Creek Arboretum
+    locality: Currency Creek Arboretum
     latitude (deg): -35.42917
     longitude (deg): 138.76278
-    soil: sand-loam over clay
-    vegetation: woodland
-    habitat: gentle hillslope
+    soil type: sand-loam over clay
+    description: woodland
+    landform: gentle hillslope
     surface/groundwater access: 'no'
-    fire: unburnt
-    Rainfall: .na.real
+    fire history: unburnt
+    precipitation, MAP (mm): .na.real
   site_1:
-    description: Lancelin coastal heathland
+    locality: Lancelin coastal heathland
     latitude (deg): -31.014
     longitude (deg): 115.33
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
     surface/groundwater access: .na.character
-    fire: '?'
-    Rainfall: 500.0
+    fire history: '?'
+    precipitation, MAP (mm): 500.0
   site_10:
-    description: Sand
+    locality: Sand
     latitude (deg): -30.2625
     longitude (deg): 119.7813889
-    soil: sand
-    vegetation: shrubland
-    habitat: plain
+    soil type: sand
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_11:
-    description: Pittosporum, rock
+    locality: Pittosporum, rock
     latitude (deg): -30.2055556
     longitude (deg): 119.8633333
-    soil: sandy loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: sandy loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_12:
-    description: Sand Acacia dominated
+    locality: Sand Acacia dominated
     latitude (deg): -30.0527778
     longitude (deg): 119.835
-    soil: sand
-    vegetation: shrubland
-    habitat: plain
+    soil type: sand
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_13:
-    description: Sand with Casuarina
+    locality: Sand with Casuarina
     latitude (deg): -30.0063889
     longitude (deg): 119.7886111
-    soil: sandy loam
-    vegetation: open shrubland
-    habitat: slightly undulating
+    soil type: sandy loam
+    description: open shrubland
+    landform: slightly undulating
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_14:
-    description: Gravel plain, quartz
+    locality: Gravel plain, quartz
     latitude (deg): -30.0194444
     longitude (deg): 119.6788889
-    soil: loam over quartz
-    vegetation: open woodland
-    habitat: low rise
+    soil type: loam over quartz
+    description: open woodland
+    landform: low rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_15:
-    description: Manning Range
+    locality: Manning Range
     latitude (deg): -29.9958333
     longitude (deg): 119.6266667
-    soil: stony (ironstone)
-    vegetation: shrubland
-    habitat: hillslope
+    soil type: stony (ironstone)
+    description: shrubland
+    landform: hillslope
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_16:
-    description: Road intersect, laterite
+    locality: Road intersect, laterite
     latitude (deg): -29.9511111
     longitude (deg): 119.3983333
-    soil: clay-loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: clay-loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_17:
-    description: Spinifex grassland
+    locality: Spinifex grassland
     latitude (deg): -29.7483333
     longitude (deg): 119.4758333
-    soil: sand
-    vegetation: shrubland
-    habitat: broad rise
+    soil type: sand
+    description: shrubland
+    landform: broad rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_18:
-    description: P theory site
+    locality: P theory site
     latitude (deg): -29.7230556
     longitude (deg): 119.4891667
-    soil: gravelly sand
-    vegetation: shrubland
-    habitat: rise
+    soil type: gravelly sand
+    description: shrubland
+    landform: rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_19:
-    description: Mulga
+    locality: Mulga
     latitude (deg): -29.6744444
     longitude (deg): 119.3661111
-    soil: loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_2:
-    description: Lancelin Pseudo-Pinnicals
+    locality: Lancelin Pseudo-Pinnicals
     latitude (deg): .na.real
     longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
     surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
   site_20:
-    description: Sand after Lake Barlee, 1-2 yrs after burn
+    locality: Sand after Lake Barlee, 1-2 yrs after burn
     latitude (deg): -29.015
     longitude (deg): 118.8908333
-    soil: sand
-    vegetation: open shrubland
-    habitat: plain
+    soil type: sand
+    description: open shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: burnt 2 yr ago
-    Rainfall: 300.0
+    fire history: burnt 2 yr ago
+    precipitation, MAP (mm): 300.0
   site_21:
-    description: Sand Lunch at E. orbifolia burnt
+    locality: Sand Lunch at E. orbifolia burnt
     latitude (deg): -28.7094444
     longitude (deg): 118.6205556
-    soil: gravelly loam
-    vegetation: shrubland
-    habitat: undulating
+    soil type: gravelly loam
+    description: shrubland
+    landform: undulating
     surface/groundwater access: 'no'
-    fire: recently burnt
-    Rainfall: 300.0
+    fire history: recently burnt
+    precipitation, MAP (mm): 300.0
   site_22:
-    description: 42km east of Mullewa, sand and laterite
+    locality: 42km east of Mullewa, sand and laterite
     latitude (deg): -28.4652778
     longitude (deg): 115.9163889
-    soil: gravelly sand
-    vegetation: shrubland
-    habitat: rise
+    soil type: gravelly sand
+    description: shrubland
+    landform: rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_23:
-    description: Mullewa - Yuna, Wheat Belt
+    locality: Mullewa - Yuna, Wheat Belt
     latitude (deg): -28.5319444
     longitude (deg): 115.2383333
-    soil: stony loam
-    vegetation: shrubland
-    habitat: low rise
+    soil type: stony loam
+    description: shrubland
+    landform: low rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_24:
-    description: Kalbarri NP Ranger track
+    locality: Kalbarri NP Ranger track
     latitude (deg): -27.6319444
     longitude (deg): 114.54
-    soil: sand
-    vegetation: shrubland
-    habitat: slightly undulating
+    soil type: sand
+    description: shrubland
+    landform: slightly undulating
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_25:
-    description: Hamelin Stromatolithes turnoff
+    locality: Hamelin Stromatolithes turnoff
     latitude (deg): -26.4433333
     longitude (deg): 114.1680556
-    soil: loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: long unburnt
-    Rainfall: 150.0
+    fire history: long unburnt
+    precipitation, MAP (mm): 150.0
   site_26:
-    description: Campsite Gascoyne River
+    locality: Campsite Gascoyne River
     latitude (deg): -24.9880556
     longitude (deg): 114.8080556
-    soil: clay
-    vegetation: open shrubland
-    habitat: plain
+    soil type: clay
+    description: open shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_27:
-    description: .na.character
+    locality: .na.character
     latitude (deg): -24.9544444
     longitude (deg): 114.9386111
-    soil: sand
-    vegetation: shrubland
-    habitat: low ridge
+    soil type: sand
+    description: shrubland
+    landform: low ridge
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_28:
-    description: .na.character
+    locality: .na.character
     latitude (deg): -24.5336111
     longitude (deg): 114.9822222
-    soil: stony loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: stony loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_29:
-    description: Outlook sandstone + reef
+    locality: Outlook sandstone + reef
     latitude (deg): -24.4997222
     longitude (deg): 115.1405556
-    soil: sand over sandstone
-    vegetation: shrubland
-    habitat: mesa/tableland
+    soil type: sand over sandstone
+    description: shrubland
+    landform: mesa/tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_3:
-    description: Banksia Woodland 90km N Perth
+    locality: Banksia Woodland 90km N Perth
     latitude (deg): .na.real
     longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
     surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
   site_30:
-    description: Campsite
+    locality: Campsite
     latitude (deg): -24.4141667
     longitude (deg): 115.1652778
-    soil: stony loam
-    vegetation: open shrubland
-    habitat: mesa/tableland
+    soil type: stony loam
+    description: open shrubland
+    landform: mesa/tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_31:
-    description: Lyons River
+    locality: Lyons River
     latitude (deg): -23.9572222
     longitude (deg): 115.1266667
-    soil: sand
-    vegetation: open woodland
-    habitat: ephemeral river
+    soil type: sand
+    description: open woodland
+    landform: ephemeral river
     surface/groundwater access: possibly
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_32:
-    description: Mt. Augustus
+    locality: Mt. Augustus
     latitude (deg): -24.2772222
     longitude (deg): 116.9594444
-    soil: stony loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: stony loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_33:
-    description: Plateau on quartzite
+    locality: Plateau on quartzite
     latitude (deg): -24.0197222
     longitude (deg): 117.2208333
-    soil: stony loam
-    vegetation: open shrubland
-    habitat: mesa/tableland
+    soil type: stony loam
+    description: open shrubland
+    landform: mesa/tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_34:
-    description: Gully
+    locality: Gully
     latitude (deg): -24.0108333
     longitude (deg): 117.2630556
-    soil: stony
-    vegetation: shrubland
-    habitat: creek gully
+    soil type: stony
+    description: shrubland
+    landform: creek gully
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 150.0
+    fire history: '?'
+    precipitation, MAP (mm): 150.0
   site_35:
-    description: Slope at Tropic of Capricorn
+    locality: Slope at Tropic of Capricorn
     latitude (deg): -23.5
     longitude (deg): 117.1605556
-    soil: stony
-    vegetation: open shrubland
-    habitat: slightly undulating
+    soil type: stony
+    description: open shrubland
+    landform: slightly undulating
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_36:
-    description: North of Paraburdoo
+    locality: North of Paraburdoo
     latitude (deg): -23.1333333
     longitude (deg): 117.8
-    soil: gravelly loam
-    vegetation: shrubland
-    habitat: slightly undulating
+    soil type: gravelly loam
+    description: shrubland
+    landform: slightly undulating
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_37:
-    description: Mt.  Nameless, 1120m
+    locality: Mt.  Nameless, 1120m
     latitude (deg): -22.7191667
     longitude (deg): 117.7613889
-    soil: rocky/stony
-    vegetation: shrubland
-    habitat: hill top
+    soil type: rocky/stony
+    description: shrubland
+    landform: hill top
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 400.0
+    fire history: '?'
+    precipitation, MAP (mm): 400.0
   site_38:
-    description: Road to Mt. Sheila
+    locality: Road to Mt. Sheila
     latitude (deg): -22.2541667
     longitude (deg): 117.6697222
-    soil: sandy loam
-    vegetation: open woodland
-    habitat: plain
+    soil type: sandy loam
+    description: open woodland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 400.0
+    fire history: '?'
+    precipitation, MAP (mm): 400.0
   site_39:
-    description: North Hamersly Range
+    locality: North Hamersly Range
     latitude (deg): -22.3213889
     longitude (deg): 118.5436111
-    soil: loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 400.0
+    fire history: '?'
+    precipitation, MAP (mm): 400.0
   site_4:
-    description: Southern Cross
+    locality: Southern Cross
     latitude (deg): -31.2136111
     longitude (deg): 119.3455556
-    soil: loam
-    vegetation: woodland
-    habitat: plain
+    soil type: loam
+    description: woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_40:
-    description: .na.character
+    locality: .na.character
     latitude (deg): -20.6636111
     longitude (deg): 120.0730556
-    soil: loam
-    vegetation: shrubland
-    habitat: plain
+    soil type: loam
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 500.0
+    fire history: '?'
+    precipitation, MAP (mm): 500.0
   site_41:
-    description: short before Coastal Highway
+    locality: short before Coastal Highway
     latitude (deg): -19.9727778
     longitude (deg): 120.2205556
-    soil: sand
-    vegetation: shrubland
-    habitat: plain
+    soil type: sand
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 500.0
+    fire history: '?'
+    precipitation, MAP (mm): 500.0
   site_42:
-    description: 270km South of Broome
+    locality: 270km South of Broome
     latitude (deg): -19.4555556
     longitude (deg): 121.4747222
-    soil: sand
-    vegetation: shrubland
-    habitat: plain
+    soil type: sand
+    description: shrubland
+    landform: plain
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 500.0
+    fire history: '?'
+    precipitation, MAP (mm): 500.0
   site_43:
-    description: Halfway Broome - Derby
+    locality: Halfway Broome - Derby
     latitude (deg): -17.6461111
     longitude (deg): 123.1544444
-    soil: loam
-    vegetation: open woodland
-    habitat: plain
+    soil type: loam
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1200.0
+    fire history: '?'
+    precipitation, MAP (mm): 1200.0
   site_44:
-    description: Plain East of Derby
+    locality: Plain East of Derby
     latitude (deg): -17.3541667
     longitude (deg): 123.7444444
-    soil: gravelly loam
-    vegetation: open woodland
-    habitat: plain
+    soil type: gravelly loam
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_45:
-    description: Napier Range
+    locality: Napier Range
     latitude (deg): -17.2436111
     longitude (deg): 124.8761111
-    soil: clay
-    vegetation: open woodland
-    habitat: plain
+    soil type: clay
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_46:
-    description: 40km East of Barnett River Roadhouse, road building camp, granite
-      and sand
+    locality: 40km East of Barnett River Roadhouse, road building camp, granite and
+      sand
     latitude (deg): -16.9055556
     longitude (deg): 125.7611111
-    soil: rocky (sandstone)
-    vegetation: open woodland
-    habitat: tableland
+    soil type: rocky (sandstone)
+    description: open woodland
+    landform: tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_47:
-    description: Walcott Track, C. papillosa site
+    locality: Walcott Track, C. papillosa site
     latitude (deg): -16.0072222
     longitude (deg): 125.5891667
-    soil: sand
-    vegetation: open woodland
-    habitat: plain
+    soil type: sand
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_48:
-    description: Munja Camp
+    locality: Munja Camp
     latitude (deg): .na.real
     longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
     surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
   site_49:
-    description: Near coast, table land
+    locality: Near coast, table land
     latitude (deg): -16.2672222
     longitude (deg): 125.0525
-    soil: rocky
-    vegetation: open woodland
-    habitat: low hills
+    soil type: rocky
+    description: open woodland
+    landform: low hills
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_5:
-    description: .na.character
+    locality: .na.character
     latitude (deg): -30.9955556
     longitude (deg): 119.4655556
-    soil: loam
-    vegetation: woodland
-    habitat: plain
+    soil type: loam
+    description: woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_50:
-    description: Timm's creek
+    locality: Timm's creek
     latitude (deg): -16.1452778
     longitude (deg): 125.1391667
-    soil: loam
-    vegetation: woodland
-    habitat: creek flat
+    soil type: loam
+    description: woodland
+    landform: creek flat
     surface/groundwater access: possibly
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_51:
-    description: Sandstone East of Calder River, quartzite
+    locality: Sandstone East of Calder River, quartzite
     latitude (deg): -16.0275
     longitude (deg): 125.2313889
-    soil: rocky (sandstone)
-    vegetation: open woodland
-    habitat: mesa/tableland
+    soil type: rocky (sandstone)
+    description: open woodland
+    landform: mesa/tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_52:
-    description: Rock surface, 100km East of Mt. Elizabeth Station
+    locality: Rock surface, 100km East of Mt. Elizabeth Station
     latitude (deg): -16.0072222
     longitude (deg): 125.4719444
-    soil: rocky (sandstone)
-    vegetation: open woodland
-    habitat: mesa/tableland
+    soil type: rocky (sandstone)
+    description: open woodland
+    landform: mesa/tableland
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_53:
-    description: Sand, 80km East of Mt. Elizabeth Station
+    locality: Sand, 80km East of Mt. Elizabeth Station
     latitude (deg): -16.0469444
     longitude (deg): 125.6641667
-    soil: sand
-    vegetation: low forest
-    habitat: plain
+    soil type: sand
+    description: low forest
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_54:
-    description: Drysdale Roadhouse
+    locality: Drysdale Roadhouse
     latitude (deg): -15.7136111
     longitude (deg): 126.3869444
-    soil: gravelly sand
-    vegetation: open woodland
-    habitat: plain
+    soil type: gravelly sand
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_55:
-    description: 60km East of intersect
+    locality: 60km East of intersect
     latitude (deg): -15.9891667
     longitude (deg): 126.9775
-    soil: stony loam
-    vegetation: open woodland
-    habitat: plain
+    soil type: stony loam
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_56:
-    description: River Crossing Homeland, sand trap
+    locality: River Crossing Homeland, sand trap
     latitude (deg): -15.5805556
     longitude (deg): 127.7647222
-    soil: sand (alluvial)
-    vegetation: shrubland
-    habitat: creek
+    soil type: sand (alluvial)
+    description: shrubland
+    landform: creek
     surface/groundwater access: possibly
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_57:
-    description: Return plateau, dry spot
+    locality: Return plateau, dry spot
     latitude (deg): -15.5852778
     longitude (deg): 127.7633333
-    soil: stony (sandstone)
-    vegetation: open woodland
-    habitat: rolling hills
+    soil type: stony (sandstone)
+    description: open woodland
+    landform: rolling hills
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_58:
-    description: Wyndham Five River Lookout
+    locality: Wyndham Five River Lookout
     latitude (deg): -15.4508333
     longitude (deg): 128.1202778
-    soil: rocky/stony
-    vegetation: open woodland
-    habitat: hill top
+    soil type: rocky/stony
+    description: open woodland
+    landform: hill top
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_59:
-    description: Bungle Bungle, sand / gravel
+    locality: Bungle Bungle, sand / gravel
     latitude (deg): -17.4669444
     longitude (deg): 128.4683333
-    soil: rocky (basalt)
-    vegetation: open woodland
-    habitat: low ridge
+    soil type: rocky (basalt)
+    description: open woodland
+    landform: low ridge
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1200.0
+    fire history: '?'
+    precipitation, MAP (mm): 1200.0
   site_6:
-    description: Iron Mine Koolianobing
+    locality: Iron Mine Koolianobing
     latitude (deg): -30.7961111
     longitude (deg): 119.5363889
-    soil: clay-loam
-    vegetation: woodland
-    habitat: plain
+    soil type: clay-loam
+    description: woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_60:
-    description: Bungle Bungle, sand
+    locality: Bungle Bungle, sand
     latitude (deg): -17.3991667
     longitude (deg): 128.2830556
-    soil: gravelly sand
-    vegetation: shrubland
-    habitat: undulating
+    soil type: gravelly sand
+    description: shrubland
+    landform: undulating
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_61:
-    description: Great Northern Highway
+    locality: Great Northern Highway
     latitude (deg): .na.real
     longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
     surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
   site_62:
-    description: Great Northern Highway
+    locality: Great Northern Highway
     latitude (deg): -16.0127778
     longitude (deg): 128.4247222
-    soil: '?'
-    vegetation: open woodland
-    habitat: '?'
+    soil type: '?'
+    description: open woodland
+    landform: '?'
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_63:
-    description: Great Northern Highway
+    locality: Great Northern Highway
     latitude (deg): -15.2413889
     longitude (deg): 128.4994444
-    soil: '?'
-    vegetation: open woodland
-    habitat: plain
+    soil type: '?'
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_64:
-    description: 20km West of Kununurra
+    locality: 20km West of Kununurra
     latitude (deg): -15.7683333
     longitude (deg): 126.6069444
-    soil: sand over rock
-    vegetation: open woodland
-    habitat: undulating
+    soil type: sand over rock
+    description: open woodland
+    landform: undulating
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 1600.0
+    fire history: '?'
+    precipitation, MAP (mm): 1600.0
   site_65:
-    description: Ashburn River
+    locality: Ashburn River
     latitude (deg): .na.real
     longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
-    surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
-  site_66:
-    description: Drysdale River
-    latitude (deg): .na.real
-    longitude (deg): .na.real
-    soil: .na.character
-    vegetation: .na.character
-    habitat: .na.character
-    surface/groundwater access: .na.character
-    fire: .na.character
-    Rainfall: .na.real
-  site_7:
+    soil type: .na.character
     description: .na.character
+    landform: .na.character
+    surface/groundwater access: .na.character
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
+  site_66:
+    locality: Drysdale River
+    latitude (deg): .na.real
+    longitude (deg): .na.real
+    soil type: .na.character
+    description: .na.character
+    landform: .na.character
+    surface/groundwater access: .na.character
+    fire history: .na.character
+    precipitation, MAP (mm): .na.real
+  site_7:
+    locality: .na.character
     latitude (deg): -30.7483333
     longitude (deg): 119.5583333
-    soil: loam
-    vegetation: open woodland
-    habitat: plain
+    soil type: loam
+    description: open woodland
+    landform: plain
     surface/groundwater access: unlikely
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_8:
-    description: Sandplain with Spinifex
+    locality: Sandplain with Spinifex
     latitude (deg): -30.515
     longitude (deg): 119.5941667
-    soil: sand
-    vegetation: shrubland
-    habitat: broad rise
+    soil type: sand
+    description: shrubland
+    landform: broad rise
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
   site_9:
-    description: .na.character
+    locality: .na.character
     latitude (deg): -30.4305556
     longitude (deg): 119.6338889
-    soil: loam
-    vegetation: open shrubland
-    habitat: undulating
+    soil type: loam
+    description: open shrubland
+    landform: undulating
     surface/groundwater access: 'no'
-    fire: '?'
-    Rainfall: 300.0
+    fire history: '?'
+    precipitation, MAP (mm): 300.0
 contexts: .na
 config:
   data_is_long_format: no
@@ -1296,4 +1296,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (known names) (2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Scott_2010/metadata.yml
+++ b/data/Scott_2010/metadata.yml
@@ -34,7 +34,7 @@ sites:
   Terrick Terrick National Park:
     latitude (deg): -36.1738
     longitude (deg): 144.227
-    rainfall (mm): 400
+    precipitation, MAP (mm): 400
     lat/lon notes: generic lat/lon for the national park, not a specific site location
 contexts: .na
 config:
@@ -63,4 +63,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Scott_2010/metadata.yml
+++ b/data/Scott_2010/metadata.yml
@@ -35,7 +35,7 @@ sites:
     latitude (deg): -36.1738
     longitude (deg): 144.227
     precipitation, MAP (mm): 400
-    lat/lon notes: generic lat/lon for the national park, not a specific site location
+    georeference remarks: generic lat/lon for the national park, not a specific site location
 contexts: .na
 config:
   data_is_long_format: no

--- a/data/Sendall_2016/metadata.yml
+++ b/data/Sendall_2016/metadata.yml
@@ -60,12 +60,12 @@ sites:
       low in complexity and often dominated by just a few species (Royer et al. 2009).
       We chose sites on each substrate with little relief to ensure that drainage
       and water availability did not vary much between comparisons.'
-    MAP (mm): 2300
-    MAT (C): 17.6
+    precipitation, MAP (mm): 2300
+    temperature, MAT (C): 17.6
     elevation (m): 200-300
-    total N (%): 0.49
-    total C (%): 5.6
-    total P (ppm): 1709
+    soil N, total (%): 0.49
+    soil C, total (%): 5.6
+    soil P, total (mg/kg): 1709
   Rhyolite:
     latitude (deg): -28.64
     longitude (deg): 153.34
@@ -85,12 +85,12 @@ sites:
       low in complexity and often dominated by just a few species (Royer et al. 2009).
       We chose sites on each substrate with little relief to ensure that drainage
       and water availability did not vary much between comparisons.'
-    MAP (mm): 2300
-    MAT (C): 17.6
+    precipitation, MAP (mm): 2300
+    temperature, MAT (C): 17.6
     elevation (m): 200-300
-    total N (%): 0.45
-    total C (%): 11.6
-    total P (ppm): 172
+    soil N, total (%): 0.45
+    soil C, total (%): 11.6
+    soil P, total (mg/kg): 172
 contexts: .na
 config:
   data_is_long_format: no
@@ -571,4 +571,3 @@ questions:
     rate at 2 mol m-2 PPFD, Relative growth rate at 4 mol m-2 PPFD, Relative growth
     rate at 8 mol m-2 PPFD, and Relative growth rate at 12 mol m-2 PPFD, Photosynthetic
     Photon Flux Density (PPFD), Relative Growth Rate (RGR)"
-

--- a/data/Smith_1996/metadata.yml
+++ b/data/Smith_1996/metadata.yml
@@ -113,7 +113,7 @@ sites:
     elevation (m): 600.0
     slope angle (degrees): 19.0
     slope aspect (degrees): 344.0
-    site code alternate: T2
+    site code, alternate: T2
   Balfour:
     site code: NWT1
     locality: Tasmania, Balfour Forest Reserve, Circular Head LGA
@@ -122,7 +122,7 @@ sites:
     elevation (m): 190.0
     slope angle (degrees): 7.0
     slope aspect (degrees): 183.0
-    site code alternate: T1
+    site code, alternate: T1
   Cascades:
     site code: NEG1
     locality: NSW, Point Lookout precinct, Armidale Regional Council LGA
@@ -131,7 +131,7 @@ sites:
     elevation (m): 1300.0
     slope angle (degrees): 11.0
     slope aspect (degrees): 158.0
-    site code alternate: A2
+    site code, alternate: A2
   Lumeah:
     site code: BAT1
     locality: NSW, Lumeah Forest Road, Mid-Coast Council LGA
@@ -140,7 +140,7 @@ sites:
     elevation (m): 930.0
     slope angle (degrees): 12.0
     slope aspect (degrees): 251.0
-    site code alternate: A1
+    site code, alternate: A1
   Mathinna:
     site code: NET1
     locality: Tasmania, Mathinna Plains, Dorset LGA
@@ -149,7 +149,7 @@ sites:
     elevation (m): 800.0
     slope angle (degrees): 6.0
     slope aspect (degrees): 294.0
-    site code alternate: T3
+    site code, alternate: T3
 contexts:
   canopy:
     description: Measurements made on canopy leaves

--- a/data/Smith_1996/metadata.yml
+++ b/data/Smith_1996/metadata.yml
@@ -106,50 +106,50 @@ dataset:
   notes: none
 sites:
   Anne:
-    Site code: SWT1
-    State, Locality, LGA: Tasmania, Mt Anne, Derwent Valley LGA
+    site code: SWT1
+    locality: Tasmania, Mt Anne, Derwent Valley LGA
     latitude (deg): -42.9166667
     longitude (deg): 146.4333333
-    altitude (m): 600.0
+    elevation (m): 600.0
     slope angle (degrees): 19.0
     slope aspect (degrees): 344.0
-    alternate site code: T2
+    site code alternate: T2
   Balfour:
-    Site code: NWT1
-    State, Locality, LGA: Tasmania, Balfour Forest Reserve, Circular Head LGA
+    site code: NWT1
+    locality: Tasmania, Balfour Forest Reserve, Circular Head LGA
     latitude (deg): -41.15
     longitude (deg): 144.9833333
-    altitude (m): 190.0
+    elevation (m): 190.0
     slope angle (degrees): 7.0
     slope aspect (degrees): 183.0
-    alternate site code: T1
+    site code alternate: T1
   Cascades:
-    Site code: NEG1
-    State, Locality, LGA: NSW, Point Lookout precinct, Armidale Regional Council LGA
+    site code: NEG1
+    locality: NSW, Point Lookout precinct, Armidale Regional Council LGA
     latitude (deg): -30.5
     longitude (deg): 152.4166667
-    altitude (m): 1300.0
+    elevation (m): 1300.0
     slope angle (degrees): 11.0
     slope aspect (degrees): 158.0
-    alternate site code: A2
+    site code alternate: A2
   Lumeah:
-    Site code: BAT1
-    State, Locality, LGA: NSW, Lumeah Forest Road, Mid-Coast Council LGA
+    site code: BAT1
+    locality: NSW, Lumeah Forest Road, Mid-Coast Council LGA
     latitude (deg): -32.1166667
     longitude (deg): 151.4166667
-    altitude (m): 930.0
+    elevation (m): 930.0
     slope angle (degrees): 12.0
     slope aspect (degrees): 251.0
-    alternate site code: A1
+    site code alternate: A1
   Mathinna:
-    Site code: NET1
-    State, Locality, LGA: Tasmania, Mathinna Plains, Dorset LGA
+    site code: NET1
+    locality: Tasmania, Mathinna Plains, Dorset LGA
     latitude (deg): -41.3333333
     longitude (deg): 147.75
-    altitude (m): 800.0
+    elevation (m): 800.0
     slope angle (degrees): 6.0
     slope aspect (degrees): 294.0
-    alternate site code: T3
+    site code alternate: T3
 contexts:
   canopy:
     description: Measurements made on canopy leaves
@@ -443,4 +443,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-24)
 exclude_observations: .na
 questions: .na
-

--- a/data/Soper_2014/metadata.yml
+++ b/data/Soper_2014/metadata.yml
@@ -50,25 +50,25 @@ sites:
   Alice Springs:
     latitude (deg): -23.51694
     longitude (deg): 133.64917
-    MAP (mm): 250.0
+    precipitation, MAP (mm): 250.0
     notes: Kunoth Paddock
     description: Acacia-dominated mulga woodland
   Darwin:
     latitude (deg): -12.43389
     longitude (deg): 130.92278
-    MAP (mm): 1600.0
+    precipitation, MAP (mm): 1600.0
     notes: Berrimah
     description: Eucalyptus-dominated
   Katherine:
     latitude (deg): -14.47306
     longitude (deg): 132.30306
-    MAP (mm): 1300.0
+    precipitation, MAP (mm): 1300.0
     notes: near Katherine Research Station grazing exclosure experiment
     description: .na.character
   Newcastle Waters:
     latitude (deg): -17.3775
     longitude (deg): 133.40972
-    MAP (mm): 600.0
+    precipitation, MAP (mm): 600.0
     notes: near repeater station
     description: two sub-sites dominated by either Acacia or Eucalyptus
 contexts:
@@ -270,4 +270,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Stewart_1995/metadata.yml
+++ b/data/Stewart_1995/metadata.yml
@@ -53,7 +53,6 @@ sites:
     vegetation: Open Forest
     latitude (deg): -27.2
     longitude (deg): 152.5
-    year collected: '1993'
     MAP (mm): 822.0
     5-yr-rainfall (mm): 979.0
     rain day (per annum): 64.0
@@ -65,7 +64,6 @@ sites:
     vegetation: Subtropical rainforest
     latitude (deg): -28.03
     longitude (deg): 152.83
-    year collected: early 1993
     MAP (mm): 1199.0
     5-yr-rainfall (mm): 1199.0
     rain day (per annum): 104.0
@@ -77,7 +75,6 @@ sites:
     vegetation: Brigalow, tropical woodland
     latitude (deg): -24.08
     longitude (deg): 145.0
-    year collected: '1992'
     MAP (mm): 450.0
     5-yr-rainfall (mm): 450.0
     rain day (per annum): 51.0
@@ -89,7 +86,6 @@ sites:
     vegetation: Melaleuca Swamp
     latitude (deg): -27.8
     longitude (deg): 153.1
-    year collected: Dec-92
     MAP (mm): 1244.0
     5-yr-rainfall (mm): 1341.0
     rain day (per annum): 124.0
@@ -102,7 +98,8 @@ config:
   variable_match:
     taxon_name: name_edited
     site_name: site
-  custom_R_code: .na
+    date: date
+  custom_R_code: data %>% mutate(date = ifelse(site == "Loganholme","1992-12",NA), date = ifelse(site == "Idalia","1992",NA), date = ifelse(site == "Gambubal","1993-01",NA), date = ifelse(site == "Coominya","1993",NA))
 traits:
 - var_in: leaf_type(B/N)
   unit_in: .na

--- a/data/Stewart_1995/metadata.yml
+++ b/data/Stewart_1995/metadata.yml
@@ -9,7 +9,7 @@ source:
       a biological integrator of water availability'
     volume: '22'
     number: '1'
-    pages: '51--55'
+    pages: 51--55
     doi: 10.1071/pp9950051
 people:
 - name: George Stewart
@@ -49,49 +49,49 @@ dataset:
     are in the file in the raw data folder
 sites:
   Coominya:
-    description: Coominya
-    vegetation: Open Forest
+    locality: Coominya
+    description: Open Forest
     latitude (deg): -27.2
     longitude (deg): 152.5
-    MAP (mm): 822.0
-    5-yr-rainfall (mm): 979.0
-    rain day (per annum): 64.0
+    precipitation, MAP (mm): 822.0
+    precipitation, 5 year total (mm): 979.0
+    precipitation, rain days (per year): 64.0
     moisture balance (mm per annum): -778.0
-    Jan-Mar rain: .na.real
-    Oct-Mar rain: .na.real
+    precipitation, Jan-Mar (mm): .na.real
+    precipitation, Oct-Mar: .na.real
   Gambubal:
-    description: Gambubul State Forest
-    vegetation: Subtropical rainforest
+    locality: Gambubul State Forest
+    description: Subtropical rainforest
     latitude (deg): -28.03
     longitude (deg): 152.83
-    MAP (mm): 1199.0
-    5-yr-rainfall (mm): 1199.0
-    rain day (per annum): 104.0
+    precipitation, MAP (mm): 1199.0
+    precipitation, 5 year total (mm): 1199.0
+    precipitation, rain days (per year): 104.0
     moisture balance (mm per annum): -361.0
-    Jan-Mar rain: .na.real
-    Oct-Mar rain: .na.real
+    precipitation, Jan-Mar (mm): .na.real
+    precipitation, Oct-Mar: .na.real
   Idalia:
-    description: Idalia National Park
-    vegetation: Brigalow, tropical woodland
+    locality: Idalia National Park
+    description: Brigalow, tropical woodland
     latitude (deg): -24.08
     longitude (deg): 145.0
-    MAP (mm): 450.0
-    5-yr-rainfall (mm): 450.0
-    rain day (per annum): 51.0
+    precipitation, MAP (mm): 450.0
+    precipitation, 5 year total (mm): 450.0
+    precipitation, rain days (per year): 51.0
     moisture balance (mm per annum): -2090.0
-    Jan-Mar rain: .na.real
-    Oct-Mar rain: .na.real
+    precipitation, Jan-Mar (mm): .na.real
+    precipitation, Oct-Mar: .na.real
   Loganholme:
-    description: Loganholme
-    vegetation: Melaleuca Swamp
+    locality: Loganholme
+    description: Melaleuca Swamp
     latitude (deg): -27.8
     longitude (deg): 153.1
-    MAP (mm): 1244.0
-    5-yr-rainfall (mm): 1341.0
-    rain day (per annum): 124.0
+    precipitation, MAP (mm): 1244.0
+    precipitation, 5 year total (mm): 1341.0
+    precipitation, rain days (per year): 124.0
     moisture balance (mm per annum): -336.0
-    Jan-Mar rain: 391.0
-    Oct-Mar rain: 718.0
+    precipitation, Jan-Mar (mm): 391.0
+    precipitation, Oct-Mar: 718.0
 contexts: .na
 config:
   data_is_long_format: no
@@ -310,4 +310,3 @@ exclude_observations:
   find: Khaya nyasica, Khaya nyastica
   reason: non-native (E Wenk, 2020.06.18)
 questions: .na
-

--- a/data/Taylor_2008/metadata.yml
+++ b/data/Taylor_2008/metadata.yml
@@ -46,19 +46,19 @@ sites:
   Jilliby_SCA:
     latitude (deg): -33.19833
     longitude (deg): 151.316389
-    MAP (mm): 1350
+    precipitation, MAP (mm): 1350
     description: Woodland within The Jilliby State Conservation area. Dominated by
       E. haemastoma (Smith) and Angophora costata (Smith).
   Royal_NP:
     latitude (deg): -34.098056
     longitude (deg): 151.059444
-    MAP (mm): 1200
+    precipitation, MAP (mm): 1200
     description: Woodland within Royal National Park. Dominated by Eucalyptus haemastoma
       (Smith) and Angophora hispida (Smith).
   Windsor:
     latitude (deg): -33.661667
     longitude (deg): 150.782778
-    MAP (mm): 800
+    precipitation, MAP (mm): 800
     elevation (m): 34
     description: A stand of remnant woodland at Windsor NSW within the bounds of land
       managed by Waste Services NSW. Dominated by by Angophora bakeri (E.C. Hall)
@@ -66,7 +66,7 @@ sites:
   Woggoon_NR:
     latitude (deg): -32.8125
     longitude (deg): 146.933611
-    MAP (mm): 464
+    precipitation, MAP (mm): 464
     elevation (m): 212
     description: Woodland within The Woggoon Nature reserve. Dominated by Eucalyptus
       populnea (F. Muell.) and Callitris glaucophylla (J. Thompson. & L. Johnson).
@@ -314,7 +314,7 @@ traits:
   replicates: 1
   methods: sampled using standard protocols
 substitutions: .na
-taxonomic_updates: 
+taxonomic_updates:
 - find: Callitris glaucophylla
   replace: Callitris columellaris
   reason: Synonym reported by TaxonStand (2020-03-05)
@@ -337,4 +337,3 @@ questions:
     but wanted to confirm these are indeed so low. Your methods indicate they were
     taken under saturating light conditions and therefore we've aligned them to "photosynthetic_rate_per_dry_mass_saturated"
     and "photosynthetic_rate_per_area_saturated".
-

--- a/data/Thomas_2017/metadata.yml
+++ b/data/Thomas_2017/metadata.yml
@@ -72,47 +72,47 @@ sites:
     latitude (deg): -34.7282361
     longitude (deg): 141.5833444
     description: Triodia Mallee and shrubby understorey
-    elevation: 72.0
-    MAP (mm): 290.0
-    mean max temperature (C): 23.8
-    primary productivity (tCha-1 yr-1): 0.9
-    years since fire: 15.0
+    elevation (m): 72.0
+    precipitation, MAP (mm): 290.0
+    temperature, mean yearly max (C): 23.8
+    primary productivity (tons C/ha/year): 0.9
+    fire history (years since fire): 15.0
   MurraySunset_28:
     latitude (deg): -34.6561972
     longitude (deg): 141.7398306
     description: Triodia Mallee and shrubby understorey
-    elevation: 60.0
-    MAP (mm): 290.0
-    mean max temperature (C): 23.8
-    primary productivity (tCha-1 yr-1): 0.9
-    years since fire: 26.0
+    elevation (m): 60.0
+    precipitation, MAP (mm): 290.0
+    temperature, mean yearly max (C): 23.8
+    primary productivity (tons C/ha/year): 0.9
+    fire history (years since fire): 26.0
   MurraySunset_36:
     latitude (deg): -34.5873639
     longitude (deg): 141.7542389
     description: Triodia Mallee and shrubby understorey
-    elevation: 55.0
-    MAP (mm): 290.0
-    mean max temperature (C): 23.8
-    primary productivity (tCha-1 yr-1): 0.9
-    years since fire: 36.0
+    elevation (m): 55.0
+    precipitation, MAP (mm): 290.0
+    temperature, mean yearly max (C): 23.8
+    primary productivity (tons C/ha/year): 0.9
+    fire history (years since fire): 36.0
   MurraySunset_41:
     latitude (deg): -34.7112556
     longitude (deg): 141.488325
     description: Triodia Mallee and shrubby understorey
-    elevation: 84.0
-    MAP (mm): 290.0
-    mean max temperature (C): 23.8
-    primary productivity (tCha-1 yr-1): 0.9
-    years since fire: 41.0
+    elevation (m): 84.0
+    precipitation, MAP (mm): 290.0
+    temperature, mean yearly max (C): 23.8
+    primary productivity (tons C/ha/year): 0.9
+    fire history (years since fire): 41.0
   MurraySunset_86:
     latitude (deg): -34.7086611
     longitude (deg): 141.480425
     description: Triodia Mallee and shrubby understorey
-    elevation: 88.0
-    MAP (mm): 290.0
-    mean max temperature (C): 23.8
-    primary productivity (tCha-1 yr-1): 0.9
-    years since fire: 86.0
+    elevation (m): 88.0
+    precipitation, MAP (mm): 290.0
+    temperature, mean yearly max (C): 23.8
+    primary productivity (tons C/ha/year): 0.9
+    fire history (years since fire): 86.0
 contexts:
   15 years since last fire:
     type: field
@@ -247,4 +247,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Tng_2013/metadata.yml
+++ b/data/Tng_2013/metadata.yml
@@ -61,8 +61,8 @@ sites:
   Arve Valley:
     longitude (deg): 146.76861
     latitude (deg): -43.0772
-    MAT (C): 18.4
-    MAP (mm): 2070
+    temperature, MAT (C): 18.4
+    precipitation, MAP (mm): 2070
     description: We sampled rainforest, and the surrounding giant eucalypt forest
       and open vegetation but did not sample treeless grasslands or sedgelands in
       two regions- tropical north Queensland and cool temperate Tasmania. North Queensland
@@ -76,8 +76,8 @@ sites:
   Herberton:
     longitude (deg): 145.3833
     latitude (deg): -17.3833
-    MAT (C): 27.1
-    MAP (mm): 2240
+    temperature, MAT (C): 27.1
+    precipitation, MAP (mm): 2240
     description: We sampled rainforest, and the surrounding giant eucalypt forest
       and open vegetation but did not sample treeless grasslands or sedgelands in
       two regions- tropical north Queensland and cool temperate Tasmania. North Queensland
@@ -202,4 +202,3 @@ exclude_observations: .na
 questions:
   additional_traits: leaf slenderness (ratio of leaf length to width) and an index
     of bark thickness.
-

--- a/data/Tomlinson_2013/metadata.yml
+++ b/data/Tomlinson_2013/metadata.yml
@@ -124,107 +124,107 @@ dataset:
     species is available in Tomlinson_2019.
 sites:
   Byfield:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    source lat/lon: author
-    Seedlot: DPI 12058
+    lat/lon notes: author
+    seedlot: DPI 12058
   Charters Towers, Qld:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -20.06
     longitude (deg): 146.2
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
   Cloncurry:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -20.71
     longitude (deg): 140.51
-    source lat/lon: AusTraits, generic regional lat/lon based on site name
-    Seedlot: .na.character
+    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    seedlot: .na.character
   Greenvale, Qld:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -19.0
     longitude (deg): 144.98
-    source lat/lon: AusTraits, generic regional lat/lon based on site name
-    Seedlot: .na.character
+    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    seedlot: .na.character
   Herberton:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.38
     longitude (deg): 145.38
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
   Jericho, Qld:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -23.59
     longitude (deg): 146.14
-    source lat/lon: AusTraits, generic regional lat/lon based on site name
-    Seedlot: .na.character
+    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    seedlot: .na.character
   Lava Plains Station:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -18.23
     longitude (deg): 144.69
-    source lat/lon: author
-    Seedlot: DPI 11149
+    lat/lon notes: author
+    seedlot: DPI 11149
   Mareeba, Qld:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
   Mareeba, Queensland:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: DPI 12330
+    lat/lon notes: author
+    seedlot: DPI 12330
   Mount Molloy:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: .na
+    lat/lon notes: author
+    seedlot: .na
   SF865 Byfield:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    source lat/lon: .na.character
-    Seedlot: DPI 12071
+    lat/lon notes: .na.character
+    seedlot: DPI 12071
   Springmount:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.12
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: DPI 2795
+    lat/lon notes: author
+    seedlot: DPI 2795
   SW Queensland:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    source lat/lon: .na.character
-    Seedlot: .na.character
+    lat/lon notes: .na.character
+    seedlot: .na.character
   Townsville:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
   Undarra Volcanic N.P.:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -18.27
     longitude (deg): 144.55
-    source lat/lon: AusTraits, generic regional lat/lon based on site name
-    Seedlot: .na.character
+    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    seedlot: .na.character
   unknown:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    source lat/lon: .na.character
-    Seedlot: .na.character
+    lat/lon notes: .na.character
+    seedlot: .na.character
   Wattle hills, N Qld:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -12.9
     longitude (deg): 143.32
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
 contexts: .na
 config:
   data_is_long_format: no
@@ -474,4 +474,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Tomlinson_2013/metadata.yml
+++ b/data/Tomlinson_2013/metadata.yml
@@ -127,103 +127,103 @@ sites:
     climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 12058
   Charters Towers, Qld:
     climate description: semi-arid
     latitude (deg): -20.06
     longitude (deg): 146.2
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
   Cloncurry:
     climate description: semi-arid
     latitude (deg): -20.71
     longitude (deg): 140.51
-    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    georeference remarks: AusTraits, generic regional lat/lon based on site name
     seedlot: .na.character
   Greenvale, Qld:
     climate description: semi-arid
     latitude (deg): -19.0
     longitude (deg): 144.98
-    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    georeference remarks: AusTraits, generic regional lat/lon based on site name
     seedlot: .na.character
   Herberton:
     climate description: humid
     latitude (deg): -17.38
     longitude (deg): 145.38
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
   Jericho, Qld:
     climate description: semi-arid
     latitude (deg): -23.59
     longitude (deg): 146.14
-    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    georeference remarks: AusTraits, generic regional lat/lon based on site name
     seedlot: .na.character
   Lava Plains Station:
     climate description: semi-arid
     latitude (deg): -18.23
     longitude (deg): 144.69
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 11149
   Mareeba, Qld:
     climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
   Mareeba, Queensland:
     climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 12330
   Mount Molloy:
     climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na
   SF865 Byfield:
     climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     seedlot: DPI 12071
   Springmount:
     climate description: humid
     latitude (deg): -17.12
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 2795
   SW Queensland:
     climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     seedlot: .na.character
   Townsville:
     climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
   Undarra Volcanic N.P.:
     climate description: humid
     latitude (deg): -18.27
     longitude (deg): 144.55
-    lat/lon notes: AusTraits, generic regional lat/lon based on site name
+    georeference remarks: AusTraits, generic regional lat/lon based on site name
     seedlot: .na.character
   unknown:
     climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     seedlot: .na.character
   Wattle hills, N Qld:
     climate description: humid
     latitude (deg): -12.9
     longitude (deg): 143.32
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
 contexts: .na
 config:

--- a/data/Tomlinson_2019/metadata.yml
+++ b/data/Tomlinson_2019/metadata.yml
@@ -137,90 +137,90 @@ dataset:
     leaf_mass_fraction, and stem_mass_fraction.
 sites:
   Byfield:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    source lat/lon: author
-    Seedlot: DPI 12058
+    lat/lon notes: author
+    seedlot: DPI 12058
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
   Charters Towers, Qld:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -20.06
     longitude (deg): 146.2
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
     description: seed collection location
     notes: ''
   Herberton:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.38
     longitude (deg): 145.38
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
     description: seed collection location
   Lava Plains Station:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): -18.23
     longitude (deg): 144.69
-    source lat/lon: author
-    Seedlot: DPI 11149
+    lat/lon notes: author
+    seedlot: DPI 11149
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
   Mareeba, Qld:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
     description: seed collection location
     notes: ''
   Mareeba, Queensland:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: DPI 12330
+    lat/lon notes: author
+    seedlot: DPI 12330
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
   SF865 Byfield:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    source lat/lon: .na.character
-    Seedlot: DPI 12071
+    lat/lon notes: .na.character
+    seedlot: DPI 12071
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
   Springmount:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -17.12
     longitude (deg): 145.42
-    source lat/lon: author
-    Seedlot: DPI 2795
+    lat/lon notes: author
+    seedlot: DPI 2795
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
   SW Queensland:
-    Climate Type: semi-arid
+    climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    source lat/lon: .na.character
-    Seedlot: .na.character
+    lat/lon notes: .na.character
+    seedlot: .na.character
     description: seed collection location
     notes: ''
   Townsville:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
     description: seed collection location
     notes: ''
   Wattle hills, N Qld:
-    Climate Type: humid
+    climate description: humid
     latitude (deg): -12.9
     longitude (deg): 143.32
-    source lat/lon: author
-    Seedlot: .na.character
+    lat/lon notes: author
+    seedlot: .na.character
     description: seed collection location
     notes: ''
 contexts:
@@ -452,4 +452,3 @@ substitutions: .na
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Tomlinson_2019/metadata.yml
+++ b/data/Tomlinson_2019/metadata.yml
@@ -140,7 +140,7 @@ sites:
     climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 12058
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
@@ -148,7 +148,7 @@ sites:
     climate description: semi-arid
     latitude (deg): -20.06
     longitude (deg): 146.2
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
     description: seed collection location
     notes: ''
@@ -156,14 +156,14 @@ sites:
     climate description: humid
     latitude (deg): -17.38
     longitude (deg): 145.38
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
     description: seed collection location
   Lava Plains Station:
     climate description: semi-arid
     latitude (deg): -18.23
     longitude (deg): 144.69
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 11149
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
@@ -171,7 +171,7 @@ sites:
     climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
     description: seed collection location
     notes: ''
@@ -179,7 +179,7 @@ sites:
     climate description: humid
     latitude (deg): -17.0
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 12330
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
@@ -187,7 +187,7 @@ sites:
     climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     seedlot: DPI 12071
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
@@ -195,7 +195,7 @@ sites:
     climate description: humid
     latitude (deg): -17.12
     longitude (deg): 145.42
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: DPI 2795
     description: seed collection location
     notes: seeds collected by "Australian Tree Seed Centre" (https://www.csiro.au/en/Research/Collections/ATSC)
@@ -203,7 +203,7 @@ sites:
     climate description: semi-arid
     latitude (deg): .na.real
     longitude (deg): .na.real
-    lat/lon notes: .na.character
+    georeference remarks: .na.character
     seedlot: .na.character
     description: seed collection location
     notes: ''
@@ -211,7 +211,7 @@ sites:
     climate description: humid
     latitude (deg): -19.43
     longitude (deg): 146.82
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
     description: seed collection location
     notes: ''
@@ -219,7 +219,7 @@ sites:
     climate description: humid
     latitude (deg): -12.9
     longitude (deg): 143.32
-    lat/lon notes: author
+    georeference remarks: author
     seedlot: .na.character
     description: seed collection location
     notes: ''

--- a/data/Turner_2010/metadata.yml
+++ b/data/Turner_2010/metadata.yml
@@ -45,9 +45,9 @@ dataset:
     located sites have been used.
 sites:
   Coolgardie arboretum:
-    Soil type: clay
+    soil type: clay
     elevation (m): 417
-    MAP (mm): 216
+    precipitation, MAP (mm): 216
     latitude (deg): -30.95
     longitude (deg): 121.15
     description: The trees at Coolgardie were planted between 1974 and 1980 in a 5-m
@@ -55,22 +55,22 @@ sites:
       (Table 1). Species were spaced such that the crowns of the individual trees
       did not touch.
   Kalgoorlie arboretum:
-    Soil type: clay
-    MAP (mm): .na
+    soil type: clay
+    precipitation, MAP (mm): .na
     latitude (deg): -30.744
     longitude (deg): 121.449
     description: .na
   Nr. Coolgardie arboretum:
-    Soil type: sand
+    soil type: sand
     elevation (m): 406
-    MAP (mm): 216
+    precipitation, MAP (mm): 216
     latitude (deg): -30.95
     longitude (deg): 121.15
     description: At Coolgardie, one species, Eucalyptus leptopoda, was collected from
       a bush site 1 km from the arboretum.
   Nr. Kalgoorlie arboretum:
-    Soil type: clay
-    MAP (mm): .na
+    soil type: clay
+    precipitation, MAP (mm): .na
     latitude (deg): -30.74
     longitude (deg): 121.45
     description: .na
@@ -195,4 +195,3 @@ taxonomic_updates:
   reason: Name corrected by C. Baxter (2020-02-10)
 exclude_observations: .na
 questions: .na
-

--- a/data/Veneklaas_2003/metadata.yml
+++ b/data/Veneklaas_2003/metadata.yml
@@ -71,14 +71,14 @@ sites:
     latitude (deg): -31.695
     longitude (deg): 115.92167
     description: Banksia woodland growing in very deep, highly leached coarse sands
-    climate: Mediterranean, annual rainfall c. 750 mm, long dry hot summer
-    MAP (mm): 810
-    MAT (C): 18.2
+    climate description: Mediterranean, annual rainfall c. 750 mm, long dry hot summer
+    precipitation, MAP (mm): 810
+    temperature, MAT (C): 18.2
     elevation (m): 15
-    pH: 5.2
-    total N (mg/g): 0.2
-    total P (mg/kg): 0.02
-    additional data: see archived notes file for additional climate data
+    soil pH: 5.2
+    soil N, total (mg/g): 0.2
+    soil P, total (mg/kg): 0.02
+    notes: see archived notes file for additional climate data
 contexts: .na
 config:
   data_is_long_format: no
@@ -293,4 +293,3 @@ taxonomic_updates:
   reason: Align to genus (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Venn_2011/metadata.yml
+++ b/data/Venn_2011/metadata.yml
@@ -81,7 +81,7 @@ sites:
     longitude (deg): 148.286
     description: snowpatch vegetation
     biome: alpine
-    lat/lon notes: A sample lat/lon from near the center of the sites sampled is listed
+    georeference remarks: A sample lat/lon from near the center of the sites sampled is listed
       as the location; this is the 'Club Lake FF' site from Pickering_2014.
 contexts: .na
 config:

--- a/data/Venn_2011/metadata.yml
+++ b/data/Venn_2011/metadata.yml
@@ -80,9 +80,9 @@ sites:
     latitude (deg): -36.417
     longitude (deg): 148.286
     description: snowpatch vegetation
-    region: alpine
-    coordinate source: A sample lat/lon from near the center of the sites sampled
-      is listed as the location; this is the 'Club Lake FF' site from Pickering_2014.
+    biome: alpine
+    lat/lon notes: A sample lat/lon from near the center of the sites sampled is listed
+      as the location; this is the 'Club Lake FF' site from Pickering_2014.
 contexts: .na
 config:
   data_is_long_format: no
@@ -145,4 +145,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Vesk_2004/metadata.yml
+++ b/data/Vesk_2004/metadata.yml
@@ -44,72 +44,72 @@ sites:
   Barrier Hwy 1:
     latitude (deg): -31.58
     longitude (deg): 145.06
-    description: Barrier Hwy west of Cobar in Callitris glaucophylla/Eucalyptus populnea
+    locality: Barrier Hwy west of Cobar in Callitris glaucophylla/Eucalyptus populnea
       woodland
-    vegetation: Callitris glaucophylla/Eucalyptus populnea woodland
-    site name long: Barrier Hwy 1, Cobar
+    description: Callitris glaucophylla/Eucalyptus populnea woodland
+    site code: Barrier Hwy 1, Cobar
   Barrier Hwy 2:
     latitude (deg): -31.52
     longitude (deg): 145.52
-    description: Barrier Hwy west of Cobar in Mulga (Acacia aneura) woodland
-    vegetation: Mulga (Acacia aneura)  shrublands
-    site name long: Barrier Hwy 2, Cobar
+    locality: Barrier Hwy west of Cobar in Mulga (Acacia aneura) woodland
+    description: Mulga (Acacia aneura)  shrublands
+    site code: Barrier Hwy 2, Cobar
   Bay Area:
     latitude (deg): -32.997
     longitude (deg): 146.162
-    description: Round Hill Nature reserve, NSW
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Bay Area, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Bay Area, Round Hill Nature reserve, NSW
   Birdos:
     latitude (deg): -32.969
     longitude (deg): 146.16
-    description: Round Hill Nature reserve, NSW
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Birdos Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Birdos Round Hill Nature reserve, NSW
   Booberoi:
     latitude (deg): -33.025
     longitude (deg): 146.511
-    description: Booberoi Regeneration area, Euabolong NSW. More information of Booberoi
+    locality: Booberoi Regeneration area, Euabolong NSW. More information of Booberoi
       (Condobolin) in Semple, W. S. (1986). Plant species lists from four exclosure
       sites in the Hay District of southwestern New South Wales. Cunninghamia, 1,
       491-502.
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Booberoi Regeneration area, Euabolong NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Booberoi Regeneration area, Euabolong NSW
   Hill:
     latitude (deg): -32.97
     longitude (deg): 146.156
-    description: Round Hill Nature reserve, NSW
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Hill, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Hill, Round Hill Nature reserve, NSW
   Lake Road:
     latitude (deg): -32.999
     longitude (deg): 146.166
-    description: Round Hill Nature reserve, NSW
-    vegetation: Eucalyptus dumosa -E. socialis shrub mallee woodland
-    site name long: Lake Road, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: Eucalyptus dumosa -E. socialis shrub mallee woodland
+    site code: Lake Road, Round Hill Nature reserve, NSW
   Mallee 1:
     latitude (deg): -32.976
     longitude (deg): 146.149
-    description: Round Hill Nature reserve, NSW
-    vegetation: Eucalyptus dumosa -E. socialis shrub mallee woodland
-    site name long: Mallee 1, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: Eucalyptus dumosa -E. socialis shrub mallee woodland
+    site code: Mallee 1, Round Hill Nature reserve, NSW
   Mallee 2:
     latitude (deg): -32.976
     longitude (deg): 146.193
-    description: Round Hill Nature reserve, NSW
-    vegetation: Eucalyptus dumosa -E. socialis shrub mallee woodland
-    site name long: Mallee 2, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: Eucalyptus dumosa -E. socialis shrub mallee woodland
+    site code: Mallee 2, Round Hill Nature reserve, NSW
   Micromyrtus:
     latitude (deg): -32.974
     longitude (deg): 146.15
-    description: Round Hill Nature reserve, NSW
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Micromyrtus, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Micromyrtus, Round Hill Nature reserve, NSW
   Round Hill Camp:
     latitude (deg): -32.973
     longitude (deg): 146.155
-    description: Round Hill Nature reserve, NSW. The climate is warm and semi-arid.
-      The closest meteorological station, Mt. Hope 30 km north-west, has median annual
+    locality: Round Hill Nature reserve, NSW. The climate is warm and semi-arid. The
+      closest meteorological station, Mt. Hope 30 km north-west, has median annual
       rainfall of 370 mm (220- 595, 1st to 9th deciles), and mean maximum daily temperatures
       ranging from 14.28C in July to 32.58C in February (Fig. 1). Monthly rainfall
       is relatively evenly distributed throughout the year, but is associated with
@@ -129,58 +129,58 @@ sites:
       in turn dependent upon the balance More info on Round Hill Sites in Cohn, J.
       S. (1995). The vegetation of Nombinnie and Round Hill nature reserves, central-western
       New South Wales. Cunninghamia, 4(1), 81-101.
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Round Hill Camp, Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Round Hill Camp, Round Hill Nature reserve, NSW
   Sturt National Park:
     latitude (deg): -29.23
     longitude (deg): 141.59
-    description: Sturt NP, Mulga (Acacia aneura)  shrublands in Sturt NP, Cameron
-      Corner Road.
-    vegetation: Mulga (Acacia aneura)  shrublands
-    site name long: Sturt National Park
+    locality: Sturt NP, Mulga (Acacia aneura)  shrublands in Sturt NP, Cameron Corner
+      Road.
+    description: Mulga (Acacia aneura)  shrublands
+    site code: Sturt National Park
   Trangie:
     latitude (deg): -32.0
     longitude (deg): 147.96
-    description: Trangie Agricultural Research Centre and vicinity. Derived grasslands
+    locality: Trangie Agricultural Research Centre and vicinity. Derived grasslands
       in Eucalyptus populnea-Callitris galucophylla woodland, More information on
       Trangie in Biddiscombe, E. F., Cuthbertson, E. G., & Hutchings, R. J. (1954).
       Autecology of some natural pasture species at Trangie, NSW. Australian journal
       of botany, 2(1), 69-98.
-    vegetation: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
-    site name long: Trangie Agricultural research Centre
+    description: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
+    site code: Trangie Agricultural research Centre
   Trangie Cemetery:
     latitude (deg): -32.035
     longitude (deg): 147.96
-    description: Trangie cemetery reserve. No grazing.
-    vegetation: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
-    site name long: Trangie Cemetery
+    locality: Trangie cemetery reserve. No grazing.
+    description: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
+    site code: Trangie Cemetery
   Trangie Cemetery Lawn:
     latitude (deg): -32.035
     longitude (deg): 147.96
-    description: Trangie Agricultural Research Centre and vicinity. Derived grasslands
+    locality: Trangie Agricultural Research Centre and vicinity. Derived grasslands
       in Eucalyptus populnea-Callitris galucophylla woodland
-    vegetation: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
-    site name long: Trangie Cemetery Lawn
+    description: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
+    site code: Trangie Cemetery Lawn
   Trangie Paddock:
     latitude (deg): -32.0
     longitude (deg): 147.96
-    description: Trangie Agricultural Research Centre and vicinity. Derived grasslands
+    locality: Trangie Agricultural Research Centre and vicinity. Derived grasslands
       in Eucalyptus populnea-Callitris galucophylla woodland
-    vegetation: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
-    site name long: Trangie Paddock
+    description: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
+    site code: Trangie Paddock
   Trangie Roadside:
     latitude (deg): -32.0
     longitude (deg): 147.96
-    description: Trangie Agricultural Research Centre and vicinity. Derived grasslands
+    locality: Trangie Agricultural Research Centre and vicinity. Derived grasslands
       in Eucalyptus populnea-Callitris galucophylla woodland
-    vegetation: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
-    site name long: Trangie Roadside
+    description: Derived grasslands in Eucalyptus populnea-Callitris galucophylla woodland
+    site code: Trangie Roadside
   Whooey Tank:
     latitude (deg): -32.962
     longitude (deg): 146.158
-    description: Round Hill Nature reserve, NSW
-    vegetation: open Callitris glaucophylla -Eucalyptus populnea woodland
-    site name long: Whooey Tank, Round Hill Nature reserve, NSW
+    locality: Round Hill Nature reserve, NSW
+    description: open Callitris glaucophylla -Eucalyptus populnea woodland
+    site code: Whooey Tank, Round Hill Nature reserve, NSW
 contexts: .na
 config:
   data_is_long_format: no
@@ -311,4 +311,3 @@ questions:
   additional_traits: Data for basal area, ranking of resprouting ability scaled from
     1 to 10 for different treatments, canopy area, and number of basal stems are in
     the Oikos manuscript.
-

--- a/data/Vesk_2019/metadata.yml
+++ b/data/Vesk_2019/metadata.yml
@@ -69,14 +69,14 @@ sites:
   Round Hill-Nombinnie Nature Reserve:
     latitude (deg): -32.965
     longitude (deg): 146.161
-    MAP (mm): 370
-    average summer temp (C): 32.5
-    average winter temp (C): 14.2
-    soil: loamy red sands light red clays and light red browns earths
-    vegetation types: predominantly open Callitris glaucophylla - Eucalyptus populnea
-      woodland and Eucalyptus dumosa - E. socialis shrub mallee woodland
-    fire frequency: 5-20 years
-    details: A clip-and-burn experiment was conducted in the field on 46 species of
+    precipitation, MAP (mm): 370
+    temperature, summer mean (C): 32.5
+    temperature, winter mean (C): 14.2
+    soil type: loamy red sands light red clays and light red browns earths
+    description: predominantly open Callitris glaucophylla - Eucalyptus populnea woodland
+      and Eucalyptus dumosa - E. socialis shrub mallee woodland
+    fire frequency (years): 5-20 years
+    notes: A clip-and-burn experiment was conducted in the field on 46 species of
       plants across 4 growth forms in order to score resprouting success (see Vesk
       et al., 2004 for details). We included 42 of these species in the present analysis.
       The experiment took place in Round Hill-Nombinnie Nature Reserve, central NSW,
@@ -181,4 +181,3 @@ substitutions:
 taxonomic_updates: .na
 exclude_observations: .na
 questions: .na
-

--- a/data/Warren_2005/metadata.yml
+++ b/data/Warren_2005/metadata.yml
@@ -57,9 +57,9 @@ sites:
     latitude (deg): -36.62
     longitude (deg): 144.3
     elevation (m): 175.0
-    MAP (mm): 550.0
-    soil: gradational profile, from reddish-brown loam with iron-stone (the top 20
-      cm), to orange-brown medium clay (20 to 80 cm), to greyer mottled clays (up
+    precipitation, MAP (mm): 550.0
+    soil type: gradational profile, from reddish-brown loam with iron-stone (the top
+      20 cm), to orange-brown medium clay (20 to 80 cm), to greyer mottled clays (up
       to a depth of 80 to 150 cm or more)
 contexts:
   Bealiba:
@@ -478,4 +478,3 @@ taxonomic_updates:
 exclude_observations: .na
 questions:
   additional_traits: photosystem II quantum yield fluorescence measurement
-

--- a/data/Warren_2006/metadata.yml
+++ b/data/Warren_2006/metadata.yml
@@ -50,38 +50,38 @@ dataset:
 sites:
   Glencoe:
     description: unproductive (xeric)
-    Mean annual increment (m3 ha-1 year-1): 8.0
+    mean annual increment (m3/ha/year): 8.0
     latitude (deg): -38.2666667
     longitude (deg): 147.05
     elevation (m): 60.0
-    MAP (mm): 600.0
+    precipitation, MAP (mm): 600.0
     PET (mm/yr): 1220.0
-    previous land use: Pinus radiata plantation
-    surface soil texture: Loamy sand
-    subsoil texture: Sand
-    profile: uniform
-    soi description: Bleached sand with a subsoil pan
-    total soil C (%): 2.2
-    total soil N (%): 0.061
-    Resin bag P (ug P g-1 resin year-1): 29.0
-    Resin bag N (ug N g-1 resin year-1): 26.0
+    land use (previous): Pinus radiata plantation
+    soil texture (surface): Loamy sand
+    soil texture (subsoil): Sand
+    soil profile description: uniform
+    soil type: Bleached sand with a subsoil pan
+    soil C, total (%): 2.2
+    soil N, total (%): 0.061
+    resin bag P (ug P/g resin/year): 29.0
+    resin bag N (ug N/g resin/year): 26.0
   Mt. Worth:
     description: productive (mesic)
-    Mean annual increment (m3 ha-1 year-1): 21.0
+    mean annual increment (m3/ha/year): 21.0
     latitude (deg): -38.3166667
     longitude (deg): 145.9833333
     elevation (m): 400.0
-    MAP (mm): 1220.0
+    precipitation, MAP (mm): 1220.0
     PET (mm/yr): 1010.0
-    previous land use: Improved pasture
-    surface soil texture: Clay loam
-    subsoil texture: Light medium clay
-    profile: gradational
-    soi description: Well structured gradational texture soil
-    total soil C (%): 9.1
-    total soil N (%): 0.74
-    Resin bag P (ug P g-1 resin year-1): 67.0
-    Resin bag N (ug N g-1 resin year-1): 524.0
+    land use (previous): Improved pasture
+    soil texture (surface): Clay loam
+    soil texture (subsoil): Light medium clay
+    soil profile description: gradational
+    soil type: Well structured gradational texture soil
+    soil C, total (%): 9.1
+    soil N, total (%): 0.74
+    resin bag P (ug P/g resin/year): 67.0
+    resin bag N (ug N/g resin/year): 524.0
 contexts:
   ecotype_from_site_with_MAP_ 1000 _and_driest_quarter_rainfall_of_ 183.4 _and_evaporation_of_ 1500:
     Annual rainfall(mm a-1): 1000.0

--- a/data/Weerasinghe_2014/metadata.yml
+++ b/data/Weerasinghe_2014/metadata.yml
@@ -93,317 +93,317 @@ dataset:
     in both data.csv files.
 sites:
   Daintree Rainforest Observatory at location 103-51:
-    Forest location: 103-51
+    plot code: 103-51
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 105-35:
-    Forest location: 105-35
+    plot code: 105-35
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 107-26:
-    Forest location: 107-26
+    plot code: 107-26
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 109-37:
-    Forest location: 109-37
+    plot code: 109-37
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 117-26:
-    Forest location: 117-26
+    plot code: 117-26
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 118-47:
-    Forest location: 118-47
+    plot code: 118-47
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 135-33:
-    Forest location: 135-33
+    plot code: 135-33
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 136-51:
-    Forest location: 136-51
+    plot code: 136-51
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 137-10:
-    Forest location: 137-10
+    plot code: 137-10
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 14-38:
-    Forest location: 14-38
+    plot code: 14-38
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 14-44:
-    Forest location: 14-44
+    plot code: 14-44
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 147-53:
-    Forest location: 147-53
+    plot code: 147-53
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 161-56:
-    Forest location: 161-56
+    plot code: 161-56
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 165-43:
-    Forest location: 165-43
+    plot code: 165-43
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 166-27:
-    Forest location: 166-27
+    plot code: 166-27
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 172-18:
-    Forest location: 172-18
+    plot code: 172-18
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 175-59:
-    Forest location: 175-59
+    plot code: 175-59
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 177-55:
-    Forest location: 177-55
+    plot code: 177-55
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 177-58:
-    Forest location: 177-58
+    plot code: 177-58
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 185-48:
-    Forest location: 185-48
+    plot code: 185-48
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 186-31:
-    Forest location: 186-31
+    plot code: 186-31
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 190-42:
-    Forest location: 190-42
+    plot code: 190-42
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 191-18:
-    Forest location: 191-18
+    plot code: 191-18
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 199-43:
-    Forest location: 199-43
+    plot code: 199-43
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 200-35:
-    Forest location: 200-35
+    plot code: 200-35
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 200-36:
-    Forest location: 200-36
+    plot code: 200-36
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 208-37:
-    Forest location: 208-37
+    plot code: 208-37
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 214-39:
-    Forest location: 214-39
+    plot code: 214-39
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 23-31:
-    Forest location: 23-31
+    plot code: 23-31
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 231-46:
-    Forest location: 231-46
+    plot code: 231-46
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 237-20:
-    Forest location: 237-20
+    plot code: 237-20
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 244-52:
-    Forest location: 244-52
+    plot code: 244-52
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 248-42:
-    Forest location: 248-42
+    plot code: 248-42
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 258-31:
-    Forest location: 258-31
+    plot code: 258-31
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 263-20:
-    Forest location: 263-20
+    plot code: 263-20
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 278-51:
-    Forest location: 278-51
+    plot code: 278-51
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 278-52:
-    Forest location: 278-52
+    plot code: 278-52
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 280-48:
-    Forest location: 280-48
+    plot code: 280-48
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 281-25:
-    Forest location: 281-25
+    plot code: 281-25
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 300-34:
-    Forest location: 300-34
+    plot code: 300-34
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 306-44:
-    Forest location: 306-44
+    plot code: 306-44
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 316-11:
-    Forest location: 316-11
+    plot code: 316-11
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 321-22:
-    Forest location: 321-22
+    plot code: 321-22
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 322-42:
-    Forest location: 322-42
+    plot code: 322-42
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 326-36:
-    Forest location: 326-36
+    plot code: 326-36
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 330-15:
-    Forest location: 330-15
+    plot code: 330-15
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 359-23:
-    Forest location: 359-23
+    plot code: 359-23
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 36-30:
-    Forest location: 36-30
+    plot code: 36-30
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 40-52:
-    Forest location: 40-52
+    plot code: 40-52
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 42-26:
-    Forest location: 42-26
+    plot code: 42-26
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 44-48:
-    Forest location: 44-48
+    plot code: 44-48
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 52-37:
-    Forest location: 52-37
+    plot code: 52-37
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 57-34:
-    Forest location: 57-34
+    plot code: 57-34
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 59-24:
-    Forest location: 59-24
+    plot code: 59-24
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 70-48:
-    Forest location: 70-48
+    plot code: 70-48
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 75-51:
-    Forest location: 75-51
+    plot code: 75-51
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 79-30:
-    Forest location: 79-30
+    plot code: 79-30
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 79-32:
-    Forest location: 79-32
+    plot code: 79-32
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 87-55:
-    Forest location: 87-55
+    plot code: 87-55
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 89-51:
-    Forest location: 89-51
+    plot code: 89-51
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location 94-26:
-    Forest location: 94-26
+    plot code: 94-26
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory at location Mar-36:
-    Forest location: Mar-36
+    plot code: Mar-36
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
   Daintree Rainforest Observatory:
-    Forest location: not specified
+    plot code: not specified
     latitude (deg): -16.117
     longitude (deg): 145.45
     description: lowland tropical wet forest
@@ -724,4 +724,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Westman_1977/metadata.yml
+++ b/data/Westman_1977/metadata.yml
@@ -34,12 +34,13 @@ sites:
     longitude (deg): 153.5
     description: Eucalyptus signata dominated forest 15 m tall on growing a coastal
       sand dune
-    MAP (mm): 1650.0
+    precipitation, MAP (mm): 1650.0
     elevation (m): 100
-    source lat/lon: Westman_1977 amended by AusTraits to align with island location
-    soil: podzols, formed to a depth of 1.2-2.5 m, that are part of the Koureyabba
+    lat/lon notes: Westman_1977 amended by AusTraits to align with island location
+    soil type: podzols, formed to a depth of 1.2-2.5 m, that are part of the Koureyabba
       Landscape unit
-    geology: light tan-coloured sands of approximately 40,000 years of age
+    geology (parent material): light tan-coloured sands of approximately 40,000 years
+      of age
 contexts:
   current leaves:
     type: field
@@ -502,4 +503,3 @@ exclude_observations: .na
 questions:
   additional_traits: flower nutrient concentrations; additional micronutrient concentrations
     for wood, bark
-

--- a/data/Westman_1977/metadata.yml
+++ b/data/Westman_1977/metadata.yml
@@ -30,7 +30,6 @@ dataset:
   notes: originally part of Richards_2008 compilation
 sites:
   North Stradbroke Island:
-    site_name_Richards_2008: Westman&Rogers1977_Stradbroke
     latitude (deg): -27.5
     longitude (deg): 153.5
     description: Eucalyptus signata dominated forest 15 m tall on growing a coastal

--- a/data/Westman_1977/metadata.yml
+++ b/data/Westman_1977/metadata.yml
@@ -36,7 +36,7 @@ sites:
       sand dune
     precipitation, MAP (mm): 1650.0
     elevation (m): 100
-    lat/lon notes: Westman_1977 amended by AusTraits to align with island location
+    georeference remarks: Westman_1977 amended by AusTraits to align with island location
     soil type: podzols, formed to a depth of 1.2-2.5 m, that are part of the Koureyabba
       Landscape unit
     geology (parent material): light tan-coloured sands of approximately 40,000 years

--- a/data/Westoby_2003/metadata.yml
+++ b/data/Westoby_2003/metadata.yml
@@ -55,7 +55,7 @@ sites:
   Ku-Ring-Gai Chase National Park:
     longitude (deg): 151.143
     latitude (deg): -33.694
-    rainfall (mm): 1200
+    precipitation, MAP (mm): 1200
     description: The main dataset concerns perennial dicotyledonous species from low-nutrient
       Hawkesbury sandstone near Sydney, Australia (66 mg kg-1 total soil P, from five
       samples to 10 cm depth spaced across the site, amalgamated before analysis).
@@ -72,13 +72,13 @@ sites:
   Round Hill Nature Reserve woodland:
     longitude (deg): 146.15
     latitude (deg): -32.96
-    rainfall (mm): 390
+    precipitation, MAP (mm): 390
     description: woodland site on a light clay soil with 250 mg kg-1 total soil P
       in the top 10 cm
   Round Hill Nature Reserve mallee:
     longitude (deg): 146.15
     latitude (deg): -32.96
-    rainfall (mm): 390
+    precipitation, MAP (mm): 390
     description: mallee site on a loamy sand with 132 mg kg-1
 contexts: .na
 config:
@@ -189,4 +189,3 @@ taxonomic_updates:
     2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Westoby_2004/metadata.yml
+++ b/data/Westoby_2004/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: Mark Westoby
     year: 2004
-    title: "Unpublished data: Trait data for plant species at Mt Wellington and Sea Acres, Macquarie University"
+    title: 'Unpublished data: Trait data for plant species at Mt Wellington and Sea
+      Acres, Macquarie University'
 people:
 - name: Mark Westoby
   institution: Macquarie University Sydney
@@ -54,24 +55,24 @@ sites:
     latitude (deg): -42.8964
     longitude (deg): 147.2353
     description: alpine heath; sub-alpine heath
-    MAP (mm): 864.0
+    precipitation, MAP (mm): 864.0
     elevation (m): 1260.0
-    MAT (deg C): MAT (deg C)
-    soil type (parent material): derived from Jurassic dolerite
-    Primary disturbance: fire (infrequent)
-    Max canopy height (m): 1m alpine, 3m sub-alpine
-    Mean relative humidity (percent) (0900 h): 83
+    temperature, MAT (C): MAT (deg C)
+    geology (parent material): derived from Jurassic dolerite
+    disturbance: fire (infrequent)
+    crown height, max (m): 1m alpine, 3m sub-alpine
+    mean relative humidity, 0900 h (%): 83
   Sea Acres Nature Reserve:
     latitude (deg): -31.4394
     longitude (deg): 152.9185
     description: sub-tropical rain forest
-    MAP (mm): 1541.0
+    precipitation, MAP (mm): 1541.0
     elevation (m): 7.0
-    MAT (deg C): MAT (deg C)
-    soil type (parent material): .na.character
-    Primary disturbance: .na.character
-    Max canopy height (m): .na.character
-    Mean relative humidity (percent) (0900 h): 77
+    temperature, MAT (C): MAT (deg C)
+    geology (parent material): .na.character
+    disturbance: .na.character
+    crown height, max (m): .na.character
+    mean relative humidity, 0900 h (%): 77
 contexts: .na
 config:
   data_is_long_format: no
@@ -206,4 +207,3 @@ taxonomic_updates:
   reason: Automatic alignment with name in APC list (accepted) (2020-06-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Westoby_2014/metadata.yml
+++ b/data/Westoby_2014/metadata.yml
@@ -84,9 +84,9 @@ source:
     author: Sean M. Gleason and Chris J. Blackman and Scott T. Gleason and Katherine
       A. McCulloh and Troy W. Ocheltree and Mark Westoby
     journal: New Phytologist
-    title: "Vessel scaling in evergreen angiosperm leaves conforms with Murray's
+    title: 'Vessel scaling in evergreen angiosperm leaves conforms with Murray''s
       law and area-filling assumptions: implications for plant size, leaf size and
-      cold tolerance"
+      cold tolerance'
     volume: '218'
     number: '4'
     pages: 1360--1370
@@ -163,200 +163,200 @@ sites:
   Bothwell:
     latitude (deg): -42.387
     longitude (deg): 147.048
-    leaf_area_index (): 2.2
-    soil_organic_C (): 3.886
-    soil_conductivity (dS/m): 0.036
-    soil_pH_(CaCl2): 3.24
-    soil_pH (mol/l): 4.38
-    exc_AI (cmol/kg): 1.465
-    exc_Ca (cmol/kg): 0.93
-    exc_Mg (cmol/kg): 0.644
-    exc_K (cmol/kg): 0.288
-    exc_Na (cmol/kg): 0.09
-    soil_total_N (%): 0.034
-    soil_total_P (mg/kg): 102.848
-    soil_cation_exchange_capacity (cmol(+)/kg): 3.417
-    AI_sat (%): 42.867
-    soil_C:N (): 114.294
-    soil_C:P (): 37.784
-    soil_N:P (): 0.331
+    leaf area index: 2.2
+    soil organic carbon (%): 3.886
+    soil conductivity (dS/m): 0.036
+    soil pH (CaCl2): 3.24
+    soil pH (H2O): 4.38
+    soil exchangeable Al (cmol/kg): 1.465
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.93
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.644
+    soil exchangeable K (cmol/kg, meq/100g): 0.288
+    soil exchangeable Na (cmol/kg, meq/100g): 0.09
+    soil N, total (%): 0.034
+    soil P, total (mg/kg): 102.848
+    soil cation exchange capacity (cmol/kg): 3.417
+    aridity index, saturated (%): 42.867
+    soil C:N: 114.294
+    soil C:P: 37.784
+    soil N:P: 0.331
     description: unknown
   Cardwell:
     latitude (deg): -18.437
     longitude (deg): 146.13
     description: unknown
-    leaf_area_index (): 6.13
-    soil_organic_C (): 3.678
-    soil_conductivity (dS/m): 0.05
-    soil_pH_(CaCl2): 4.78
-    soil_pH (mol/l): 5.66
-    exc_AI (cmol/kg): 0.449
-    exc_Ca (cmol/kg): 4.68
-    exc_Mg (cmol/kg): 1.81
-    exc_K (cmol/kg): 0.21
-    exc_Na (cmol/kg): 0.082
-    soil_total_N (%): 0.188
-    soil_total_P (mg/kg): 131.984
-    soil_cation_exchange_capacity (cmol(+)/kg): 7.231
-    AI_sat (%): 6.212
-    soil_C:N (): 19.564
-    soil_C:P (): 27.867
-    soil_N:P (): 1.424
+    leaf area index: 6.13
+    soil organic carbon (%): 3.678
+    soil conductivity (dS/m): 0.05
+    soil pH (CaCl2): 4.78
+    soil pH (H2O): 5.66
+    soil exchangeable Al (cmol/kg): 0.449
+    soil exchangeable Ca (cmol/kg, meq/100g): 4.68
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.81
+    soil exchangeable K (cmol/kg, meq/100g): 0.21
+    soil exchangeable Na (cmol/kg, meq/100g): 0.082
+    soil N, total (%): 0.188
+    soil P, total (mg/kg): 131.984
+    soil cation exchange capacity (cmol/kg): 7.231
+    aridity index, saturated (%): 6.212
+    soil C:N: 19.564
+    soil C:P: 27.867
+    soil N:P: 1.424
   Claraville:
     latitude (deg): -18.705
     longitude (deg): 141.818
     description: unknown
-    leaf_area_index (): 0.5
-    soil_organic_C (): 0.29
-    soil_conductivity (dS/m): 0
-    soil_pH_(CaCl2): 5.033
-    soil_pH (mol/l): 5.967
-    exc_AI (cmol/kg): 0.113
-    exc_Ca (cmol/kg): 0.827
-    exc_Mg (cmol/kg): 0.167
-    exc_K (cmol/kg): 0.04
-    exc_Na (cmol/kg): 0
-    soil_total_N (%): 0.24
-    soil_total_P (mg/kg): 39.973
-    soil_cation_exchange_capacity (cmol(+)/kg): 1.146
-    AI_sat (%): 9.831
-    soil_C:N (): 1.208
-    soil_C:P (): 7.255
-    soil_N:P (): 6.004
+    leaf area index: 0.5
+    soil organic carbon (%): 0.29
+    soil conductivity (dS/m): 0
+    soil pH (CaCl2): 5.033
+    soil pH (H2O): 5.967
+    soil exchangeable Al (cmol/kg): 0.113
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.827
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.167
+    soil exchangeable K (cmol/kg, meq/100g): 0.04
+    soil exchangeable Na (cmol/kg, meq/100g): 0
+    soil N, total (%): 0.24
+    soil P, total (mg/kg): 39.973
+    soil cation exchange capacity (cmol/kg): 1.146
+    aridity index, saturated (%): 9.831
+    soil C:N: 1.208
+    soil C:P: 7.255
+    soil N:P: 6.004
   Fowlers Gap:
     latitude (deg): -31.074
     longitude (deg): 141.679
     description: Sparse arid scrub.
     elevation (m): 182
-    rainfall (mm): 236
-    temp_min_monthly: 4.3
-    temp_max_monthly: 34
-    aridity index: 0.146
+    precipitation, MAP (mm): 236
+    temperature, monthly min (C): 4.3
+    temperature, monthly max (C): 34
+    aridity index (MAP/PET): 0.146
   Ku-ring-gai:
     latitude (deg): -33.68
     longitude (deg): 151.148
     description: Coastal woodland/scrub.
-    leaf_area_index (): 5.3
-    soil_organic_C (): 2.06
-    soil_conductivity (dS/m): 0.031
-    soil_pH_(CaCl2): 3.86
-    soil_pH (mol/l): 4.68
-    exc_AI (cmol/kg): 1.436
-    exc_Ca (cmol/kg): 0.56
-    exc_Mg (cmol/kg): 0.36
-    exc_K (cmol/kg): 0.056
-    exc_Na (cmol/kg): 0.076
-    soil_total_N (%): 0.094
-    soil_total_P (mg/kg): 54.834
-    soil_cation_exchange_capacity (cmol(+)/kg): 2.488
-    AI_sat (%): 57.714
-    soil_C:N (): 21.915
-    soil_C:P (): 37.568
-    soil_N:P (): 1.714
+    leaf area index: 5.3
+    soil organic carbon (%): 2.06
+    soil conductivity (dS/m): 0.031
+    soil pH (CaCl2): 3.86
+    soil pH (H2O): 4.68
+    soil exchangeable Al (cmol/kg): 1.436
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.56
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.36
+    soil exchangeable K (cmol/kg, meq/100g): 0.056
+    soil exchangeable Na (cmol/kg, meq/100g): 0.076
+    soil N, total (%): 0.094
+    soil P, total (mg/kg): 54.834
+    soil cation exchange capacity (cmol/kg): 2.488
+    aridity index, saturated (%): 57.714
+    soil C:N: 21.915
+    soil C:P: 37.568
+    soil N:P: 1.714
     elevation (m): 201
-    rainfall (mm): 1210
-    temp_min_monthly: 5.3
-    temp_max_monthly: 26.3
-    aridity index: 1.038
+    precipitation, MAP (mm): 1210
+    temperature, monthly min (C): 5.3
+    temperature, monthly max (C): 26.3
+    aridity index (MAP/PET): 1.038
   Longley:
     latitude (deg): -42.982
     longitude (deg): 147.19
     description: unknown
-    leaf_area_index (): 4.49
-    soil_organic_C (): 6.068
-    soil_conductivity (dS/m): 0.073
-    soil_pH_(CaCl2): 2.98
-    soil_pH (mol/l): 4
-    exc_AI (cmol/kg): 2.616
-    exc_Ca (cmol/kg): 0.556
-    exc_Mg (cmol/kg): 1.54
-    exc_K (cmol/kg): 0.23
-    exc_Na (cmol/kg): 0.272
-    soil_total_N (%): 0.262
-    soil_total_P (mg/kg): 92.084
-    soil_cation_exchange_capacity (cmol(+)/kg): 5.214
-    AI_sat (%): 50.169
-    soil_C:N (): 23.16
-    soil_C:P (): 65.896
-    soil_N:P (): 2.845
+    leaf area index: 4.49
+    soil organic carbon (%): 6.068
+    soil conductivity (dS/m): 0.073
+    soil pH (CaCl2): 2.98
+    soil pH (H2O): 4
+    soil exchangeable Al (cmol/kg): 2.616
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.556
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.54
+    soil exchangeable K (cmol/kg, meq/100g): 0.23
+    soil exchangeable Na (cmol/kg, meq/100g): 0.272
+    soil N, total (%): 0.262
+    soil P, total (mg/kg): 92.084
+    soil cation exchange capacity (cmol/kg): 5.214
+    aridity index, saturated (%): 50.169
+    soil C:N: 23.16
+    soil C:P: 65.896
+    soil N:P: 2.845
   Princess Hills:
     latitude (deg): -18.295
     longitude (deg): 145.492
     description: Seasonally dry woodland.
-    leaf_area_index (): 3.68
-    soil_organic_C (): 4.606
-    soil_conductivity (dS/m): 0.04
-    soil_pH_(CaCl2): 4.76
-    soil_pH (mol/l): 5.72
-    exc_AI (cmol/kg): 0.546
-    exc_Ca (cmol/kg): 5.95
-    exc_Mg (cmol/kg): 3.776
-    exc_K (cmol/kg): 0.256
-    exc_Na (cmol/kg): 0.11
-    soil_total_N (%): 0.232
-    soil_total_P (mg/kg): 156.72
-    soil_cation_exchange_capacity (cmol(+)/kg): 10.638
-    AI_sat (%): 5.129
-    soil_C:N (): 19.853
-    soil_C:P (): 29.39
-    soil_N:P (): 1.48
+    leaf area index: 3.68
+    soil organic carbon (%): 4.606
+    soil conductivity (dS/m): 0.04
+    soil pH (CaCl2): 4.76
+    soil pH (H2O): 5.72
+    soil exchangeable Al (cmol/kg): 0.546
+    soil exchangeable Ca (cmol/kg, meq/100g): 5.95
+    soil exchangeable Mg (cmol/kg, meq/100g): 3.776
+    soil exchangeable K (cmol/kg, meq/100g): 0.256
+    soil exchangeable Na (cmol/kg, meq/100g): 0.11
+    soil N, total (%): 0.232
+    soil P, total (mg/kg): 156.72
+    soil cation exchange capacity (cmol/kg): 10.638
+    aridity index, saturated (%): 5.129
+    soil C:N: 19.853
+    soil C:P: 29.39
+    soil N:P: 1.48
     elevation (m): 677
-    rainfall (mm): 1139
-    temp_min_monthly: 10.1
-    temp_max_monthly: 30.6
-    aridity index: 0.717
+    precipitation, MAP (mm): 1139
+    temperature, monthly min (C): 10.1
+    temperature, monthly max (C): 30.6
+    aridity index (MAP/PET): 0.717
   Round Hill:
     latitude (deg): -32.976
     longitude (deg): 146.156
     description: Semi-arid shrubland.
-    leaf_area_index (): 0.64
-    soil_organic_C (): 0.848
-    soil_conductivity (dS/m): 0.022
-    soil_pH_(CaCl2): 5.28
-    soil_pH (mol/l): 6.28
-    exc_AI (cmol/kg): 0.107
-    exc_Ca (cmol/kg): 3.868
-    exc_Mg (cmol/kg): 1.308
-    exc_K (cmol/kg): 0.444
-    exc_Na (cmol/kg): 0.038
-    soil_total_N (%): 0.05
-    soil_total_P (mg/kg): 105.944
-    soil_cation_exchange_capacity (cmol(+)/kg): 5.765
-    AI_sat (%): 1.853
-    soil_C:N (): 16.96
-    soil_C:P (): 8.004
-    soil_N:P (): 0.472
+    leaf area index: 0.64
+    soil organic carbon (%): 0.848
+    soil conductivity (dS/m): 0.022
+    soil pH (CaCl2): 5.28
+    soil pH (H2O): 6.28
+    soil exchangeable Al (cmol/kg): 0.107
+    soil exchangeable Ca (cmol/kg, meq/100g): 3.868
+    soil exchangeable Mg (cmol/kg, meq/100g): 1.308
+    soil exchangeable K (cmol/kg, meq/100g): 0.444
+    soil exchangeable Na (cmol/kg, meq/100g): 0.038
+    soil N, total (%): 0.05
+    soil P, total (mg/kg): 105.944
+    soil cation exchange capacity (cmol/kg): 5.765
+    aridity index, saturated (%): 1.853
+    soil C:N: 16.96
+    soil C:P: 8.004
+    soil N:P: 0.472
     elevation (m): 180
-    rainfall (mm): 383
-    temp_min_monthly: 3.6
-    temp_max_monthly: 33.2
-    aridity index: 0.287
+    precipitation, MAP (mm): 383
+    temperature, monthly min (C): 3.6
+    temperature, monthly max (C): 33.2
+    aridity index (MAP/PET): 0.287
   Yengo:
     latitude (deg): -32.778
     longitude (deg): 150.922
     description: Sclerophyllous woodland.
-    leaf_area_index (): 3.74
-    soil_organic_C (): 4.587
-    soil_conductivity (dS/m): 0.043
-    soil_pH_(CaCl2): 4.433
-    soil_pH (mol/l): 5.233
-    exc_AI (cmol/kg): 2.197
-    exc_Ca (cmol/kg): 0.913
-    exc_Mg (cmol/kg): 0.99
-    exc_K (cmol/kg): 0.457
-    exc_Na (cmol/kg): 0.21
-    soil_total_N (%): 0.147
-    soil_total_P (mg/kg): 222.87
-    soil_cation_exchange_capacity (cmol(+)/kg): 4.767
-    AI_sat (%): 46.091
-    soil_C:N (): 31.273
-    soil_C:P (): 20.58
-    soil_N:P (): 0.658
+    leaf area index: 3.74
+    soil organic carbon (%): 4.587
+    soil conductivity (dS/m): 0.043
+    soil pH (CaCl2): 4.433
+    soil pH (H2O): 5.233
+    soil exchangeable Al (cmol/kg): 2.197
+    soil exchangeable Ca (cmol/kg, meq/100g): 0.913
+    soil exchangeable Mg (cmol/kg, meq/100g): 0.99
+    soil exchangeable K (cmol/kg, meq/100g): 0.457
+    soil exchangeable Na (cmol/kg, meq/100g): 0.21
+    soil N, total (%): 0.147
+    soil P, total (mg/kg): 222.87
+    soil cation exchange capacity (cmol/kg): 4.767
+    aridity index, saturated (%): 46.091
+    soil C:N: 31.273
+    soil C:P: 20.58
+    soil N:P: 0.658
     elevation (m): 310
-    rainfall (mm): 779
-    temp_min_monthly: 2.8
-    temp_max_monthly: 28.6
-    aridity index: 0.598
+    precipitation, MAP (mm): 779
+    temperature, monthly min (C): 2.8
+    temperature, monthly max (C): 28.6
+    aridity index (MAP/PET): 0.598
 contexts: .na
 config:
   data_is_long_format: no
@@ -1300,4 +1300,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Wills_2018/metadata.yml
+++ b/data/Wills_2018/metadata.yml
@@ -65,9 +65,9 @@ sites:
     latitude (deg): -17.11345
     longitude (deg): 145.60134
     elevation (m): 790
-    geology: coarse granite
-    aspect: E
-    rainfall (mm): 1650
+    geology (parent material): coarse granite
+    slope aspect (degrees): E
+    precipitation, MAP (mm): 1650
     description: The vegetation has been classified under the Wet Tropics Management
       Authority vegetation classification (WTMA. 2009) as Simple Notophyll Vine Forests
       (SNVF) type 10a. Within experiment 625, species such as Flindersia pimenteliana
@@ -80,9 +80,9 @@ sites:
     latitude (deg): -17.12013
     longitude (deg): 145.60082
     elevation (m): 730
-    geology: coarse granite
-    aspect: SE
-    rainfall (mm): 1650
+    geology (parent material): coarse granite
+    slope aspect (degrees): SE
+    precipitation, MAP (mm): 1650
     description: The vegetation has been classified under the Wet Tropics Management
       Authority vegetation classification (WTMA. 2009) as Simple Notophyll Vine Forests
       (SNVF) type 10a. Within experiment 625, species such as Flindersia pimenteliana
@@ -95,9 +95,9 @@ sites:
     latitude (deg): -17.17688
     longitude (deg): 145.58667
     elevation (m): 680
-    geology: volcanic
-    aspect: NNW
-    rainfall (mm): 1320
+    geology (parent material): volcanic
+    slope aspect (degrees): NNW
+    precipitation, MAP (mm): 1320
     description: The vegetation has been classified under the Wet Tropics Management
       Authority vegetation classification (WTMA. 2009) as Simple Notophyll Vine Forests
       (SNVF) type 10a. More specifically, the floristics within experiment 78 comprises
@@ -110,9 +110,9 @@ sites:
     latitude (deg): -17.17724
     longitude (deg): 145.58667
     elevation (m): 680
-    geology: metamorphic
-    aspect: NNW
-    rainfall (mm): 1320
+    geology (parent material): metamorphic
+    slope aspect (degrees): NNW
+    precipitation, MAP (mm): 1320
     description: The vegetation has been classified under the Wet Tropics Management
       Authority vegetation classification (WTMA. 2009) as Simple Notophyll Vine Forests
       (SNVF) type 10a. More specifically, the floristics within experiment 78 comprises
@@ -300,4 +300,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Wright_2001/metadata.yml
+++ b/data/Wright_2001/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: Ian J. Wright
     year: 2001
-    title: 'Unpublished data: Seed mass reserve data for various species in NSW, Macquarie University'
+    title: 'Unpublished data: Seed mass reserve data for various species in NSW, Macquarie
+      University'
 people:
 - name: Ian Wright
   institution: Macquarie University Sydney
@@ -36,26 +37,26 @@ dataset:
     is a column in the data.csv file with seed provenance.
 sites:
   loRloP:
-    rainfall: low
-    phosphorus: low
+    precipitation, MAP (mm): low
+    soil P, description: low
     seed provenance: Round Hill mallee, and various seedstock
     latitude (deg): .na
     longitude (deg): .na
   loRhiP:
-    rainfall: low
-    phosphorus: high
+    precipitation, MAP (mm): low
+    soil P, description: high
     seed provenance: Round Hill woodland, and various seedstock
     latitude (deg): .na
     longitude (deg): .na
   hiRloP:
-    rainfall: high
-    phosphorus: low
+    precipitation, MAP (mm): high
+    soil P, description: low
     seed provenance: Murrua Track (KNP), Centre Track (KNP), and various seedstock
     latitude (deg): .na
     longitude (deg): .na
   hiRhiP:
-    rainfall: high
-    phosphorus: high
+    precipitation, MAP (mm): high
+    soil P, description: high
     seed provenance: Westhead (KNP), Shoalhaven (MLF), and various seedstock
     latitude (deg): .na
     longitude (deg): .na
@@ -119,4 +120,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Wright_2002/metadata.yml
+++ b/data/Wright_2002/metadata.yml
@@ -83,51 +83,52 @@ sites:
   Kuring-gai NP hiP:
     longitude (deg): 151.2922222
     latitude (deg): -33.5788889
-    description: Kuring-gai National Park, high P site
-    vegetation: Closed forest
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 442.3
-    soil_total_N (%): 0.256
-    soil_total_C (%): 5.91
-    soil_cation_exchange_capacity (meq/kg): 55.6
-    geology: Red-brown clay (weathered volcanic dyke)
+    locality: Kuring-gai National Park, high P site
+    description: Closed forest
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 442.3
+    soil N, total (%): 0.256
+    soil C, total (%): 5.91
+    soil cation exchange capacity (meq/kg): 55.6
+    geology (stratigraphic map unit): Red-brown clay (weathered volcanic dyke)
   Kuring-gai NP lowP:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
-    description: Kuring-gai National Park, low P site
-    vegetation: Low open woodland
-    nutrient summary: hiRhiP
-    MAP (mm): 1220
-    soil_total_P (ppm): 93.6
-    soil_total_N (%): 0.03
-    soil_total_C (%): 0.95
-    soil_cation_exchange_capacity (meq/kg): 9
-    geology: Yellow-grey sand (Hawkesbury sandstone)
+    locality: Kuring-gai National Park, low P site
+    description: Low open woodland
+    soil nutrient summary: hiRhiP
+    precipitation, MAP (mm): 1220
+    soil P, total (mg/kg): 93.6
+    soil N, total (%): 0.03
+    soil C, total (%): 0.95
+    soil cation exchange capacity (meq/kg): 9
+    geology (stratigraphic map unit): Yellow-grey sand (Hawkesbury sandstone)
   Round Hill woodland:
     longitude (deg): 146.1547222
     latitude (deg): -32.9666667
-    description: Round Hill Nature Reserve, woodland site
-    vegetation: Open woodland
-    nutrient summary: loRhiP
-    MAP (mm): 387
-    soil_total_P (ppm): 250.4
-    soil_total_N (%): 0.071
-    soil_total_C (%): 1.2
-    soil_cation_exchange_capacity (meq/kg): 65.8
-    geology: Light red clay (residual deposits overlying Mt Hope volcanics)
+    locality: Round Hill Nature Reserve, woodland site
+    description: Open woodland
+    soil nutrient summary: loRhiP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 250.4
+    soil N, total (%): 0.071
+    soil C, total (%): 1.2
+    soil cation exchange capacity (meq/kg): 65.8
+    geology (stratigraphic map unit): Light red clay (residual deposits overlying
+      Mt Hope volcanics)
   Round Hill mallee:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
-    description: Round Hill Nature Reserve, mallee site
-    vegetation: Open shrub mallee
-    nutrient summary: loRloP
-    MAP (mm): 387
-    soil_total_P (ppm): 132.4
-    soil_total_N (%): 0.031
-    soil_total_C (%): 0.67
-    soil_cation_exchange_capacity (meq/kg): 38.7
-    geology: Loamy red sand (Quaternary dune systems)
+    locality: Round Hill Nature Reserve, mallee site
+    description: Open shrub mallee
+    soil nutrient summary: loRloP
+    precipitation, MAP (mm): 387
+    soil P, total (mg/kg): 132.4
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
+    geology (stratigraphic map unit): Loamy red sand (Quaternary dune systems)
 contexts: .na
 config:
   data_is_long_format: no
@@ -1028,4 +1029,3 @@ exclude_observations: .na
 questions:
   additional_traits: additional PV curve parameters (solute potential, water content
     at turgor loss, symplastic water fraction)
-

--- a/data/Wright_2006/metadata.yml
+++ b/data/Wright_2006/metadata.yml
@@ -64,7 +64,6 @@ sites:
     MAP (mm): 1400
     MAT (deg): 11
     description: Tall closed forest dominated by mountain ash (Eucalyptus regnans)
-    vegetation: Tall closed forest dominated by mountain ash (Eucalyptus regnans)
 contexts: .na
 config:
   data_is_long_format: no

--- a/data/Wright_2006/metadata.yml
+++ b/data/Wright_2006/metadata.yml
@@ -61,8 +61,8 @@ sites:
   Ash:
     longitude (deg): 145.2333333
     latitude (deg): -37.3833333
-    MAP (mm): 1400
-    MAT (deg): 11
+    precipitation, MAP (mm): 1400
+    temperature, MAT (C): 11
     description: Tall closed forest dominated by mountain ash (Eucalyptus regnans)
 contexts: .na
 config:
@@ -194,4 +194,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Wright_2008/metadata.yml
+++ b/data/Wright_2008/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: Ian J. Wright
     year: 2008
-    title: 'Unpublished data: Trait data for Northern Territory savanna species, Macquarie University'
+    title: 'Unpublished data: Trait data for Northern Territory savanna species, Macquarie
+      University'
 people:
 - name: Ian Wright
   institution: Macquarie University Sydney
@@ -29,34 +30,34 @@ sites:
     latitude (deg): -13.545
     longitude (deg): 132.296
     description: unknown
-    soil_C:N (): 31.9451928
-    soil_total_C (): 1.66
-    soil_total_N (): 0.051964
-    soil_total_P (): 80.9713175
+    soil C:N: 31.9451928
+    soil C, total (%): 1.66
+    soil N, total (%): 0.051964
+    soil P, total (mg/kg): 80.9713175
   Kakadu fireplot 33:
     latitude (deg): -13.517
     longitude (deg): 132.459
     description: unknown
-    soil_C:N (): 25.0843644
-    soil_total_C (): 0.7359
-    soil_total_N (): 0.029337
-    soil_total_P (): 84.1693635
+    soil C:N: 25.0843644
+    soil C, total (%): 0.7359
+    soil N, total (%): 0.029337
+    soil P, total (mg/kg): 84.1693635
   Kakadu fireplot 37:
     latitude (deg): -13.499
     longitude (deg): 132.576
     description: unknown
-    soil_C:N (): 21.3278281
-    soil_total_C (): 0.5837
-    soil_total_N (): 0.027368
-    soil_total_P (): 38.5902973
+    soil C:N: 21.3278281
+    soil C, total (%): 0.5837
+    soil N, total (%): 0.027368
+    soil P, total (mg/kg): 38.5902973
   Kakadu fireplot 41:
     latitude (deg): -13.554
     longitude (deg): 132.272
     description: unknown
-    soil_C:N (): 20.1549935
-    soil_total_C (): 1.381
-    soil_total_N (): 0.068519
-    soil_total_P (): 77.8603413
+    soil C:N: 20.1549935
+    soil C, total (%): 1.381
+    soil N, total (%): 0.068519
+    soil P, total (mg/kg): 77.8603413
   Western Arnhem Land WALFA plot 31:
     latitude (deg): -12.711
     longitude (deg): 133.838
@@ -65,18 +66,18 @@ sites:
     latitude (deg): -12.711
     longitude (deg): 133.836
     description: unknown
-    soil_C:N (): 36.4450475
-    soil_total_C (): 0.2686
-    soil_total_N (): 0.00737
-    soil_total_P (): 10.2563345
+    soil C:N: 36.4450475
+    soil C, total (%): 0.2686
+    soil N, total (%): 0.00737
+    soil P, total (mg/kg): 10.2563345
   Western Arnhem Land WALFA plot 33:
     latitude (deg): -12.71
     longitude (deg): 133.835
     description: unknown
-    soil_C:N (): 25.0843644
-    soil_total_C (): 0.7359
-    soil_total_N (): 0.029337
-    soil_total_P (): 84.1693635
+    soil C:N: 25.0843644
+    soil C, total (%): 0.7359
+    soil N, total (%): 0.029337
+    soil P, total (mg/kg): 84.1693635
   Western Arnhem Land WALFA plot 58:
     latitude (deg): -12.154
     longitude (deg): 133.94
@@ -89,10 +90,10 @@ sites:
     latitude (deg): -12.342
     longitude (deg): 134.365
     description: unknown
-    soil_C:N (): 32.8980954
-    soil_total_C (): 0.6702
-    soil_total_N (): 0.020372
-    soil_total_P (): 28.1607354
+    soil C:N: 32.8980954
+    soil C, total (%): 0.6702
+    soil N, total (%): 0.020372
+    soil P, total (mg/kg): 28.1607354
   Western Arnhem Land WALFA plot 71:
     latitude (deg): -12.357
     longitude (deg): 134.159
@@ -101,10 +102,10 @@ sites:
     latitude (deg): -12.257
     longitude (deg): 134.077
     description: unknown
-    soil_C:N (): 27.2869287
-    soil_total_C (): 1.345
-    soil_total_N (): 0.049291
-    soil_total_P (): 50.1567755
+    soil C:N: 27.2869287
+    soil C, total (%): 1.345
+    soil N, total (%): 0.049291
+    soil P, total (mg/kg): 50.1567755
   Western Arnhem Land WALFA plot 73:
     latitude (deg): -12.13
     longitude (deg): 133.794
@@ -218,4 +219,3 @@ taxonomic_updates:
   reason: Change spelling to Align to APC or ALA species lists (Sam Andrew, 2018-02-07)
 exclude_observations: .na
 questions: .na
-

--- a/data/Wright_2009/metadata.yml
+++ b/data/Wright_2009/metadata.yml
@@ -4,7 +4,8 @@ source:
     bibtype: Unpublished
     author: Ian J. Wright
     year: 2009
-    title: "Unpublished data: Leaf pigment and reflectance data for sclerophylls, Macquarie University"
+    title: 'Unpublished data: Leaf pigment and reflectance data for sclerophylls,
+      Macquarie University'
 people:
 - name: Ian Wright
   institution: Macquarie University
@@ -80,89 +81,89 @@ sites:
   AgnesBanks:
     longitude (deg): 150.696
     latitude (deg): -33.642
-    description: Agnes Banks Nature Reserve
-    vegetation: Low open woodland dominated by Banksia aemula and Eucalyptus sclerophylla
-    phosphorus: low
-    rainfall: low
-    MAP (mm): 801
-    soil_total_P (ug/g): 5
-    soil_total_N (%): <0.01
+    locality: Agnes Banks Nature Reserve
+    description: Low open woodland dominated by Banksia aemula and Eucalyptus sclerophylla
+    soil P, description: low
+    precipitation, description: low
+    precipitation, MAP (mm): 801
+    soil P, total (mg/kg): 5
+    soil N, total (%): <0.01
     soil type: yellow sand
-    soil parent rock: windblown dunes of Pliocene to Pleistocene
+    geology (stratigraphic map unit): windblown dunes of Pliocene to Pleistocene
   Castlereagh:
     longitude (deg): 150.755
     latitude (deg): -33.68
-    description: Castlereagh Nature Reserve. Samples from two sub-sites, one accessed
+    locality: Castlereagh Nature Reserve. Samples from two sub-sites, one accessed
       from west side of the park (via Barbaras Trail), the other accessed from east
       side (in part near Llandillo Trail).
-    vegetation: Open woodland dominated by Angophora bakeri, Eucalyptus fibrosa, and
+    description: Open woodland dominated by Angophora bakeri, Eucalyptus fibrosa, and
       Eucalyptus umbria
-    phosphorus: high
-    rainfall: low
-    MAP (mm): 801
-    soil_total_P (ug/g): 205
-    soil_total_N (%): 0.059
+    soil P, description: high
+    precipitation, description: low
+    precipitation, MAP (mm): 801
+    soil P, total (mg/kg): 205
+    soil N, total (%): 0.059
     soil type: sandy clay
-    soil parent rock: tertiary alluvial deposits
+    geology (stratigraphic map unit): tertiary alluvial deposits
   KCNP_Basin_Track:
     longitude (deg): 151.28
     latitude (deg): -33.591
-    description: start of Basin Track in Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: start of Basin Track in Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   KCNP_Murrua_Track:
     longitude (deg): 151.145
     latitude (deg): -33.693
-    description: Murrua Track in Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: Murrua Track in Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   KCNP_unknown_track:
     longitude (deg): 151.145
     latitude (deg): -33.693
-    description: either Murrua or Basin Trackin Ku-ring-gai Chase National Park
-    vegetation: low open woodland dominated by Angophora hispida and Corymbia gummifera
-    phosphorus: low
-    rainfall: high
-    soil_total_P (ug/g): 94
-    soil_total_N (%): 0.03
+    locality: either Murrua or Basin Trackin Ku-ring-gai Chase National Park
+    description: low open woodland dominated by Angophora hispida and Corymbia gummifera
+    soil P, description: low
+    precipitation, description: high
+    soil P, total (mg/kg): 94
+    soil N, total (%): 0.03
     soil type: yellow-grey sand
-    soil parent rock: Hawkesbury sandstone
+    geology (stratigraphic map unit): Hawkesbury sandstone
   MU_forest:
     longitude (deg): 151.1166667
     latitude (deg): -33.7833333
-    description: native species from that tiny fragment of turpentine forest still
-      on campus
-    phosphorus: high
-    rainfall: high
+    locality: native species from that tiny fragment of turpentine forest still on
+      campus
+    soil P, description: high
+    precipitation, description: high
   MU_campus:
     longitude (deg): 151.1166667
     latitude (deg): -33.7833333
     description: plantings of some native species, varying considerably how far they
       are from native range
-    phosphorus: high
-    rainfall: high
+    soil P, description: high
+    precipitation, description: high
   WestHead:
     longitude (deg): 151.298
     latitude (deg): -33.578
-    description: West Head diatreme in Ku-ring-gai Chase National Park
-    vegetation: closed forest dominated by Eucalyptus umbra, Livistona australis,
-      and Syncarpia glomulifera
-    phosphorus: high
-    rainfall: high
-    soil_total_P (ug/g): 440
-    soil_total_N (%): 0.26
+    locality: West Head diatreme in Ku-ring-gai Chase National Park
+    description: closed forest dominated by Eucalyptus umbra, Livistona australis, and
+      Syncarpia glomulifera
+    soil P, description: high
+    precipitation, description: high
+    soil P, total (mg/kg): 440
+    soil N, total (%): 0.26
     soil type: red-brown clay
-    soil parent roc: weathered volcanic dyke
+    geology (stratigraphic map unit): weathered volcanic dyke
 contexts: .na
 config:
   data_is_long_format: no
@@ -436,4 +437,3 @@ exclude_observations:
 questions:
   additional_traits: Ian Wright has data on absorption, reflection, and transmission
     for each wavelength (by nanometer).
-

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -52,24 +52,23 @@ sites:
   Howard_Springs:
     latitude (deg): -12.4528
     longitude (deg): 131.1083
-    vegetation: tropical savanna
+    description: tropical savanna
     elevation (m): 30
-    total C (%): 2.7
-    total N (%): 0.093
-    total P (ppm): 72.7
-    description: 'We sampled species at Howard Springs Nature Reserve, 30 km east
-      from Darwin. The savanna vegetation there is typical of the region, with an
-      overstory dominated by eucalypts and an understory dominated by C4 grasses.
-      Overstory leaf area index ranges between about 0.6 in the dry season to 1 in
-      the wet season (Hutley et al. 2001). At Darwin airport (20 km to the west),
-      long-term annual rainfall is 1736 mm, typically with >95% of rain falling during
-      the wet season (October-April). Mean annual temperature is 27.6 deg C (data
-      from www.bom.gov.au). Fires occur regularly in the dry season; typical fire
-      return intervals in the region are 1-3 years (Russell-Smith et al. 2003). Soils
-      at the site are sandy and low in nutrients: mean (and standard deviation) nutrient
-      concentrations in eight soil samples (0-20 cm depth) collected in September
-      2010 were as follows: total C = 2.7% (1.8), total N = 0.093% (0.074), total
-      P = 72.7 mg kg_1 (22.6).'
+    soil C, total (%): 2.7
+    soil N, total (%): 0.093
+    soil P, total (mg/kg): 72.7
+    notes: 'We sampled species at Howard Springs Nature Reserve, 30 km east from Darwin.
+      The savanna vegetation there is typical of the region, with an overstory dominated
+      by eucalypts and an understory dominated by C4 grasses. Overstory leaf area
+      index ranges between about 0.6 in the dry season to 1 in the wet season (Hutley
+      et al. 2001). At Darwin airport (20 km to the west), long-term annual rainfall
+      is 1736 mm, typically with >95% of rain falling during the wet season (October-April).
+      Mean annual temperature is 27.6 deg C (data from www.bom.gov.au). Fires occur
+      regularly in the dry season; typical fire return intervals in the region are
+      1-3 years (Russell-Smith et al. 2003). Soils at the site are sandy and low in
+      nutrients: mean (and standard deviation) nutrient concentrations in eight soil
+      samples (0-20 cm depth) collected in September 2010 were as follows: total C
+      = 2.7% (1.8), total N = 0.093% (0.074), total P = 72.7 mg kg_1 (22.6).'
 contexts:
   dry_season_measurement_on_adult:
     type: field
@@ -549,4 +548,3 @@ taxonomic_updates:
   reason: Change spelling to align with known name in APC (Daniel Falster, 2020.05.22)
 exclude_observations: .na
 questions: .na
-

--- a/data/Zanne_2007/metadata.yml
+++ b/data/Zanne_2007/metadata.yml
@@ -33,42 +33,42 @@ sites:
     longitude (deg): 146.1458333
     latitude (deg): -32.9763889
     description: open shrub mallee
-    rainfall (mm): 387
-    soil: Loamy red sand (Quaternary dune systems)
-    Total P (ug/g): 132
-    Total N (%): 0.031
-    Total C (%): 0.67
-    CEC (meq kg-1): 38.7
+    precipitation, MAP (mm): 387
+    soil type: Loamy red sand (Quaternary dune systems)
+    soil P, total (mg/kg): 132
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
   Murrua Track Kuringai Chase National Park:
     longitude (deg): 151.1430556
     latitude (deg): -33.6938889
     description: low open woodland
-    rainfall (mm): 1220
-    soil: Yellow-grey sand (Hawkesbury sandstone)
-    Total P (ug/g): 93.6
-    Total N (%): 0.03
-    Total C (%): 0.95
-    CEC (meq kg-1): 9.0
+    precipitation, MAP (mm): 1220
+    soil type: Yellow-grey sand (Hawkesbury sandstone)
+    soil P, total (mg/kg): 93.6
+    soil N, total (%): 0.03
+    soil C, total (%): 0.95
+    soil cation exchange capacity (meq/kg): 9.0
   Westhead Kuringai Chase National Park:
     longitude (deg): 151.2922222
     latitude (deg): -33.5788889
     description: closed forest
-    rainfall (mm): 1220
-    soil: Red-brown clay (weathered volcanic dyke)
-    Total P (ug/g): 442
-    Total N (%): 0.256
-    Total C (%): 5.91
-    CEC (meq kg-1): 55.6
+    precipitation, MAP (mm): 1220
+    soil type: Red-brown clay (weathered volcanic dyke)
+    soil P, total (mg/kg): 442
+    soil N, total (%): 0.256
+    soil C, total (%): 5.91
+    soil cation exchange capacity (meq/kg): 55.6
   Woodland Round Hill Nature Reserve:
     longitude (deg): 146.1547222
     latitude (deg): -32.9666667
     description: open woodland
-    rainfall (mm): 387
-    soil: Loamy red sand (Quaternary dune systems)
-    Total P (ug/g): 132
-    Total N (%): 0.031
-    Total C (%): 0.67
-    CEC (meq kg-1): 38.7
+    precipitation, MAP (mm): 387
+    soil type: Loamy red sand (Quaternary dune systems)
+    soil P, total (mg/kg): 132
+    soil N, total (%): 0.031
+    soil C, total (%): 0.67
+    soil cation exchange capacity (meq/kg): 38.7
 contexts: .na
 config:
   data_is_long_format: no
@@ -174,4 +174,3 @@ taxonomic_updates:
   reason: Align to APC accepted synonym (E. Wenk, 2020-05-25)
 exclude_observations: .na
 questions: .na
-

--- a/data/Zieminska_2013/metadata.yml
+++ b/data/Zieminska_2013/metadata.yml
@@ -66,40 +66,40 @@ sites:
     sampling time: Mar-09
     description: woodland
     elevation (m): 420
-    MAP (mm): 547
-    MAT (C): 10
+    precipitation, MAP (mm): 547
+    temperature, MAT (C): 10
     aridity index (MAP/PET): 0.646
-    climate summary: cool, dry
+    climate description: cool, dry
   Cardwell:
     latitude (deg): -18.48
     longitude (deg): 146.16
     sampling time: Aug-09
     description: tropical dry forest
     elevation (m): 50
-    MAP (mm): 1925
-    MAT (C): 24.1
+    precipitation, MAP (mm): 1925
+    temperature, MAT (C): 24.1
     aridity index (MAP/PET): 1.026
-    climate summary: hot, wet
+    climate description: hot, wet
   Longley:
     latitude (deg): -42.98
     longitude (deg): 147.18
     sampling time: Mar-09
     description: woodland
     elevation (m): 280
-    MAP (mm): 964
-    MAT (C): 11.3
+    precipitation, MAP (mm): 964
+    temperature, MAT (C): 11.3
     aridity index (MAP/PET): 1.153
-    climate summary: cool, wet
+    climate description: cool, wet
   Princess Hills:
     latitude (deg): -18.25
     longitude (deg): 145.52
     sampling time: Nov-09
     description: savanna
     elevation (m): 595
-    MAP (mm): 1106
-    MAT (C): 21.3
+    precipitation, MAP (mm): 1106
+    temperature, MAT (C): 21.3
     aridity index (MAP/PET): 0.601
-    climate summary: hot, dry
+    climate description: hot, dry
 contexts: .na
 config:
   data_is_long_format: no
@@ -814,4 +814,3 @@ exclude_observations: .na
 questions:
   additional_traits: additional traits including fibre wall fraction and fibre lumen
     fraction
-

--- a/data/Zieminska_2015/metadata.yml
+++ b/data/Zieminska_2015/metadata.yml
@@ -5,8 +5,8 @@ source:
     year: '2015'
     author: Kasia Zieminska and Mark Westoby and Ian J. Wright
     journal: '{PLOS} {ONE}'
-    title: Broad anatomical variation within a narrow wood density range - A
-      study of twig wood across 69 Australian Angiosperms
+    title: Broad anatomical variation within a narrow wood density range - A study
+      of twig wood across 69 Australian Angiosperms
     volume: '10'
     number: '4'
     pages: e0124892
@@ -100,24 +100,24 @@ sites:
     description: tropical woodland  (Girringun NP)
     elevation (m): 650
     sampling time: Oct-12
-    MAT (C): 22.4
-    MAP (mm): 197
+    temperature, MAT (C): 22.4
+    precipitation, MAP (mm): 197
   Cape Tribulation:
     latitude (deg): -16.104
     longitude (deg): 145.449
     description: tropical rainforest (Daintree NP)
     elevation (m): 50
     sampling time: May-12
-    MAT (C): 22.2
-    MAP (mm): 817
+    temperature, MAT (C): 22.2
+    precipitation, MAP (mm): 817
   Thredbo:
     latitude (deg): -36.482
     longitude (deg): 148.35
     description: temperate forest (Kosciuszko NP)
     elevation (m): 1300
     sampling time: Mar-12
-    MAT (C): 7.2
-    MAP (mm): 210
+    temperature, MAT (C): 7.2
+    precipitation, MAP (mm): 210
 contexts: .na
 config:
   data_is_long_format: no
@@ -879,4 +879,3 @@ exclude_observations: .na
 questions:
   additional_traits: additional traits including fibre lumen fraction, mucilage canal
     fraction
-


### PR DESCRIPTION
Aligned all site properties names through commit [ea2615c](https://github.com/traitecoevo/austraits.build/commit/ea2615c708ed2cf3265fdbf26fe6d30b1fd9ff03).

Used the following code to programmatically rename site properties based on names in a lookup table. Afterwards a few additional manual changes were made to metadata files.

This job is complete, other than finalising an unofficial site properties dictionary, that indicates, for a few properties, how they align to published ontologies (i.e. DarwinCore; ETS).