### PR TITLE
Modify metadata create template

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^\.Rproj\.user$
 Dockerfile
 _pkgdown.yml
+^codecov\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,9 @@
 ^\.github$
 ^\.rstudio$
 ^\.remake$
+^\.local$
+^\.cache$
+^\.config$
 ^README\.Rmd$
 ^data$
 ^docs$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,11 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v1
         with:
           extra-packages: rcmdcheck
-
+          
+      - name: Install dependencies
+        run: |
+          install.packages("bibtex")
+          
       - name: Run tests
         run: testthat::test_dir("tests/testthat")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          install.packages("bibtex")
+          remotes::install_github("ROpenSci/bibtex")
           
       - name: Run tests
         run: testthat::test_dir("tests/testthat")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,10 +40,6 @@ jobs:
         with:
           extra-packages: rcmdcheck
           
-      - name: Install dependencies
-        run: |
-          remotes::install_github("ROpenSci/bibtex")
-          
       - name: Run tests
         run: testthat::test_dir("tests/testthat")
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,12 +64,13 @@ Suggests:
     testthat,
     pkgdown,
     rcrossref,
-    zip
+    zip,
+    covr
 Remotes:
     traitecoevo/austraits,
     richfitz/remake
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
     yaml
 Suggests:
     austraits,
+    bibtex,
     bench,
     desc,
     devtools,

