### PR TITLE
A few small fixes to metadata function and the austraits schema

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -221,7 +221,9 @@ metadata_add_traits <- function(dataset_id) {
   traits <- tibble::tibble(var_in = var_in,
                             unit_in = "unknown",
                             trait_name = "unknown",
+                            entity_type = "unknown",
                             value_type = "unknown",
+                            basis_of_value = "unknown",
                             replicates = "unknown",
                             methods = "unknown") 
 

--- a/R/steps.R
+++ b/R/steps.R
@@ -311,7 +311,7 @@ create_entity_id <- function(data) {
   
   # Create species_id segment of entity_id: spp_id_segment
   data <- data %>% 
-    mutate(spp_id_segment = create_id(taxon_name, "spp", sort = TRUE))
+    mutate(spp_id_segment = create_id(taxon_name, "tax", sort = TRUE))
   
   # Create population_id segment of entity_id: pop_id_segment  
   
@@ -406,7 +406,7 @@ create_entity_id <- function(data) {
   data <- data %>%
     dplyr::mutate(
       entity_id = paste(dataset_id, spp_id_segment, pop_id_segment, ind_id_segment, sep="-"),
-      entity_id = ifelse(entity_type == "species", paste(dataset_id, spp_id_segment, sep="-"), entity_id),
+      entity_id = ifelse(entity_type %in% c("species","genus","family","order"), paste(dataset_id, spp_id_segment, sep="-"), entity_id),
       entity_id = ifelse(entity_type %in% c("population", "metapopulation"), paste(dataset_id, spp_id_segment, pop_id_segment, sep="-"), entity_id),
       individual_id = as.character(individual_id),
       replicates = as.character(replicates),

--- a/inst/support/austraits.build_schema.yml
+++ b/inst/support/austraits.build_schema.yml
@@ -4,10 +4,13 @@ entity_type:
   type: categorical
   values:
     individual: Value comes from a single individual
-    population: Value represents a summary statsitic from multiple individuals at a single site
-    metapopulation: Value represents a summary statsitic from individuals of the taxon across multiple sites
-    species: Values the mean observed for a taxon across its range or, in this particular dataset, as estimated by an expert based on their knowledge of the taxon. Data fitting this category include estimates from floras that represent a taxon's entire range and values for categorical variables obtained from a reference book, or identified by an expert.
-  
+    population: Value represents a summary statistic from multiple individuals at a single site
+    metapopulation: Value represents a summary statistic from individuals of the taxon across multiple sites
+    species: Value represents a summary statistic for a species or infraspecific taxon across its range or as estimated by an expert based on their knowledge of the taxon. Data fitting this category include estimates from reference books that represent a taxon's entire range and values for categorical variables obtained from a reference book or identified by an expert.
+    genus: Value represents a summary statistic or expert score for an entire genus.
+    family: Value represents a summary statistic or expert score for an entire family.
+    order: Value represents a summary statistic or expert score for an entire order.
+
 value_type:
   description: &value_type A categorical variable describing the type of value recorded.
   type: categorical


### PR DESCRIPTION
One more piece is needed - right now in metadata_create_template() all fields are added to the metadata template. However, entity_id should never appear here (it is just an output) and population_id and individual_id should only appear if specified. (And population_id is best just added manually). Right now the default is "population_id: unknown" (and same for others), which would override the code to actually build a population_id or individual_id, creating a fixed value for the entire dataset. Best for people to have to add these in, not forget to remove them. @dfalster @GaryTruong 