### PR TITLE
Bugfix: incorrect argument being passed

### DIFF
--- a/data/Pollock_2012/metadata.yml
+++ b/data/Pollock_2012/metadata.yml
@@ -29,7 +29,7 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:     data %>% mutate(date_time = date_time %>% ymd_hms() %>% floor_date(x, unit = "day"))
+  custom_R_code:     data %>% mutate(date_time = date_time %>% ymd_hms() %>% floor_date(unit = "day"))
   collection_date: date_time
   taxon_name: taxon
   location_name: locality_edited


### PR DESCRIPTION
Newest version of lubridate (1.9.0) fails where earlier vision passed. Failing is correct behaviour. 