--- a/R/report_utils.R
+++ b/R/report_utils.R
@@ -15,7 +15,7 @@ build_study_reports <- function(dataset_ids=NULL, ...) {
   # define if does not already exist, 
   # for all studies with suitable metadata file
   if(length(dataset_ids) ==0 | is.null(dataset_ids) | any(is.na(dataset_ids)))
-    dataset_ids <- austraits$trait$dataset_id %>% unique()
+    dataset_ids <- list.files("data")
   
   for(dataset_id in dataset_ids)
     build_study_report(dataset_id, ...)

--- a/R/setup.R
+++ b/R/setup.R
@@ -485,7 +485,7 @@ metadata_add_taxonomic_change <- function(dataset_id, find, replace, reason) {
   }
   
   # Check if find record already exists for that trait
-  data <-  list_to_df(metadata[[set_name]])  
+  data <- list_to_df(metadata[[set_name]])  
   if(!is.na(data) && nrow(data) > 0 && length(which(find %in% data$find)) > 0) {
     cat(sprintf("\tSubstitution already exists for %s\n", crayon::red(find)))
     return(invisible(TRUE))

--- a/R/setup.R
+++ b/R/setup.R
@@ -363,7 +363,16 @@ metadata_add_source_bibtex <- function(dataset_id, file, type="primary", key=dat
 #' @export
 #'
 metadata_add_source_doi <- function(doi, ...) {
-
+  
+  if(!stringr::str_starts(doi, "https://doi.org") &
+     !stringr::str_starts(doi, "http://doi.org")){
+    if(stringr::str_starts(doi, "doi.org")) {
+      doi <- paste0("https://", doi)
+    } else {
+      doi <- paste0("https://doi.org/", doi)
+    }
+  }
+  
   bib <- suppressWarnings(rcrossref::cr_cn(doi))
 
   if(is.null(bib)) {

--- a/R/steps.R
+++ b/R/steps.R
@@ -124,8 +124,8 @@ load_study <- function(filename_data_raw,
     add_all_columns(definitions$columns_sites) %>%
     dplyr::select(-.data$error) %>%
     # reorder so type, description come first, if present
-    dplyr::mutate(i = case_when(site_property == "description" ~ 1, site_property == "latitude (deg)" ~ 2,
-                                site_property == "longitude (deg)" ~ 3, TRUE ~ 4)) %>%
+    dplyr::mutate(i = case_when(.data$site_property == "description" ~ 1, .data$site_property == "latitude (deg)" ~ 2,
+                                .data$site_property == "longitude (deg)" ~ 3, TRUE ~ 4)) %>%
     dplyr::arrange(.data$site_name, .data$i, .data$site_property) %>%
     dplyr::select(-.data$i)
 
@@ -224,7 +224,7 @@ load_study <- function(filename_data_raw,
   }
   
   # Remove any values included to map into traits table
-  sites <- sites %>% dplyr::filter(!(site_property %in% vars))
+  sites <- sites %>% dplyr::filter(!(.data$site_property %in% vars))
 
   # Retrieve taxonomic details for known species
   taxonomic_updates <-

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3583418.svg)](https://doi.org/10.5281/zenodo.3583418)
 [![build](https://github.com/traitecoevo/austraits.build/actions/workflows/check-build.yml/badge.svg)](https://github.com/traitecoevo/austraits.build/actions/workflows/check-build.yml)
 [![R-CMD-check](https://github.com/traitecoevo/austraits.build/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/traitecoevo/austraits.build/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/traitecoevo/austraits.build/branch/develop/graph/badge.svg)](https://app.codecov.io/gh/traitecoevo/austraits.build?branch=develop)
 <!-- badges: end -->
 
 <img src="docs/figures/logo.png">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/config/definitions.yml
+++ b/config/definitions.yml
@@ -4375,8 +4375,8 @@ metadata:
             bibtype: &bibtype Entry type for reference source e.g. Article, Book, Thesis, Unpublished.
             year: &year The year that the reference was published, or written in the case of unpublished articles.
             author: &author Names of all the authors for the reference.
-            journal: &journal Journal in which the article was published.
             title: &title The title of the reference.
+            journal: &journal Journal in which the article was published.
             volume: &volume The volumn number of the article or book.
             number: &number The issue number for a journal article.
             pages: &pages The page numbers for a reference.

--- a/config/definitions.yml
+++ b/config/definitions.yml
@@ -4367,8 +4367,48 @@ metadata:
       description: Citation details for the original source(s) for the data, whether it is a published journal article, book, website, or thesis.
       type: categorical
       values:
-        primary: &source_primary The original study in which data were collected.
-        secondary: &source_secondary A subsequent study where data were compiled or re-analysed.
+        primary:
+          description: &source_primary The original study in which data were collected.
+          type: catergorical
+          values:
+            key: &key The key is used to identify the exact reference using authors last name and year of publication.
+            bibtype: &bibtype Entry type for reference source e.g. Article, Book, Thesis, Unpublished.
+            year: &year The year that the reference was published, or written in the case of unpublished articles.
+            author: &author Names of all the authors for the reference.
+            journal: &journal Journal in which the article was published.
+            title: &title The title of the reference.
+            volume: &volume The volumn number of the article or book.
+            number: &number The issue number for a journal article.
+            pages: &pages The page numbers for a reference.
+            doi: &doi The digital object identifer.
+            url: &url The URL of of a web page.
+            type: &type The type of thesis which can include PhD, Masters, Honours.
+            institution: &institution The institution that published or sponsored the report.
+            publisher: &publisher The name of the publisher.
+            isbn: &isbn The International Standard Book Number of a book or report.
+            place: &place The location where the reference was written or published.
+            note: &note Additional notes for the reference which are not contained in the other fields.
+        secondary:
+          description: &source_secondary A subsequent study where data were compiled or re-analysed.
+          type: categorical
+          values:
+            key: *key
+            bibtype: *bibtype
+            year: *year
+            author: *author
+            journal: *journal
+            title: *title
+            volume: *volume
+            number: *number
+            pages: *pages
+            doi: *doi
+            url: *url
+            type: *type
+            institution: *institution
+            publisher: *publisher
+            isbn: *isbn
+            place: *place
+            note: *note
     contributors:
       description: A list of contributors to the study, their respective affiliations, roles in the study, and ORCIDs.
       type: array

--- a/data/BRAIN_2007/metadata.yml
+++ b/data/BRAIN_2007/metadata.yml
@@ -5,7 +5,7 @@ source:
     author: '{Brisbane Rainforest Action & Information Network}'
     title: Trait measurements for Australian rainforest species
     year: 2016
-    published: Brisbane Rainforest Action and Information Network
+    publisher: Brisbane Rainforest Action and Information Network
     url: http://www.brisrain.org.au/
 contributors:
   data_collectors: .na.character

--- a/data/Brock_1993/metadata.yml
+++ b/data/Brock_1993/metadata.yml
@@ -6,7 +6,7 @@ source:
     year: 1993
     title: Native plants of northern Australia
     publisher: Reed New Holland
-    address: Frenchs Forest, N.S.W.
+    place: Frenchs Forest, N.S.W.
     isbn: '9781877069246'
 contributors:
   data_collectors:

--- a/data/Chinnock_2007/metadata.yml
+++ b/data/Chinnock_2007/metadata.yml
@@ -6,7 +6,7 @@ source:
     year: 2007
     title: 'Eremophila and allied genera: A monograph of the plant family Myoporaceae'
     publisher: Rosenberg
-    address: Dural, NSW
+    place: Dural, NSW
     isbn: '9781877058165'
 contributors:
   data_collectors:

--- a/data/Smith_1996/metadata.yml
+++ b/data/Smith_1996/metadata.yml
@@ -8,7 +8,7 @@ source:
       forests
     type: PhD
     institution: University of Otago, Dunedin, New Zealand
-    archived: http://web.nateko.lu.se/personal/benjamin.smith/thesis/thesis.html
+    url: http://web.nateko.lu.se/personal/benjamin.smith/thesis/thesis.html
 contributors:
   data_collectors:
   - last_name: Smith

--- a/data/Wheeler_2002/metadata.yml
+++ b/data/Wheeler_2002/metadata.yml
@@ -7,7 +7,7 @@ source:
     title: 'Flora of the south west: Bunbury, Augusta, Denmark'
     publisher: '{Australian Biological Resources Study ; University of Western Australia
       Press}'
-    address: 'Canberra, A.C.T. : Crawley, W.A'
+    place: 'Canberra, A.C.T. : Crawley, W.A'
     isbn: '9780642568168'
 contributors:
   data_collectors:

--- a/man/metadata_create_template.Rd
+++ b/man/metadata_create_template.Rd
@@ -6,13 +6,16 @@
 \usage{
 metadata_create_template(
   dataset_id,
-  path = file.path("data", dataset_id, "metadata.yml")
+  path = file.path("data", dataset_id),
+  skip_manual = FALSE
 )
 }
 \arguments{
 \item{dataset_id}{identifier for a particular study in the AusTraits database}
 
 \item{path}{location of file where output is saved}
+
+\item{skip_manual}{allows skipping of manual selection of variables, default = FALSE}
 }
 \value{
 a yml file template for metadata

--- a/tests/testthat/config/definitions.yml
+++ b/tests/testthat/config/definitions.yml
@@ -1,0 +1,284 @@
+
+#-------------------------------------------------------------
+
+value_type:
+  description: &value_type A categorical variable describing the type of trait value recorded.
+  type: categorical
+  values:
+    raw_value: Value is a direct measurement.
+    site_min: Value is the minimum of measurements on multiple individuals of the taxon at a single site.
+    site_mean: Value is the mean or median of measurements on multiple individuals of the taxon at a single site.
+    site_max: Value is the maximum of measurements on multiple individuals of the taxon at a single site.
+    multisite_min: Value is the minimum of measurements on multiple individuals of the taxon across multiple sites.
+    multisite_mean: Value is the mean or median of measurements on multiple individuals of the taxon across multiple sites.
+    multisite_max: Value is the maximum of measurements on multiple individuals of the taxon across multiple sites.
+    expert_min: Value is the minimum observed for a taxon across its range or in this particular dataset, as estimated by an expert based on their knowledge of the taxon. Data fitting this category include estimates from floras that represent a taxon's entire range.
+    expert_mean: Value is the mean observed for a taxon across its range or, in this particular dataset, as estimated by an expert based on their knowledge of the taxon. Data fitting this category include estimates from floras that represent a taxon's entire range and values for categorical variables obtained from a reference book, or identified by an expert.
+    expert_max: Value is the maximum observed for a taxon across its range or, in this particular dataset, as estimated by an expert based on their knowledge of the taxon. Data fitting this category include estimates from floras that represent a taxon's entire range.
+    experiment_min: Value is the minimum of measurements on multiple individuals of the taxon from an experimental study (either in the field or a glasshouse).
+    experiment_mean: Value is the mean or median of measurements on multiple individuals of the taxon from an experimental study (either in the field or a glasshouse).
+    experiment_max: Value is the maximum of measurements on multiple individuals of the taxon from an experimental study (either in the field or a glasshouse).
+    individual_mean: Value is a mean of replicate measurements on an individual.
+    individual_max: Value is a maximum of replicate measurements on an individual.
+    literature_source: Value is a site_mean, multisite_mean, or expert_mean that has been sourced from an unknown literature source.
+    unknown: Value type is not currently known.
+
+#-------------------------------------------------------------
+# A key describing the structure of the compiled `AusTraits` dataset
+
+austraits:
+  description: The compiled `AusTraits` dataset.
+  type: list
+  elements:
+    traits:
+      description: A table containing measurements of plant traits.
+      type: table
+      elements:
+        dataset_id: &dataset_id Primary identifier for each study contributed to AusTraits; most often these are scientific papers, books, or online resources. By default this should be the name of the first author and year of publication, e.g. `Falster_2005`.
+        taxon_name: &taxon_name Whenever possible, this field indicates the current accepted scientific name of a taxon, per the Australian Plant Census (APC). Alternatively, `taxon_name` can indicate an alignment with a name included in the comprehensive Australian Plant Names Index (APNI), but not currently marked as accepted in APC, or a name that cannot be aligned to available lists of Australian plant names.
+        site_name: &site_name Name of the site where the individual was sampled. Cross-references between similar columns in `sites` and `traits`.
+        context_name: &context_name Name of contextual senario where the individual was sampled. Cross-references between similar columns in `contexts` and `traits`.
+        observation_id: &observation_id A unique identifier for the observation, useful for joining traits coming from the same `observation_id`. For wide datasets, these are assigned automatically based on the `dataset_id` and row number of the raw data.
+        trait_name: &trait_name Name of the trait sampled. Allowable values specified in the table `definitions`.
+        value: &value Measured value.
+        unit: &units Units of the sampled trait value after aligning with AusTraits standards.
+        collection_date: &collection_date Date sample was taken, in the format `yyyy-mm-dd`, `yyyy-mm` or `yyyy`, depending on the resoluton specified.
+        value_type: *value_type
+        replicates: &replicates Number of replicate measurements that comprise the data points for the trait for each measurement. A numeric value (or range) is ideal and appropriate if the value type is a `mean`, `median`, `min` or  `max`. For these value types, if replication is unknown the entry should be `unknown`. If the value type is `raw_value` the replicate value should be 1. If the value type is `expert_mean`, `expert_min`, or `expert_max` the replicate value should be `.na`.
+        collection_type: &collection_type A field to indicate where the majority of plants on which traits were measured were collected -  in the `field`, `lab`, `glasshouse`, `botanical collection`, or `literature`. The latter should only be used when the data were sourced from the literature and the collection type is unknown.
+        sample_age_class: &sample_age_class A field to indicate if the study was completed on `adult` or `juvenile` plants.
+        measurement_remarks: &measurement_remarks Comments or notes accompanying the trait measurement.
+        original_name: &orginal_name Name given to taxon in the original data supplied by the authors.
+    sites:
+      description: A table containing observations of site characteristics associated with information in `traits`. Cross referencing between the two dataframes is possible using combinations of the variables `dataset_id`, `site_name`.
+      type: table
+      elements:
+        dataset_id: *dataset_id
+        site_name: *site_name
+        site_property: The site characteristic being recorded. The name should include units of measurement, e.g. `MAT (C)`. Ideally we have at least the following variables for each site, `longitude (deg)`, `latitude (deg)`, `description`.
+        value: *value
+    contexts:
+      description: A table containing observations of contextual characteristics associated with information in `traits`. Cross referencing between the two dataframes is possible using combinations of the variables `dataset_id`, `context_name`.
+      type: table
+      elements:
+        dataset_id: *dataset_id
+        context_name: *context_name
+        context_property: The contextual characteristic being recorded. Name should include units of measurement, e.g. `CO2 concentration (ppm)`.
+        value: *value
+    methods:
+      description: A table containing details on methods with which data were collected, including time frame and source. Cross referencing with the `traits` table is possible using combinations of the variables `dataset_id`, `trait_name`.
+      type: table
+      elements:
+        dataset_id: *dataset_id
+        trait_name: *trait_name
+        methods: &methods A textual description of the methods used to collect the trait data. Whenever available, methods are taken near-verbatim from the referenced source. Methods can include descriptions such as 'measured on botanical collections', 'data from the literature', or a detailed description of the field or lab methods used to collect the data.
+        description: &description A 1-2 sentence description of the purpose of the study.
+        sampling_strategy: &sampling_strategy A written description of how study sites were selected and how study individuals were selected. When available, this information is lifted verbatim from a published manuscript. For botanical collections, this field ideally indicates which records were 'sampled' to measure a specific trait.
+        source_primary_key: Citation key for the primary source in `sources`. The key is typically formatted as `Surname_year`.
+        source_primary_citation: Citation for the primary source. This detail is generated from the primary source in the metadata.
+        source_secondary_key: Citation key for the secondary source in `sources`.  The key is typically formatted as `Surname_year`.
+        source_secondary_citation: Citations for the secondary source. This detail is generated from the secondary source in the metadata.
+        data_collectors: &data_collectors The person (people) leading data collection for this study.
+        assistants: &assistants Names of additional people who played a more minor role in data collection for the study.
+        austraits_curators: &austraits_curators Names of AusTraits team member(s) who contacted the data collectors and added the study to the AusTraits repository.
+    excluded_data:
+      description: A table of data that did not pass quality tests and so were excluded from the master dataset. The structure is identical to that presented in the `traits` table, only with an extra column called `error` indicating why the record was excluded. Common reasons are missing_unit_conversions, missing_value, and unsupported_trait_value.
+      type: table
+      elements:
+        error: Indicating why the record was excluded. Common reasons are missing_unit_conversions, missing_value, and unsupported_trait_value.
+        dataset_id: *dataset_id
+        taxon_name: *taxon_name
+        site_name: *site_name
+        context_name: *context_name
+        observation_id: *observation_id
+        trait_name: *trait_name
+        value: *value
+        unit: *units
+        collection_date: *collection_date
+        value_type: *value_type
+        replicates: *replicates
+        collection_type: *collection_type
+        sample_age_class: *sample_age_class
+        measurement_remarks: *measurement_remarks
+        original_name: *orginal_name
+    taxonomic_updates:
+      description: A table of all taxonomic changes implemented in the construction of AusTraits. Changes are determined by comparing the originally submitted taxon name against the APC (Australian Plant Census) and APNI (Australian Plant Names Index). Cross referencing with the `traits` table is possible using combinations of the variables `dataset_id` and `taxon_name`.
+      type: table
+      elements:
+        dataset_id: *dataset_id
+        original_name: *orginal_name
+        cleaned_name: Name of the taxon after implementing automated syntax standardisation and spelling changes as well as manually encoded syntax alignments for this taxon in the metadata file for the corresponding `dataset_id`.
+        taxonIDClean: The APC identifier for the `cleaned_name` of the taxon (for taxa designated as current for APC) or APNI identifier (for taxa included in APNI, but unplaced for APC).
+        taxonomicStatusClean: The APC taxonomic status for the `cleaned_name` of the taxon identified by `taxonIDClean`.
+        alternativeTaxonomicStatusClean: The APC taxonomic status of alternative APC records with the name `cleaned_name`.
+        acceptedNameUsageID: The APC identifier for the accepted name (`taxon_name`) for a taxon; this is different from `taxonIDClean` if `taxonomicStatusClean` is not `accepted`.
+        taxon_name: *taxon_name
+    taxa:
+      description: A table containing details on taxa associated with information in `traits`. This information has been sourced from the APC (Australian Plant Census) and APNI (Australian Plant Names Index) and is released under a CC-BY3 license. Cross referencing between the two dataframes is possible using combinations of the variable `taxon_name`.
+      type: table
+      elements:
+        taxon_name: *taxon_name
+        source: Source of taxonomic information, either APC or APNI.
+        acceptedNameUsageID: The identifier of the accepted concept in APC for this taxon name.
+        scientificNameAuthorship: Authority for the taxon indicated under `taxon_name`; applicable for most taxa in APC.
+        taxonRank: Rank of the taxon.
+        taxonomicStatus: "Taxonomic status of the taxon. `accepted` indicates the taxon name is designated as `current` in APC, a taxonomy endorsed by the Council of Heads of Australasian Herbaria. Alternate statuses are: `unplaced` indicating that the taxon name is included in APNI but has yet to be reviewed for inclusion/exclusion as a current name (or synonym) for APC; `genus_known` indicating the taxon name can only be aligned to the genus level; `family_known` indicating the taxon name can only be aligned to the family level, and `unknown` indicating a taxon name submitted to AusTraits that cannot be aligned at any level."
+        family: Family of the taxon.
+        taxonDistribution: Known distribution of the taxon, by Australian state.
+        ccAttributionIRI: Source of taxonomic information (for taxa designated as current for APC) or name information (for taxa included in APNI, but unplaced  for APC).
+        genus: Genus of the taxon.
+    definitions:
+      description: A copy of the definitions for all tables and terms. Information included here was used to process data and generate any documentation for the study.
+      type: categorical
+      value: A structured yaml file, represented as a list in R. See file `config/definitions.yaml` for more details.
+    contributors:
+      description: A table of people contributing to each study.
+      type: table
+      elements:
+        dataset_id: *dataset_id
+        last_name: Last name of the data collector
+        given_name: Given names of the data collector
+        ORCID: ORCID of the data collector
+        affiliation: Last known institution or affiliation
+        additional_role: Additional roles of data collector, mostly contact person
+    sources:
+      description: Bibtex entries for all primary and secondary sources in the compilation.
+      type: list
+    build_info:
+      description: A description of the computing environment used to create this version of the dataset, including version number, git commit and R session_info.
+      type: list
+      elements:
+        version:
+          description: Version number of the dataset.
+          type: categorical
+          value:
+        git_SHA: Commit in git repository.
+        session_info:
+          description: The versions of R, packages, and data used to generate the dataset.
+          type: categorical
+          value: A structured yaml file, represented as a list in R.
+
+#-------------------------------------------------------------
+
+metadata:
+  description: &metadata Structured recording of metadata for each individual study, as entered into AusTraits. Information included in `sites` and `methods` are derived from this file. Also includes information on mapping of trait data into standard terms and units, plus any taxonomic changes implemented.
+  type: list
+  elements:
+    source:
+      description: Citation details for the original source(s) for the data, whether it is a published journal article, book, website, or thesis.
+      type: categorical
+      values:
+        primary:
+          description: &source_primary The original study in which data were collected.
+          type: catergorical
+          values:
+            key: &key The key is used to identify the exact reference using authors last name and year of publication.
+            bibtype: &bibtype Entry type for reference source e.g. Article, Book, Thesis, Unpublished.
+            year: &year The year that the reference was published, or written in the case of unpublished articles.
+            author: &author Names of all the authors for the reference.
+            title: &title The title of the reference.
+            journal: &journal Journal in which the article was published.
+            volume: &volume The volumn number of the article or book.
+            number: &number The issue number for a journal article.
+            pages: &pages The page numbers for a reference.
+            doi: &doi The digital object identifer.
+            url: &url The URL of of a web page.
+            type: &type The type of thesis which can include PhD, Masters, Honours.
+            institution: &institution The institution that published or sponsored the report.
+            publisher: &publisher The name of the publisher.
+            isbn: &isbn The International Standard Book Number of a book or report.
+            place: &place The location where the reference was written or published.
+            note: &note Additional notes for the reference which are not contained in the other fields.
+        secondary:
+          description: &source_secondary A subsequent study where data were compiled or re-analysed.
+          type: categorical
+          values:
+            key: *key
+            bibtype: *bibtype
+            year: *year
+            author: *author
+            journal: *journal
+            title: *title
+            volume: *volume
+            number: *number
+            pages: *pages
+            doi: *doi
+            url: *url
+            type: *type
+            institution: *institution
+            publisher: *publisher
+            isbn: *isbn
+            place: *place
+            note: *note
+    contributors:
+      description: A list of contributors to the study, their respective affiliations, roles in the study, and ORCIDs.
+      type: array
+      elements:
+        data_collectors:
+          description: *data_collectors
+          last_name: Last name of data collector
+          given_name: Given name of data collector
+          affiliation: Affiliation of data collector
+          notes: optional notes for the data collector
+          ORCID: ORCID iD (Open Researcher and Contributor ID) for the data collector, if available
+          additional_role: Any additional roles the data collector had in the study, a field most frequently used to identify which data contributor is the contact person for the dataset.
+          type: categorical
+        assistants:
+          description: *assistants
+        austraits_curators:
+          description: *austraits_curators
+    dataset:
+      description: Study details, including format of the data, custom R code applied to data, and various descriptors. Each can a header for a column of the data, or actual value to be used.
+      type: categorical
+      values:
+        data_is_long_format: Indicates if the data spreadsheet has a vertical (long) or  horizontal (wide) configuration with `yes` or `no` terminology
+        custom_R_code: A field where additional R code can be included. This allows for custom manipulation of the data in the submitted spreadsheet into a different format for easy integration with AusTraits. `.na` indicates no custom R code was used.
+        collection_date: *collection_date
+        taxon_name: *taxon_name
+        site_name: *site_name
+        context_name: *context_name
+        observation_id: *observation_id
+        trait_name: *trait_name
+        value: *value
+        description: *description
+        collection_type: *collection_type
+        sample_age_class: *sample_age_class
+        sampling_strategy: *sampling_strategy
+        original_file: The name of the file initially submitted to AusTraits
+        notes: Generic notes about the study and processing of data
+    sites:
+      description: A list of study sites and information about each of the study sites where data were collected. Each should include at least three variables - `latitude`, `longitude` and `description`. Additional variables can be included where available. Set to `.na` for botanical collections and field studies where data values are a mean across many locations.
+    contexts:
+      description: A list of scenarios sites and contextial information about each of the scenarios where data were collected. A list of contexts. Each should include at least two variables - `context_type` and `description`. Additional variables can be included where available. Set to `.na` as default.
+    traits:
+      description: A translation table, mapping traits and units from a contributed study onto corresponding variables in AusTraits. The methods used to collect the data are also specified here.
+      type: array
+      elements:
+        var_in: Name of trait in the original data submitted
+        unit_in: Units of trait in the original data submitted
+        trait_name: *trait_name
+        value_type: *value_type
+        replicates: *replicates
+        methods: *methods
+    substitutions:
+      description: A list of any "find and replace" substitutions needed to get the data into the right format.
+      type: array
+      values:
+        trait_name: Trait where substitutions are required
+        find: Contributor's trait value that needs to be changed
+        replace: AusTraits supported replacement value
+    taxonomic_updates:
+      description: A table of taxonomic name changes needed to align original names in the dataset with taxa in APC and APNI.
+      type: array
+      values:
+        find: *orginal_name
+        replace: *taxon_name
+        reason: Records why the change was implemented, e.g. `typos`, `taxonomic synonyms`, and `standardising spellings`
+    exclude_observations:
+      description: A table of observations to remove from the compilation
+      type: array
+      values:
+        variable: A variable from the traits table, typically `taxon_name`, `site_name` or `context_name`
+        find: Value of variable to remove
+        reason: Records why the data was removed, e.g. `exotic`
+    questions: A place to record any queries we have about the dataset (recorded as a named array), including notes on any additional traits that may have been collected in the study but have not been incorporated into AusTraits.

--- a/tests/testthat/data/Test_2022/data.csv
+++ b/tests/testthat/data/Test_2022/data.csv
@@ -1,0 +1,46 @@
+Species,species_abb,site,LMA (mg mm-2),Leaf nitrogen (mg mg-1),leaf size (mm2),wood density (mg mm-3),branch mass fraction,Seed mass (mg),LASA10,LASA250,LASA50,LASA1000
+Acacia celsa,acacel,Atherton,0.145,0.0214,2786,0.498,0.67,10.3,2977,7260,3722,6824
+Acronychia acidula,acraci,Atherton,0.085,0.0243,14302,0.525,0.48,,,7560,5541,9480
+Alphitonia petriei,alppet,Atherton,0.149,0.0163,6820,0.413,0.42,27.2,,4340,3313,4335
+Glochidion hylandii,glohyl,Atherton,0.106,0.0137,3209,0.566,0.41,10.41,1993,5075,5455,8664
+Homalanthus novoguineensis,omanov,Atherton,0.082,0.022,10682,0.319,0.47,7,,2136,2158,3307
+Melicope elleryana,melell,Atherton,0.075,0.0268,6955,0.346,0.58,1.61,,4201,2860,6119
+Neolitsea dealbata,neodea,Atherton,0.093,0.0164,5228,0.352,0.58,176.1,1686,2747,3049,7504
+Polyscias australiana,polaus,Atherton,0.079,0.0154,6806,0.397,0.42,8.35,,6008,,6700
+Psychotria sp Utchee Creek,psyspp,Atherton,0.108,0.0179,11157,0.582,0,23.09,,4977,2302,2037
+Rhodomyrtus trineura,rhotri,Atherton,0.129,0.0111,3401,0.763,0.34,,4321,3803,6088,6877
+Acmena graveolens,acmgra,Cape Tribulation,0.151,0.0155,5246,0.599,0.67,,,3057,2667,7156
+Aleurites rockinghamensis,aleroc,Cape Tribulation,0.113,0.0184,73984,0.28,0.02,7077,,4194,,6209
+Alstonia scholaris,alssch,Cape Tribulation,0.107,0.0223,6182,0.361,0.46,1.53,,1854,1682,3932
+Argyrodendron peralatum,argper,Cape Tribulation,0.244,0.0119,3201,0.726,0.71,433,,3832,1689,6718
+Atractocarpus hirtus,atrhir,Cape Tribulation,0.072,0.0157,11374,0.804,0.28,,,7143,6727,6103
+Brombya platynema,bropla,Cape Tribulation,0.106,0.0188,8218,0.603,0.33,,,4261,3531,5377
+Cardwellia sublimis,carsub,Cape Tribulation,0.127,0.0128,4352,0.603,0.56,582.3,,6315,4880,8282
+Castanospermum australe,casaus,Cape Tribulation,0.117,0.0237,2765,0.587,0.37,14851,,7329,,8869
+Cleistanthus myrianthus,clemyr,Cape Tribulation,0.078,0.0228,4828,0.588,0.56,,3720,6084,5233,8559
+Cryptocarya laevigata,crylae,Cape Tribulation,0.087,0.0156,2682,0.64,0.65,1281,1391,3297,4680,7588
+Cryptocarya mackinnoniana,crymac,Cape Tribulation,0.204,0.0152,10458,0.655,0.61,204,,3277,2325,8657
+Cryptocarya murrayi,crymur,Cape Tribulation,0.155,0.0167,9960,0.674,0.39,,2693,5543,4298,5451
+Dendrocnide moroides,denmor,Cape Tribulation,0.052,0.0312,26454,0.23,0.46,0.71,,2372,,2090
+Elaeocarpus grandis,elaang,Cape Tribulation,0.122,0.0187,2762,0.499,0.47,3699,,2598,1748,4635
+Endiandra leptodendron,endlep,Cape Tribulation,0.106,0.018,3987,0.611,0.68,,1492,2412,2783,7477
+Endiandra microneura,endmic,Cape Tribulation,0.151,0.0177,3377,0.623,0.61,,3573,6344,3354,6235
+Gillbeea adenopetala,gilade,Cape Tribulation,0.126,0.0096,3678,0.43,0.46,15,,2863,3160,6549
+Haplostichanthus sp Coop. Ck,hapspp,Cape Tribulation,0.072,0.022,4685,0.668,0.36,,2430,12304,3282,2992
+Harpullia rhyticarpa,harrhy,Cape Tribulation,0.076,0.0174,40876,0.621,0.01,,,8971,5922,4669
+Hernandia albiflora,heralb,Cape Tribulation,0.069,0.0195,3806,0.447,0.33,,3123,4145,4643,6086
+Ixora biflora,ixobif,Cape Tribulation,0.081,0.01,2760,0.843,0.55,41.5,5244,3892,1969,8094
+Lasianthus strigosus,lasstr,Cape Tribulation,0.055,0.0158,3313,0.684,0.15,7,1841,5100,2379,2731
+Litsea leefeana,litlee,Cape Tribulation,0.13,0.0144,3917,0.549,0.68,263.4,3984,4141,3816,9645
+Macaranga tanarius,mactan,Cape Tribulation,0.104,0.0205,46676,0.344,0,,,3377,,3901
+Mallotus mollissimus,malmol,Cape Tribulation,0.063,0.0352,16716,0.373,0.32,31.25,1788,5580,5163,7944
+Medicosma sessiliflora,medses,Cape Tribulation,0.106,0.0153,8164,0.69,0.65,,2844,9332,6514,10298
+Melastoma cyanoides,melaff,Cape Tribulation,0.046,0.0208,4009,0.381,0.6,0.07,2960,4057,4661,6637
+Myristica insipida,myrins,Cape Tribulation,0.106,0.0185,8379,0.433,0.51,1612,,6929,4852,9273
+Pittosporum rubiginosum,pitrub,Cape Tribulation,0.065,0.0143,9931,0.728,0.28,27.94,7428,7459,5265,6548
+Psychotria dallachiana,psydal,Cape Tribulation,0.079,0.0177,2495,0.612,0.33,,4290,5666,4916,4761
+Quassia baileyana,quabai,Cape Tribulation,0.086,0.023,9624,0.501,0.42,,,5867,3216,5719
+Rockinghamia angustifolia,rocang,Cape Tribulation,0.108,0.0158,10636,0.455,0.39,19.38,,5862,4611,6098
+Syzygium gustavioides,syzgus,Cape Tribulation,0.167,0.0129,3590,0.521,0.59,48000,2833,3121,3047,6584
+Syzygium sayeri,syzsay,Cape Tribulation,0.131,0.0137,2645,0.485,0.65,841,3929,5767,4939,9836
+Trema aspera,treasp,Cape Tribulation,0.053,0.0299,2071,0.357,0.53,5.12,3578,5291,5440,6695

--- a/tests/testthat/data/Test_2022/metadata.yml
+++ b/tests/testthat/data/Test_2022/metadata.yml
@@ -1,0 +1,41 @@
+source:
+  primary:
+    key: Test_2022
+    bibtype: Article
+    year: '2005'
+    author: DANIEL S. FALSTER and MARK WESTOBY
+    journal: Journal of Ecology
+    title: Alternative height strategies among 45 dicot rain forest species from tropical
+      Queensland, Australia
+    volume: '93'
+    number: '3'
+    pages: 521--535
+    doi: 10.1111/j.0022-0477.2005.00992.x
+contributors:
+  data_collectors:
+    last_name: unknown
+    given_name: unknown
+    affiliation: unknown
+    ORCID: unknown
+    additional_role: unknown
+  assistants: unknown
+  austraits_curators: unknown
+dataset:
+  data_is_long_format: no
+  custom_R_code: .na
+  collection_date: 2022/2022
+  taxon_name: Species
+  site_name: site
+  description: unknown
+  collection_type: unknown
+  sample_age_class: unknown
+  sampling_strategy: unknown
+  original_file: unknown
+  notes: unknown
+sites: .na
+contexts: .na
+traits: .na
+substitutions: .na
+taxonomic_updates: .na
+exclude_observations: .na
+questions: .na

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,5 +1,4 @@
 library(testthat)
-library(bibtex)
 
 test_that("metadata_create_template is working",{
   expect_invisible(metadata_create_template(dataset_id = "Test_2022",
@@ -106,7 +105,6 @@ test_that("metadata_exclude_observations is working",{
 
 test_that("metadata_update_taxonomic_change is working",{
   expect_error(metadata_update_taxonomic_change("Test_2022", "grass", "bark", "soil"))
-  expect_output(suppressWarnings(metadata_add_taxonomic_change("Test_2022", "flower", "tree", "leaves")))
   expect_invisible(suppressMessages(metadata_update_taxonomic_change("Test_2022", "flower", "bark", "soil")))
   expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$find, "flower")
   expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$replace, "bark")

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(bibtex)
 
 test_that("metadata_create_template is working",{
   expect_invisible(metadata_create_template(dataset_id = "Test_2022",

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,0 +1,25 @@
+library(testthat)
+
+setwd("tests/testthat")
+ 
+test_that("metadata_path_dataset_id is working",{
+  expect_silent(metadata_path_dataset_id("Test_2022"))
+  expect_equal(metadata_path_dataset_id("Test_2022"), "data/Test_2022/metadata.yml")
+  expect_equal(class(metadata_path_dataset_id("Test_2022")), "character")
+})
+
+test_that("metadata_read_dataset_id is working",{
+  expect_silent(metadata_read_dataset_id("Test_2022"))
+  expect_equal(class(metadata_read_dataset_id("Test_2022")), "list")
+})  
+
+test_that("metadata_add_source_doi is working",{
+  metadata_add_source_doi(dataset_id = "Test_2022", doi = "10.1111/j.0022-0477.2005.00992.x")
+  
+  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "https://doi.org/10.3389/fmars.2021.671145"))
+  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "http://doi.org/10.3389/fmars.2021.671145"))
+  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "doi.org/10.3389/fmars.2021.671145"))
+  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "10.3389/fmars.2021.671145"))
+})
+
+

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,7 +1,32 @@
 library(testthat)
 
-setwd("tests/testthat")
- 
+test_that("metadata_create_template is working",{
+  expect_invisible(metadata_create_template(dataset_id = "Test_2022",
+                                            path = file.path("data", "Test_2022"),
+                                            skip_manual = TRUE))
+  test_metadata <- read_metadata("data/Test_2022/metadata.yml")
+  
+  metadata_names <- c("source", "contributors", "dataset", "sites", "contexts", "traits", 
+                      "substitutions", "taxonomic_updates", "exclude_observations", 
+                      "questions")
+  data_collector_names <- c("last_name", "given_name", "affiliation", "ORCID", "additional_role")
+  
+  ## Test metadata exists with correct names 
+  expect_named(test_metadata)
+  expect_equal(names(test_metadata), metadata_names)
+  expect_equal(length(test_metadata$source$primary), 10)
+  
+  ## Test contributors exist with the correct names
+  expect_equal(length(test_metadata$contributors), 3)
+  expect_equal(length(test_metadata$contributors$data_collectors), 5)
+  expect_equal(names(test_metadata$contributors$data_collectors), data_collector_names)
+  expect_equal(length(test_metadata$contributors$assistants), 1)
+  expect_equal(length(test_metadata$contributors$austraits_curators), 1)
+  expect_equal(length(test_metadata$contributors$austraits_curators), 1)
+  
+  expect_equal(length(test_metadata$dataset), 15)
+})
+
 test_that("metadata_path_dataset_id is working",{
   expect_silent(metadata_path_dataset_id("Test_2022"))
   expect_equal(metadata_path_dataset_id("Test_2022"), "data/Test_2022/metadata.yml")
@@ -13,13 +38,80 @@ test_that("metadata_read_dataset_id is working",{
   expect_equal(class(metadata_read_dataset_id("Test_2022")), "list")
 })  
 
-test_that("metadata_add_source_doi is working",{
-  metadata_add_source_doi(dataset_id = "Test_2022", doi = "10.1111/j.0022-0477.2005.00992.x")
+test_that("metadata_write_dataset_id is working",{
+  metadata <- metadata_read_dataset_id("Test_2022")
   
-  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "https://doi.org/10.3389/fmars.2021.671145"))
+  unlink("data/Test_2022/metadata.yml")
+  expect_false(file.exists("data/Test_2022/metadata.yml"))
+  
+  expect_silent(metadata_write_dataset_id(metadata, "Test_2022"))
+  expect_true(file.exists("data/Test_2022/metadata.yml"))
+  
+  expect_silent(metadata_read_dataset_id("Test_2022"))
+  expect_equal(class(metadata_read_dataset_id("Test_2022")), "list")
+})  
+
+test_that("metadata_add_source_doi is working",{
+  expect_invisible(metadata_add_source_doi(dataset_id = "Test_2022", doi = "https://doi.org/10.3389/fmars.2021.671145"))
   expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "http://doi.org/10.3389/fmars.2021.671145"))
   expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "doi.org/10.3389/fmars.2021.671145"))
   expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "10.3389/fmars.2021.671145"))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$source$primary$journal, "Frontiers in Marine Science")
+  
+  expect_silent(metadata_add_source_doi(dataset_id = "Test_2022", doi = "10.1111/j.0022-0477.2005.00992.x"))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$source$primary$journal, "Journal of Ecology")
 })
 
 
+test_that("metadata_check_custom_R_code is working",{
+  expect_equal(class(metadata_check_custom_R_code("Test_2022")), c("spec_tbl_df", "tbl_df", "tbl", "data.frame"))
+  expect_equal(ncol(metadata_check_custom_R_code("Test_2022")), 13)
+  expect_equal(nrow(metadata_check_custom_R_code("Test_2022")), 45)
+  
+  expect_visible(metadata_check_custom_R_code("Test_2022"))
+})
+
+test_that("metadata_add_source_bibtex is working",{
+  doi = "https://doi.org/10.3389/fmars.2021.671145"
+  bib <- suppressWarnings(rcrossref::cr_cn(doi))
+  file <- tempfile()
+  writeLines(bib, file)
+  expect_silent(metadata_add_source_bibtex(dataset_id = "Test_2022", file = file))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$source$primary$journal, "Frontiers in Marine Science")
+})
+
+test_that("metadata_add_substitution is working",{
+  expect_silent(suppressMessages(metadata_add_substitution("Test_2022", "specific_leaf_area", 
+                                                           "leaf_area", "specific_leaf_area")))
+  expect_equal(length(read_metadata("data/Test_2022/metadata.yml")$substitutions[[1]]), 3)
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$substitutions[[1]]$trait_name, "specific_leaf_area")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$substitutions[[1]]$find, "leaf_area")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$substitutions[[1]]$replace, "specific_leaf_area")
+})
+
+test_that("metadata_add_taxonomic_change is working",{
+  expect_output(metadata_add_taxonomic_change("Test_2022", "flower", "tree", "leaves"))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$find, "flower")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$replace, "tree")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$reason, "leaves")
+})
+
+test_that("metadata_exclude_observations is working",{
+  expect_output(metadata_exclude_observations("Test_2022", "stem", "branch", "test"))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$exclude_observations[[1]]$variable, "stem")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$exclude_observations[[1]]$find, "branch")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$exclude_observations[[1]]$reason, "test")
+})  
+
+test_that("metadata_update_taxonomic_change is working",{
+  expect_error(metadata_update_taxonomic_change("Test_2022", "grass", "bark", "soil"))
+  expect_output(suppressWarnings(metadata_add_taxonomic_change("Test_2022", "flower", "tree", "leaves")))
+  expect_invisible(suppressMessages(metadata_update_taxonomic_change("Test_2022", "flower", "bark", "soil")))
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$find, "flower")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$replace, "bark")
+  expect_equal(read_metadata("data/Test_2022/metadata.yml")$taxonomic_updates[[1]]$reason, "soil")
+})  
+
+test_that("metadata_remove_taxonomic_change is working",{
+  expect_invisible(metadata_remove_taxonomic_change("Test_2022", "flower"))
+})


### PR DESCRIPTION
In addition to modifying `metadata_create_template` to create template from definitions.yml, also wrote test coverage for most functions in setup.R

Things that need to be reviewed include: 
- modified code to `metadata_create_template`
- the tests for creating the metadata template requires access to the config/defintions.yml. Is it possible to read in from config/definitions.yml directly? I had to copy in a lite version of definitions.yml into the testthat folder.