### PR TITLE
Fixing duplication

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -1465,7 +1465,7 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
       taxonomic_resolution = ifelse(is.na(.data$taxonomic_resolution), .data$taxon_rank, .data$taxonomic_resolution)
     ) %>%
     dplyr::distinct() %>%
-    dplyr::select(-taxon_rank) %>%
+    dplyr::select(-.data$taxon_rank) %>%
     dplyr::arrange(.data$cleaned_name)
 
 
@@ -1569,14 +1569,15 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
 
   austraits_raw$taxa <-
     species_tmp %>%
+    dplyr::bind_rows() %>%
     dplyr::arrange(.data$taxon_name) %>%
     dplyr::distinct(.data$taxon_name, .keep_all = TRUE)
 
   # only now, at the very end, can `taxonomic_resolution` be removed from the traits table
-  
+
   austraits_raw$traits <-
     austraits_raw$traits %>%
-      dplyr::select(-.data$taxonomic_resolution)
+      dplyr::select(-.data$taxonomic_resolution, -.data$taxon_rank)
 
   austraits_raw$excluded_data <-
     austraits_raw$excluded_data %>%

--- a/R/process.R
+++ b/R/process.R
@@ -183,7 +183,7 @@ dataset_process <- function(filename_data_raw,
             lapply(util_list_to_bib) %>% purrr::reduce(c)
 
   # record methods
-  methods <- process_format_methods(metadata, dataset_id, sources, contributors, context_ids)
+  methods <- process_format_methods(metadata, dataset_id, sources, contributors)
  
   # Retrieve taxonomic details for known species
   taxonomic_updates <-
@@ -1190,7 +1190,7 @@ process_format_contributors <- function(my_list, dataset_id, schema) {
   contributors
 }
 
-process_format_methods <- function(metadata, dataset_id, sources, contributors, context_ids) {
+process_format_methods <- function(metadata, dataset_id, sources, contributors) {
 
   # identify sources as being `primary`, `secondary` or `original`
   # secondary datasets are additional publications associated with the primary citation
@@ -1225,7 +1225,7 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors, 
         util_list_to_df2() %>%
         dplyr::filter(!is.na(.data$trait_name)) %>%
         dplyr::mutate(dataset_id = dataset_id) %>%
-        dplyr::select(dataset_id, .data$trait_name, .data$methods, dplyr::any_of("method_context"))
+        dplyr::select(dataset_id, .data$trait_name, .data$methods)
       ,
       # study methods
       metadata$dataset %>%
@@ -1262,29 +1262,9 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors, 
       assistants = ifelse(is.null(metadata$contributors$assistants), NA_character_,
                                       metadata$contributors$assistants),
       austraits_curators = metadata$contributors$austraits_curators
-    )
+      )
 
-  method_contexts <- 
-    context_ids$contexts %>%
-      filter(category == "method", link_id == "method_id") %>%
-      rename(method_context = value, method_id = link_vals) %>%
-      select(method_context, method_id)
-
-#  browser()
-  if(nrow(method_contexts) > 0 ) {
-    methods <-
-      methods %>%
-      left_join(by = "method_context", method_contexts) %>% 
-      select(c("dataset_id", "trait_name", "method_id", "method_context", "methods"), everything())
-  } else {
-    methods <-
-      methods %>%
-      mutate(method_id = NA_character_)
-  }
-
-  methods %>% 
-  select(-any_of(c("method_context"))) %>%
-  select(c("dataset_id", "trait_name", "method_id", "methods"), everything())
+  methods
 }
 
 #' Standardise species names

--- a/R/process.R
+++ b/R/process.R
@@ -183,7 +183,7 @@ dataset_process <- function(filename_data_raw,
             lapply(util_list_to_bib) %>% purrr::reduce(c)
 
   # record methods
-  methods <- process_format_methods(metadata, dataset_id, sources, contributors)
+  methods <- process_format_methods(metadata, dataset_id, sources, contributors, context_ids)
  
   # Retrieve taxonomic details for known species
   taxonomic_updates <-
@@ -1190,7 +1190,7 @@ process_format_contributors <- function(my_list, dataset_id, schema) {
   contributors
 }
 
-process_format_methods <- function(metadata, dataset_id, sources, contributors) {
+process_format_methods <- function(metadata, dataset_id, sources, contributors, context_ids) {
 
   # identify sources as being `primary`, `secondary` or `original`
   # secondary datasets are additional publications associated with the primary citation
@@ -1225,7 +1225,7 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors) 
         util_list_to_df2() %>%
         dplyr::filter(!is.na(.data$trait_name)) %>%
         dplyr::mutate(dataset_id = dataset_id) %>%
-        dplyr::select(dataset_id, .data$trait_name, .data$methods)
+        dplyr::select(dataset_id, .data$trait_name, .data$methods, dplyr::any_of("method_context"))
       ,
       # study methods
       metadata$dataset %>%
@@ -1262,9 +1262,29 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors) 
       assistants = ifelse(is.null(metadata$contributors$assistants), NA_character_,
                                       metadata$contributors$assistants),
       austraits_curators = metadata$contributors$austraits_curators
-      )
+    )
 
-  methods
+  method_contexts <- 
+    context_ids$contexts %>%
+      filter(category == "method", link_id == "method_id") %>%
+      rename(method_context = value, method_id = link_vals) %>%
+      select(method_context, method_id)
+
+#  browser()
+  if(nrow(method_contexts) > 0 ) {
+    methods <-
+      methods %>%
+      left_join(by = "method_context", method_contexts) %>% 
+      select(c("dataset_id", "trait_name", "method_id", "method_context", "methods"), everything())
+  } else {
+    methods <-
+      methods %>%
+      mutate(method_id = NA_character_)
+  }
+
+  methods %>% 
+  select(-any_of(c("method_context"))) %>%
+  select(c("dataset_id", "trait_name", "method_id", "methods"), everything())
 }
 
 #' Standardise species names

--- a/R/process.R
+++ b/R/process.R
@@ -183,7 +183,7 @@ dataset_process <- function(filename_data_raw,
             lapply(util_list_to_bib) %>% purrr::reduce(c)
 
   # record methods
-  methods <- process_format_methods(metadata, dataset_id, sources, contributors, context_ids)
+  methods <- process_format_methods(metadata, dataset_id, sources, contributors, context_ids, contexts)
  
   # Retrieve taxonomic details for known species
   taxonomic_updates <-
@@ -1190,7 +1190,7 @@ process_format_contributors <- function(my_list, dataset_id, schema) {
   contributors
 }
 
-process_format_methods <- function(metadata, dataset_id, sources, contributors, context_ids) {
+process_format_methods <- function(metadata, dataset_id, sources, contributors, context_ids, contexts) {
 
   # identify sources as being `primary`, `secondary` or `original`
   # secondary datasets are additional publications associated with the primary citation
@@ -1218,6 +1218,39 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors, 
                           paste0(" (", contributors$additional_role, ")"),
                           ""))  %>% paste(collapse = ", ")
 
+  # contexts that are of category = method
+ # browser()
+  if(nrow(contexts) > 0) {
+     if(nrow(contexts %>% filter(category == "method")) > 0) {
+    method_contexts_tmp <-
+      contexts %>%
+        filter(category == "method") %>% 
+        distinct(var_in)
+     } else {
+       method_contexts_tmp <- tibble::tibble(var_in = "XX")
+     }
+  } else {
+    method_contexts_tmp <- tibble::tibble(var_in = "XX")
+  }
+  
+  # identify which method contexts come from metadata[["traits"]]
+  # XXXX But I know it can't just be searching for method_contexts_tmp$var_in[[1]] - needs a seq_along, but this is a start
+  
+  if(nrow(contexts) > 0) { 
+    traits_columns <-  metadata[["traits"]] %>%
+      util_list_to_df2() %>% dplyr::select(dplyr::any_of(method_contexts_tmp$var_in[[1]]))
+  } else {
+    traits_columns <- tibble::tibble()
+  }
+    
+  # TRUE/FALSE variable, which is TRUE if there are method contexts keyed in through metadata[["traits]] and FALSE if all metadata contexts come from columns
+  # if FALSE, then there is no need for those method_ids to be in the methods tables and in fact they can't be in the methods table, because they are likely
+  # to vary across rows of data, not simply across trait entries
+  
+  traits_columns_tmp <- ifelse(ncol(traits_columns) == 0 | is.null(traits_columns), FALSE, TRUE)
+  
+  #browser()
+  
   methods <-
     dplyr::full_join( by = "dataset_id",
       # methods used to collect each trait
@@ -1225,7 +1258,8 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors, 
         util_list_to_df2() %>%
         dplyr::filter(!is.na(.data$trait_name)) %>%
         dplyr::mutate(dataset_id = dataset_id) %>%
-        dplyr::select(dataset_id, .data$trait_name, .data$methods, dplyr::any_of("method_context"))
+  #      dplyr::select(dataset_id, .data$trait_name, .data$methods, dplyr::any_of("method_context"))
+        dplyr::select(dataset_id, .data$trait_name, .data$methods, dplyr::any_of(method_contexts_tmp$var_in[[1]]))
       ,
       # study methods
       metadata$dataset %>%
@@ -1264,13 +1298,13 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors, 
       austraits_curators = metadata$contributors$austraits_curators
     )
 
+
   method_contexts <- 
     context_ids$contexts %>%
-      filter(category == "method", link_id == "method_id") %>%
+      filter(category == "method", link_id == "method_id", var_in %in% traits_columns) %>%
       rename(method_context = value, method_id = link_vals) %>%
       select(method_context, method_id)
 
-#  browser()
   if(nrow(method_contexts) > 0 ) {
     methods <-
       methods %>%

--- a/R/process.R
+++ b/R/process.R
@@ -1506,22 +1506,22 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
       # if no taxonomic resolution is specified, then the name's taxonomic resolution is the taxon_rank for the taxon name
       taxon_rank = ifelse(!is.na(.data$taxonomic_resolution), .data$taxonomic_resolution, .data$taxon_rank),
       # field trinomial is only filled in if taxonomic resolution is an infraspecific name 
-      trinomial = ifelse(.data$taxon_rank %in% c("trinomial", "Subspecies", "Forma", "Varietas"),             
+      trinomial = ifelse(.data$taxon_rank %in% c("Subspecies", "Forma", "Varietas"),             
                         stringr::str_split_fixed(.data$taxon_name, "\\[",2)[,1] %>% stringr::str_trim(), NA),
       # field binomial is filled in if taxonomic resolution is an infraspecific name or a binomial
       # all taxon names that have "extra" information (beyond the actual name) have been formatted to have that information in square brackets '[]',
       # so these can be used as a delimitor to extract the actual name
-      binomial = ifelse(.data$taxon_rank %in% c("binomial", "Species"), 
+      binomial = ifelse(.data$taxon_rank %in% c("Species"), 
                         stringr::str_split_fixed(.data$taxon_name, "\\[",2)[,1] %>% stringr::str_trim(), NA),
-      binomial = ifelse(.data$taxon_rank %in% c("trinomial", "Subspecies", "Forma", "Varietas", "Series"), 
+      binomial = ifelse(.data$taxon_rank %in% c("Subspecies", "Forma", "Varietas", "Series"), 
                         stringr::word(.data$taxon_name, start = 1, end = 2), .data$binomial),
       binomial = stringr::str_trim(.data$binomial),
       # genus filled in for all names that have a taxonomic of genus or more detailed
       genus = ifelse(!.data$taxon_rank %in% c("Familia", "family"), ifelse(stringr::word(.data$taxon_name, 1) == "x", stringr::word(.data$taxon_name, start = 1, end = 2), stringr::word(.data$taxon_name, 1)), NA),
       family = ifelse(.data$taxon_rank %in% c("Familia", "family"), stringr::word(.data$taxon_name, 1), .data$family),
       # identify which name is to be matched to the various identifiers, distribution information, etc. in the taxa file
-      name_to_match_to = ifelse(.data$taxon_rank %in% c("trinomial", "Subspecies", "Forma", "Varietas"), .data$trinomial, NA),
-      name_to_match_to = ifelse(is.na(.data$name_to_match_to) & .data$taxon_rank %in% c("binomial", "Species"), .data$binomial, .data$name_to_match_to),
+      name_to_match_to = ifelse(.data$taxon_rank %in% c("Subspecies", "Forma", "Varietas"), .data$trinomial, NA),
+      name_to_match_to = ifelse(is.na(.data$name_to_match_to) & .data$taxon_rank %in% c("Species"), .data$binomial, .data$name_to_match_to),
       name_to_match_to = ifelse(is.na(.data$name_to_match_to) & .data$taxon_rank %in% c("genus", "Genus"), .data$genus, .data$name_to_match_to),
       name_to_match_to = ifelse(is.na(.data$name_to_match_to) & is.na(.data$taxon_rank), .data$genus, .data$name_to_match_to),
       name_to_match_to = ifelse(is.na(.data$name_to_match_to) & .data$taxon_rank %in% c("family", "Familia"), .data$family, .data$name_to_match_to)

--- a/data/ABRS_1981/metadata.yml
+++ b/data/ABRS_1981/metadata.yml
@@ -517,5 +517,8 @@ taxonomic_updates:
   reason: match_14. Automatic alignment with species-level canonical name in APC accepted
     when notes are ignored (2022-11-12)
   taxonomic_resolution: Species
-exclude_observations: .na
+exclude_observations:
+- variable: taxon_name
+  find: Platanus x hispanica 'Acerifolia'
+  reason: excluding cultivars
 questions: .na

--- a/data/ABRS_2022/metadata.yml
+++ b/data/ABRS_2022/metadata.yml
@@ -399,10 +399,6 @@ taxonomic_updates:
   reason: match_14. Automatic alignment with species-level name known by APC when
     notes are ignored (2022-11-22)
   taxonomic_resolution: Species
-- find: Platanus xhispanica 'Acerifolia'
-  replace: Platanus x hispanica 'Acerifolia'
-  reason: Manual alignment with canonical  species name in APC (Elizabeth Wenk, 2022-11-21)
-  taxonomic_resolution: Species
 - find: Pterostylis xaenigma
   replace: Pterostylis x aenigma
   reason: match_07_fuzzy. Fuzzy alignment with accepted canonical name in APC (2022-11-22)
@@ -570,4 +566,7 @@ exclude_observations:
     Group, Strumosa Group, Thelemanniana Group, Trifida Group, Trifurcata Group, Triloba
     Group, Trineura Group, Ulicina Group, Undulata Group, Wickhamii Group
   reason: not species in APC/APNI
+- variable: taxon_name
+  find: Platanus xhispanica 'Acerifolia'
+  reason: excluding cultivars
 questions: .na

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -229,9 +229,11 @@ contexts:
   category: method
   var_in: method_context
   values:
-  - value: 400 ppm CO2
+  - find: 400 ppm CO2
+    value: 400 ppm
     description: Measurement made at ambient CO2 concentrations (400 ppm).
-  - value: 1500 ppm CO2
+  - find: 1500 ppm CO2
+    value: 1500 ppm
     description: Measurement made at an elevated CO2 concentration of 1500 ppm.
 traits:
 - var_in: A400.a

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -229,11 +229,9 @@ contexts:
   category: method
   var_in: method_context
   values:
-  - find: 400 ppm CO2
-    value: 400 ppm
+  - value: 400 ppm CO2
     description: Measurement made at ambient CO2 concentrations (400 ppm).
-  - find: 1500 ppm CO2
-    value: 1500 ppm
+  - value: 1500 ppm CO2
     description: Measurement made at an elevated CO2 concentration of 1500 ppm.
 traits:
 - var_in: A400.a

--- a/data/Cooper_2013/metadata.yml
+++ b/data/Cooper_2013/metadata.yml
@@ -180,7 +180,7 @@ traits:
   value_type: maximum
   basis_of_value: measurement
   replicates: .na
-  methods: measurement
+  methods: reference book
 - var_in: min seed length
   unit_in: mm
   trait_name: seed_length

--- a/data/Ghannoum_2010/metadata.yml
+++ b/data/Ghannoum_2010/metadata.yml
@@ -333,17 +333,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: entire plant LMA
-  methods: Two destructive harvests were conducted 80 and 150 DAP; nine trees at 80
-    DAP and 18 trees at 150 DAP of each species were harvested within each [CO2] and
-    temperature treatment combination. During each harvest, we measured the length
-    of the main stem, diameter at stem base, and separated the seedling into stems
-    (including branches and petioles) and leaf blades; shoot tips were removed separately
-    and roots were washed free of soil. Total leaf area was determined using a portable
-    leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA). The number of leaves and
-    branches were counted at 150 DAP harvest only. Harvested samples were oven-dried
-    at 80 deg C for 48 h, then weighed. For each plant, mean leaf mass per area (LMA)
-    and leaf area ratio (LAR) were calculated as total leaf dry mass/total leaf area
-    and total leaf area/total plant dry mass, respectively.
+  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
 - var_in: leaf_area_ratio
   unit_in: mm2/mg
   trait_name: leaf_area_ratio
@@ -406,9 +396,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: single leaf LMA
-  methods: Measurement on samples collected for biochemical analyses. Leaf area was
-    determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA). Harvested
-    samples were oven-dried at 80 deg C for 48 h, then weighed.
+  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
 - var_in: LSolSugA (g m-2)
   unit_in: g/m2
   trait_name: leaf_soluble_sugars_per_area

--- a/data/Ghannoum_2010/metadata.yml
+++ b/data/Ghannoum_2010/metadata.yml
@@ -333,7 +333,17 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: entire plant LMA
-  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
+  methods: Two destructive harvests were conducted 80 and 150 DAP; nine trees at 80
+    DAP and 18 trees at 150 DAP of each species were harvested within each [CO2] and
+    temperature treatment combination. During each harvest, we measured the length
+    of the main stem, diameter at stem base, and separated the seedling into stems
+    (including branches and petioles) and leaf blades; shoot tips were removed separately
+    and roots were washed free of soil. Total leaf area was determined using a portable
+    leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA). The number of leaves and
+    branches were counted at 150 DAP harvest only. Harvested samples were oven-dried
+    at 80 deg C for 48 h, then weighed. For each plant, mean leaf mass per area (LMA)
+    and leaf area ratio (LAR) were calculated as total leaf dry mass/total leaf area
+    and total leaf area/total plant dry mass, respectively.
 - var_in: leaf_area_ratio
   unit_in: mm2/mg
   trait_name: leaf_area_ratio
@@ -396,7 +406,9 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: single leaf LMA
-  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
+  methods: Measurement on samples collected for biochemical analyses. Leaf area was
+    determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA). Harvested
+    samples were oven-dried at 80 deg C for 48 h, then weighed.
 - var_in: LSolSugA (g m-2)
   unit_in: g/m2
   trait_name: leaf_soluble_sugars_per_area

--- a/data/Ghannoum_2010/metadata.yml
+++ b/data/Ghannoum_2010/metadata.yml
@@ -333,17 +333,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: entire plant LMA
-  methods: Two destructive harvests were conducted 80 and 150 DAP; nine trees at 80
-    DAP and 18 trees at 150 DAP of each species were harvested within each [CO2] and
-    temperature treatment combination. During each harvest, we measured the length
-    of the main stem, diameter at stem base, and separated the seedling into stems
-    (including branches and petioles) and leaf blades; shoot tips were removed separately
-    and roots were washed free of soil. Total leaf area was determined using a portable
-    leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA). The number of leaves and
-    branches were counted at 150 DAP harvest only. Harvested samples were oven-dried
-    at 80 deg C for 48 h, then weighed. For each plant, mean leaf mass per area (LMA)
-    and leaf area ratio (LAR) were calculated as total leaf dry mass/total leaf area
-    and total leaf area/total plant dry mass, respectively.
+  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
 - var_in: leaf_area_ratio
   unit_in: mm2/mg
   trait_name: leaf_area_ratio
@@ -406,9 +396,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: single leaf LMA
-  methods: Measurement on samples collected for biochemical analyses. Leaf area was
-    determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested
-    samples were oven-dried at 80 deg C for 48 h, then weighed.
+  methods: Leaf area was determined using a portable leaf area meter (LI-3100A, LI-COR, Lincoln, NE, USA).Harvested samples were oven-dried at 80 deg C for 48 h, then weighed.
 - var_in: LSolSugA (g m-2)
   unit_in: g/m2
   trait_name: leaf_soluble_sugars_per_area

--- a/data/Kotowska_2020/metadata.yml
+++ b/data/Kotowska_2020/metadata.yml
@@ -606,11 +606,11 @@ contexts:
   var_in: method_context
   values:
   - value: stem sample
-    description: Measurements made on the main stem.
+    description: Measurements made on the main stem. In detail, the wood cores of length 5-6 cm were extracted using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele, Sweden). The samples were transported in marked straws to ensure the determination of inner and outer segments. In the lab the cores were immediately divided into five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy, wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer to the inner wood, respectively). Fresh samples for wood anatomy were stored in 70% ethanol until further processing while nutrient samples were oven dried at 60 deg C for 48 h. Ethanol storage has proven to be a better storage method based on preliminary work, as cutting previously dried samples led to lower quality sections in some species. All plant samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University of Goettingen, Germany.
   - value: branch sample
-    description: Measurements made on a branch.
+    description: Measurements made on a branch. In detail, for the twig samples one sun-exposed branch per tree optimally in mid-canopy position was chosen and cut using loppers mounted on an elongated pole. From this branch a healthy twig with diameter 5-7 mm was selected and a 3-4 cm segment removed for wood anatomy and for nutrient analysis. From this branch, 5-30 healthy and intact mature leaves (the youngest fully expanded leaves without any sign of damage) were taken and dust removed using wet tissue. Senescent leaves (usually visually determinable by an altered color and easy to detach) were collected from the same branch or at least the same tree by shaking the tree or touching the leaf by hand. In the lab, bark from nutrient-sample twigs was carefully removed and bagged separately. Small pieces of stem bark were removed using a knife or small chisel. All plant samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University of Goettingen, Germany.
   - value: heartwood sample
-    description: Measurements made on heartwood.
+    description: Measurements made on heartwood. In detail, the wood cores of length 5-6 cm were extracted using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele, Sweden). The samples were transported in marked straws to ensure the determination of inner and outer segments. In the lab the cores were immediately divided into five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy, wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer to the inner wood, respectively). Fresh samples for wood anatomy were stored in 70% ethanol until further processing while nutrient samples were oven dried at 60 deg C for 48 h. Ethanol storage has proven to be a better storage method based on preliminary work, as cutting previously dried samples led to lower quality sections in some species. All plant samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University of Goettingen, Germany.
 - context_property: leaf lifespan method
   category: method
   var_in: method_context2
@@ -1703,21 +1703,7 @@ traits:
   replicates: 1
   method_context: stem sample
   methods: For measuring tissue fractions in xylem, one wood core of the main trunk
-    and one twig sample per tree was taken. The wood cores of length 5-6 cm were extracted
-    using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele,
-    Sweden). The samples were transported in marked straws to ensure the determination
-    of inner and outer segments. In the lab the cores were immediately divided into
-    five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy,
-    wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer
-    to the inner wood, respectively). Fresh samples for wood anatomy were stored in
-    70% ethanol until further processing while nutrient samples were oven dried at
-    60 deg C for 48 h. Ethanol storage has proven to be a better storage method based
-    on preliminary work, as cutting previously dried samples led to lower quality
-    sections in some species. All plant samples were oven-dried at 60 deg C for 48
-    h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario
-    EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by
-    inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer
-    Optima 5300 DV) at the University of Goettingen, Germany.
+    and one twig sample per tree was taken.
 - var_in: N.leaf
   unit_in: mg/g
   trait_name: leaf_N_per_dry_mass
@@ -1772,21 +1758,8 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: branch sample
-  methods: For the twig samples one sun-exposed branch per tree optimally in mid-canopy
-    position was chosen and cut using loppers mounted on an elongated pole. From this
-    branch a healthy twig with diameter 5-7 mm was selected and a 3-4 cm segment removed
-    for wood anatomy and for nutrient analysis. From this branch, 5-30 healthy and
-    intact mature leaves (the youngest fully expanded leaves without any sign of damage)
-    were taken and dust removed using wet tissue. Senescent leaves (usually visually
-    determinable by an altered color and easy to detach) were collected from the same
-    branch or at least the same tree by shaking the tree or touching the leaf by hand.
-    In the lab, bark from nutrient-sample twigs was carefully removed and bagged separately.
-    Small pieces of stem bark were removed using a knife or small chisel. All plant
-    samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for
-    C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P
-    and other nutrients after HNO3 digestion by inductively coupled plasma optical
-    emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University
-    of Goettingen, Germany.
+  methods: For measuring tissue fractions in xylem, one wood core of the main trunk
+    and one twig sample per tree was taken.
 - var_in: N.bark
   unit_in: mg/g
   trait_name: bark_N_per_dry_mass
@@ -1842,21 +1815,7 @@ traits:
   replicates: 1
   method_context: heartwood sample
   methods: For measuring tissue fractions in xylem, one wood core of the main trunk
-    and one twig sample per tree was taken. The wood cores of length 5-6 cm were extracted
-    using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele,
-    Sweden). The samples were transported in marked straws to ensure the determination
-    of inner and outer segments. In the lab the cores were immediately divided into
-    five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy,
-    wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer
-    to the inner wood, respectively). Fresh samples for wood anatomy were stored in
-    70% ethanol until further processing while nutrient samples were oven dried at
-    60 deg C for 48 h. Ethanol storage has proven to be a better storage method based
-    on preliminary work, as cutting previously dried samples led to lower quality
-    sections in some species. All plant samples were oven-dried at 60 deg C for 48
-    h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario
-    EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by
-    inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer
-    Optima 5300 DV) at the University of Goettingen, Germany.
+    and one twig sample per tree was taken.
 - var_in: N.recy.st
   unit_in: '%'
   trait_name: .na
@@ -1913,21 +1872,7 @@ traits:
   replicates: 1
   method_context: stem sample
   methods: For measuring tissue fractions in xylem, one wood core of the main trunk
-    and one twig sample per tree was taken. The wood cores of length 5-6 cm were extracted
-    using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele,
-    Sweden). The samples were transported in marked straws to ensure the determination
-    of inner and outer segments. In the lab the cores were immediately divided into
-    five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy,
-    wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer
-    to the inner wood, respectively). Fresh samples for wood anatomy were stored in
-    70% ethanol until further processing while nutrient samples were oven dried at
-    60 deg C for 48 h. Ethanol storage has proven to be a better storage method based
-    on preliminary work, as cutting previously dried samples led to lower quality
-    sections in some species. All plant samples were oven-dried at 60 deg C for 48
-    h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario
-    EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by
-    inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer
-    Optima 5300 DV) at the University of Goettingen, Germany.
+    and one twig sample per tree was taken.
 - var_in: P.leaf
   unit_in: mg/g
   trait_name: leaf_P_per_dry_mass
@@ -1982,21 +1927,8 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: branch sample
-  methods: For the twig samples one sun-exposed branch per tree optimally in mid-canopy
-    position was chosen and cut using loppers mounted on an elongated pole. From this
-    branch a healthy twig with diameter 5-7 mm was selected and a 3-4 cm segment removed
-    for wood anatomy and for nutrient analysis. From this branch, 5-30 healthy and
-    intact mature leaves (the youngest fully expanded leaves without any sign of damage)
-    were taken and dust removed using wet tissue. Senescent leaves (usually visually
-    determinable by an altered color and easy to detach) were collected from the same
-    branch or at least the same tree by shaking the tree or touching the leaf by hand.
-    In the lab, bark from nutrient-sample twigs was carefully removed and bagged separately.
-    Small pieces of stem bark were removed using a knife or small chisel. All plant
-    samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for
-    C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P
-    and other nutrients after HNO3 digestion by inductively coupled plasma optical
-    emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University
-    of Goettingen, Germany.
+  methods: For measuring tissue fractions in xylem, one wood core of the main trunk
+    and one twig sample per tree was taken.
 - var_in: P.bark
   unit_in: mg/g
   trait_name: bark_P_per_dry_mass
@@ -2006,21 +1938,7 @@ traits:
   replicates: 1
   method_context: stem sample
   methods: For measuring tissue fractions in xylem, one wood core of the main trunk
-    and one twig sample per tree was taken. The wood cores of length 5-6 cm were extracted
-    using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele,
-    Sweden). The samples were transported in marked straws to ensure the determination
-    of inner and outer segments. In the lab the cores were immediately divided into
-    five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy,
-    wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer
-    to the inner wood, respectively). Fresh samples for wood anatomy were stored in
-    70% ethanol until further processing while nutrient samples were oven dried at
-    60 deg C for 48 h. Ethanol storage has proven to be a better storage method based
-    on preliminary work, as cutting previously dried samples led to lower quality
-    sections in some species. All plant samples were oven-dried at 60 deg C for 48
-    h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario
-    EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by
-    inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer
-    Optima 5300 DV) at the University of Goettingen, Germany.
+    and one twig sample per tree was taken.
 - var_in: P.br.bark
   unit_in: mg/g
   trait_name: bark_P_per_dry_mass
@@ -2029,21 +1947,8 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: branch sample
-  methods: For the twig samples one sun-exposed branch per tree optimally in mid-canopy
-    position was chosen and cut using loppers mounted on an elongated pole. From this
-    branch a healthy twig with diameter 5-7 mm was selected and a 3-4 cm segment removed
-    for wood anatomy and for nutrient analysis. From this branch, 5-30 healthy and
-    intact mature leaves (the youngest fully expanded leaves without any sign of damage)
-    were taken and dust removed using wet tissue. Senescent leaves (usually visually
-    determinable by an altered color and easy to detach) were collected from the same
-    branch or at least the same tree by shaking the tree or touching the leaf by hand.
-    In the lab, bark from nutrient-sample twigs was carefully removed and bagged separately.
-    Small pieces of stem bark were removed using a knife or small chisel. All plant
-    samples were oven-dried at 60 deg C for 48 h and then ground and analyzed for
-    C+N contents with a CN auto-analyzer (Vario EL III, Hanau, Germany) and for P
-    and other nutrients after HNO3 digestion by inductively coupled plasma optical
-    emission spectrometry analysis (Perkin Elmer Optima 5300 DV) at the University
-    of Goettingen, Germany.
+  methods: For measuring tissue fractions in xylem, one wood core of the main trunk
+    and one twig sample per tree was taken.
 - var_in: P.hr
   unit_in: mg/g
   trait_name: wood_P_per_dry_mass
@@ -2053,21 +1958,7 @@ traits:
   replicates: 1
   method_context: heartwood sample
   methods: For measuring tissue fractions in xylem, one wood core of the main trunk
-    and one twig sample per tree was taken. The wood cores of length 5-6 cm were extracted
-    using an increment borer with an inner diameter of 5.15 mm (Haglof, Langsele,
-    Sweden). The samples were transported in marked straws to ensure the determination
-    of inner and outer segments. In the lab the cores were immediately divided into
-    five segments of 1 cm length for sapwood nutrient analysis, sapwood wood anatomy,
-    wood density, inner wood anatomy, and inner wood nutrient analysis (from the outer
-    to the inner wood, respectively). Fresh samples for wood anatomy were stored in
-    70% ethanol until further processing while nutrient samples were oven dried at
-    60 deg C for 48 h. Ethanol storage has proven to be a better storage method based
-    on preliminary work, as cutting previously dried samples led to lower quality
-    sections in some species. All plant samples were oven-dried at 60 deg C for 48
-    h and then ground and analyzed for C+N contents with a CN auto-analyzer (Vario
-    EL III, Hanau, Germany) and for P and other nutrients after HNO3 digestion by
-    inductively coupled plasma optical emission spectrometry analysis (Perkin Elmer
-    Optima 5300 DV) at the University of Goettingen, Germany.
+    and one twig sample per tree was taken.
 - var_in: P.recy.st
   unit_in: '%'
   trait_name: .na

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -147,14 +147,6 @@ traits:
   basis_of_value: expert_score
   replicates: .na
   methods: data sourced from reference books listed as secondary references
-- var_in: parasitic
-  unit_in: .na
-  trait_name: parasitic
-  value_type: mode
-  basis_of_value: expert_score
-  replicates: .na
-  methods: data sourced from reference books listed as secondary references; a subset
-    of data under `habit`
 - var_in: woodiness
   unit_in: .na
   trait_name: woodiness

--- a/data/Metcalfe_2020_2/metadata.yml
+++ b/data/Metcalfe_2020_2/metadata.yml
@@ -402,10 +402,6 @@ taxonomic_updates:
   replace: Dimeria sp. Mosquito Point (J.R.Clarkson+ 9994)
   reason: match_07_fuzzy. Fuzzy alignment with accepted canonical name in APC (2022-11-10)
   taxonomic_resolution: Species
-- find: Echinochloa polystachya cv. Amity
-  replace: Echinochloa polystachya 'Amity'
-  reason: Manual alignment with canonical species name in APC (Elizabeth Wenk, 2022-11-12)
-  taxonomic_resolution: Species
 - find: Eriachne armitii
   replace: Eriachne armittii
   reason: match_07_fuzzy. Fuzzy alignment with accepted canonical name in APC (2022-11-10)
@@ -427,10 +423,6 @@ taxonomic_updates:
 - find: Gen.(Aq577997) sp. (Port Douglas R.L.Jago 6610)
   replace: Pseudoraphis sp. (Port Douglas R.L.Jago 6610)
   reason: Manual alignment with canonical species name in APC (Elizabeth Wenk, 2022-11-22)
-  taxonomic_resolution: Species
-- find: Hymenachne amplexicaulis cv. Olive
-  replace: Hymenachne amplexicaulis 'Olive'
-  reason: Manual alignment with canonical species name in APC (Elizabeth Wenk, 2022-11-12)
   taxonomic_resolution: Species
 - find: Iseilema calvum x I. vaginiflorum
   replace: Iseilema x [Iseilema calvum x I. vaginiflorum; Metcalfe_2020_2]
@@ -469,5 +461,8 @@ taxonomic_updates:
   replace: Thaumastochloa sp. Morehead River (J.R.Clarkson+ 8086)
   reason: match_07_fuzzy. Fuzzy alignment with accepted canonical name in APC (2022-11-10)
   taxonomic_resolution: Species
-exclude_observations: .na
+exclude_observations: 
+- variable: taxon_name
+  find: Echinochloa polystachya cv. Amity, Hymenachne amplexicaulis cv. Olive
+  reason: excluding cultivars
 questions: .na

--- a/data/NHNSW_2022/metadata.yml
+++ b/data/NHNSW_2022/metadata.yml
@@ -221,10 +221,6 @@ taxonomic_updates:
   reason: match_20. Rewording name to be recognised as genus rank, with genus accepted
     by APC (2022-11-22)
   taxonomic_resolution: genus
-- find: Cyrtomium falcatum  ;qu;Rochfordii;qu;
-  replace: Cyrtomium falcatum 'Rochfordii'
-  reason: Manual alignment with canonical  species name in APC (Elizabeth Wenk, 2022-11-21)
-  taxonomic_resolution: Species
 - find: Dillwynia sp. Ebor (P.C.Jobson 5318 ;amp; S.A.Mills)
   replace: Dillwynia sp. Ebor (P.C.Jobson 5318 & S.A.Mills)
   reason: match_17_fuzzy. Imprecise fuzzy alignment with canonical name in APNI (2022-11-21)
@@ -454,14 +450,6 @@ taxonomic_updates:
   replace: Rubus loganubaccus
   reason: match_07_fuzzy. Fuzzy alignment with known canonical name in APC (2022-11-21)
   taxonomic_resolution: Species
-- find: Salix humboldtiana cv. ;qu;Pyramidalis;qu;
-  replace: Salix humboldtiana 'Pyramidalis'
-  reason: Manual alignment with canonical  species name in APC (Elizabeth Wenk, 2022-11-21)
-  taxonomic_resolution: Species
-- find: Salix matsudana cv. ;qu;Tortuosa;qu;
-  replace: Salix matsudana 'Tortuosa'
-  reason: Manual alignment with canonical  species name in APC (Elizabeth Wenk, 2022-11-21)
-  taxonomic_resolution: Species
 - find: Salix matsudana x alba
   replace: Salix matsudana x Salix alba
   reason: Manual alignment with canonical hybrid species name in APC (Elizabeth Wenk,
@@ -473,11 +461,11 @@ taxonomic_updates:
     2022-11-21)
   taxonomic_resolution: Species
 - find: Salix x sepulcralis var. chrysocoma
-  replace: Salix x sepulcralis nothovar. chrysocoma
+  replace: Salix x sepulcralis
   reason: Manual alignment with canonical species name in APC (Elizabeth Wenk, 2022-11-22)
-  taxonomic_resolution: Varietas
+  taxonomic_resolution: Species
 - find: Salix x sepulcralis var. sepulcralis
-  replace: Salix x sepulcralis nothovar. sepulcralis
+  replace: Salix x sepulcralis
   reason: Manual alignment with canonical species name in APC (Elizabeth Wenk, 2022-11-22)
   taxonomic_resolution: Varietas
 - find: Salvinia molesta
@@ -555,5 +543,8 @@ taxonomic_updates:
   reason: Manual matched to genus for taxon that can't be matched to species (Elizabeth
     Wenk, 2022-11-22)
   taxonomic_resolution: genus
-exclude_observations: .na
+exclude_observations:
+- variable: taxon_name
+  find: Salix humboldtiana cv. ;qu;Pyramidalis;qu;, Salix matsudana cv. ;qu;Tortuosa;qu;, Cyrtomium falcatum  ;qu;Rochfordii;qu;
+  reason: excluding cultivars
 questions: .na

--- a/data/Pickup_2005/metadata.yml
+++ b/data/Pickup_2005/metadata.yml
@@ -109,16 +109,132 @@ contexts:
   values:
   - value: 10mm2 stem cross-sectional area
     description: Leaf area was determined for a shoot whose sapwood had a cross sectional
-      area of 10 mm2.
+      area of 10 mm2. In detail, while initial data were collected in terms of aggregate (or whole) stem
+      cross-sectional areas, we subsequently decided to use the conductive tissue cross-section
+      (excluding bark and pith) as a reference diameter. To determine the cross-sectional
+      area of the aggregate (or whole) stem where the cross-section of the conductive
+      tissue was 5, 10, 15, 20 and 30 mm 2 for each species, a ratio of the aggregate
+      stem cross-sectional area to the conductive stem cross-sectional area was measured
+      as follows for each species in the low-nutrient, high-rainfall site. For four
+      individuals per species, two sections of stem 20-30 mm in length, one 3-5 mm and
+      the second 6-8 mm in diameter, were randomly sampled from an actively growing
+      shoot in the upper canopy. Long and short diameters were used to calculate the
+      aggregate cross-sectional area. The stem was then dissected along the vascular
+      cambium and the cross-sectional area of the water-conductive tissue was similarly
+      calculated. Water-conductive tissue was identified as the portion of the stem
+      remaining after dissection along the vascular cambium and removal of the bark
+      (phloem, cortex and epidermis). Examining stained cross-sections of the stem under
+      a light microscope substantiated identification of water-conductive tissue. (Hereafter,
+      the term conductive tissue refers to the water-conductive tissue.) This resulted
+      in two ratios of aggregate to conductive stem cross-sectional area, one at ~10
+      mm 2 and the second at ~25 mm 2 . This was done to account for changes in the
+      proportion of conductive and non-conductive tissue along the stem. The first ratio
+      was used to calculate variables at 5, 10 and 15 mm 2 of conductive tissue, and
+      the second ratio was applied at 20 and 30 mm 2 . Average aggregate cross-sectional
+      area of the stem where the conductive tissue was 10 mm 2 ranged from 11.3 mm 2
+      in Epacris pulchella , which had the thinnest bark, to 18.9 mm 2 in Angophora
+      costata , which had the thickest.
   - value: 25mm2 stem cross-sectional area
     description: Leaf area was determined for a shoot whose sapwood had a cross sectional
-      area of 25 mm2.
+      area of 25 mm2. In detail, while initial data were collected in terms of aggregate (or whole) stem
+      cross-sectional areas, we subsequently decided to use the conductive tissue cross-section
+      (excluding bark and pith) as a reference diameter. To determine the cross-sectional
+      area of the aggregate (or whole) stem where the cross-section of the conductive
+      tissue was 5, 10, 15, 20 and 30 mm 2 for each species, a ratio of the aggregate
+      stem cross-sectional area to the conductive stem cross-sectional area was measured
+      as follows for each species in the low-nutrient, high-rainfall site. For four
+      individuals per species, two sections of stem 20-30 mm in length, one 3-5 mm and
+      the second 6-8 mm in diameter, were randomly sampled from an actively growing
+      shoot in the upper canopy. Long and short diameters were used to calculate the
+      aggregate cross-sectional area. The stem was then dissected along the vascular
+      cambium and the cross-sectional area of the water-conductive tissue was similarly
+      calculated. Water-conductive tissue was identified as the portion of the stem
+      remaining after dissection along the vascular cambium and removal of the bark
+      (phloem, cortex and epidermis). Examining stained cross-sections of the stem under
+      a light microscope substantiated identification of water-conductive tissue. (Hereafter,
+      the term conductive tissue refers to the water-conductive tissue.) This resulted
+      in two ratios of aggregate to conductive stem cross-sectional area, one at ~10
+      mm 2 and the second at ~25 mm 2 . This was done to account for changes in the
+      proportion of conductive and non-conductive tissue along the stem. The first ratio
+      was used to calculate variables at 5, 10 and 15 mm 2 of conductive tissue, and
+      the second ratio was applied at 20 and 30 mm 2 . Average aggregate cross-sectional
+      area of the stem where the conductive tissue was 10 mm 2 ranged from 11.3 mm 2
+      in Epacris pulchella , which had the thinnest bark, to 18.9 mm 2 in Angophora
+      costata , which had the thickest.
   - value: 250mm long branch segment
     description: Leaf area was determined for a 250 mm branch segment and sapwood
-      cross-sectional area was determined where the branch was cut.
+      cross-sectional area was determined where the branch was cut. In detail, 'from Wright 2006; Leaf area and sapwood cross-sectional area were determined
+      for a 250 mm branch segment. In detail, No single best point exists to compare
+      traits such as LM/ SM, LA/SM and LA/SA when considering a set of species that
+      varies widely in canopy architecture and typical maximum height (here, approximately
+      20 cm to 85 m). We have used several approaches (Table 1). In one study, we made
+      measurements on the terminal twigs of each species, i.e. on a relatively standard
+      developmental unit (Westoby and Wright 2003). For species at Ash, GLP, Myall and
+      TRF, traits were measured at each of several different distances back down the
+      stem from the branch tip (Falster and Westoby 2005a, 2005b and unpublished, Pickup
+      et al. 2005). At GHP, RHM and RHW, traits were measured at a standard sapwood
+      cross-sectional area (10 mm2; Pickup et al. 2005). For the present re-analysis,
+      we took the raw data from the previous studies and, for every species possible,
+      calculated patterns of leaf and stem deployment at two standard points, at 250
+      mm distance from the branch tip (Ash, GLP, Myall and TRF) and at 10 mm2 stem (Ash,
+      Myall, TRF) or sapwood (GHP, GLP, RHM, RHW) crosssectional area (250 mm or 10
+      mm2 formulation denoted as subscript in trait abbreviations). This was done as
+      follows. For each individual plant, total leaf and stem dry mass at 250 mm distance
+      was estimated by straightline interpolation from values measured at the nearest
+      sampling points on either side of this distance. As the dry mass data tended to
+      display non-linear (power) relationships with distance from the branch tip, the
+      interpolated values were calculated from log10-log10- transformed data, then back-transformed
+      to the original scale. The same approach was used for interpolating data to the
+      standard stem (or sapwood) cross-sectional area. For individuals where measurements
+      had not been made on either side of the desired point but the nearest measurement
+      had been made within 25 mm of 250 mm or 1 mm2 of 10 mm2 cross-section (i.e. within
+      10% of the desired point), we extrapolated (rather than interpolated) the measured
+      data to the standard point. This allowed us to include a number of individuals
+      and species for which interpolation was not possible. Still, several large-leaved,
+      large-stemmed species from the TRF site could not be included in the 10-mm2 crosssection
+      dataset. No unusual tendencies in analyses, including the extrapolated data, were
+      seen in comparison to analyses including interpolated data only (details not shown).
+      To illustrate how species'' morphology varied at the two standard sampling points,
+      species-mean stem cross-sectional area varied between 1.2 and 258 mm2 at 250 mm
+      distance from the branch tip, while the distance from the branch tip at which
+      stem cross-sectional area reached 10 mm2 varied from 64 to 995 mm.'
   - value: 1000mm long branch segment
     description: Leaf area was determined for a 1000 mm branch segment and sapwood
-      cross-sectional area was determined where the branch was cut.
+      cross-sectional area was determined where the branch was cut. In detail, 'from Wright 2006; Leaf area and sapwood cross-sectional area were determined
+      for a 250 mm branch segment. In detail, No single best point exists to compare
+      traits such as LM/ SM, LA/SM and LA/SA when considering a set of species that
+      varies widely in canopy architecture and typical maximum height (here, approximately
+      20 cm to 85 m). We have used several approaches (Table 1). In one study, we made
+      measurements on the terminal twigs of each species, i.e. on a relatively standard
+      developmental unit (Westoby and Wright 2003). For species at Ash, GLP, Myall and
+      TRF, traits were measured at each of several different distances back down the
+      stem from the branch tip (Falster and Westoby 2005a, 2005b and unpublished, Pickup
+      et al. 2005). At GHP, RHM and RHW, traits were measured at a standard sapwood
+      cross-sectional area (10 mm2; Pickup et al. 2005). For the present re-analysis,
+      we took the raw data from the previous studies and, for every species possible,
+      calculated patterns of leaf and stem deployment at two standard points, at 250
+      mm distance from the branch tip (Ash, GLP, Myall and TRF) and at 10 mm2 stem (Ash,
+      Myall, TRF) or sapwood (GHP, GLP, RHM, RHW) crosssectional area (250 mm or 10
+      mm2 formulation denoted as subscript in trait abbreviations). This was done as
+      follows. For each individual plant, total leaf and stem dry mass at 250 mm distance
+      was estimated by straightline interpolation from values measured at the nearest
+      sampling points on either side of this distance. As the dry mass data tended to
+      display non-linear (power) relationships with distance from the branch tip, the
+      interpolated values were calculated from log10-log10- transformed data, then back-transformed
+      to the original scale. The same approach was used for interpolating data to the
+      standard stem (or sapwood) cross-sectional area. For individuals where measurements
+      had not been made on either side of the desired point but the nearest measurement
+      had been made within 25 mm of 250 mm or 1 mm2 of 10 mm2 cross-section (i.e. within
+      10% of the desired point), we extrapolated (rather than interpolated) the measured
+      data to the standard point. This allowed us to include a number of individuals
+      and species for which interpolation was not possible. Still, several large-leaved,
+      large-stemmed species from the TRF site could not be included in the 10-mm2 crosssection
+      dataset. No unusual tendencies in analyses, including the extrapolated data, were
+      seen in comparison to analyses including interpolated data only (details not shown).
+      To illustrate how species'' morphology varied at the two standard sampling points,
+      species-mean stem cross-sectional area varied between 1.2 and 258 mm2 at 250 mm
+      distance from the branch tip, while the distance from the branch tip at which
+      stem cross-sectional area reached 10 mm2 varied from 64 to 995 mm.'
 traits:
 - var_in: Stem wood density
   unit_in: mg/mm3
@@ -193,31 +309,7 @@ traits:
   basis_of_value: measurement
   replicates: 4
   method_context: 10mm2 stem cross-sectional area
-  methods: While initial data were collected in terms of aggregate (or whole) stem
-    cross-sectional areas, we subsequently decided to use the conductive tissue cross-section
-    (excluding bark and pith) as a reference diameter. To determine the cross-sectional
-    area of the aggregate (or whole) stem where the cross-section of the conductive
-    tissue was 5, 10, 15, 20 and 30 mm 2 for each species, a ratio of the aggregate
-    stem cross-sectional area to the conductive stem cross-sectional area was measured
-    as follows for each species in the low-nutrient, high-rainfall site. For four
-    individuals per species, two sections of stem 20-30 mm in length, one 3-5 mm and
-    the second 6-8 mm in diameter, were randomly sampled from an actively growing
-    shoot in the upper canopy. Long and short diameters were used to calculate the
-    aggregate cross-sectional area. The stem was then dissected along the vascular
-    cambium and the cross-sectional area of the water-conductive tissue was similarly
-    calculated. Water-conductive tissue was identified as the portion of the stem
-    remaining after dissection along the vascular cambium and removal of the bark
-    (phloem, cortex and epidermis). Examining stained cross-sections of the stem under
-    a light microscope substantiated identification of water-conductive tissue. (Hereafter,
-    the term conductive tissue refers to the water-conductive tissue.) This resulted
-    in two ratios of aggregate to conductive stem cross-sectional area, one at ~10
-    mm 2 and the second at ~25 mm 2 . This was done to account for changes in the
-    proportion of conductive and non-conductive tissue along the stem. The first ratio
-    was used to calculate variables at 5, 10 and 15 mm 2 of conductive tissue, and
-    the second ratio was applied at 20 and 30 mm 2 . Average aggregate cross-sectional
-    area of the stem where the conductive tissue was 10 mm 2 ranged from 11.3 mm 2
-    in Epacris pulchella , which had the thinnest bark, to 18.9 mm 2 in Angophora
-    costata , which had the thickest.
+  methods: Huber value calculated as the ratio of a stem's leaf area to its water conductive area, as details under method context.
 - var_in: LASA50
   unit_in: mm2_leaf/mm2_sapwood
   trait_name: huber_value
@@ -226,31 +318,7 @@ traits:
   basis_of_value: measurement
   replicates: 4
   method_context: 25mm2 stem cross-sectional area
-  methods: While initial data were collected in terms of aggregate (or whole) stem
-    cross-sectional areas, we subsequently decided to use the conductive tissue cross-section
-    (excluding bark and pith) as a reference diameter. To determine the cross-sectional
-    area of the aggregate (or whole) stem where the cross-section of the conductive
-    tissue was 5, 10, 15, 20 and 30 mm 2 for each species, a ratio of the aggregate
-    stem cross-sectional area to the conductive stem cross-sectional area was measured
-    as follows for each species in the low-nutrient, high-rainfall site. For four
-    individuals per species, two sections of stem 20-30 mm in length, one 3-5 mm and
-    the second 6-8 mm in diameter, were randomly sampled from an actively growing
-    shoot in the upper canopy. Long and short diameters were used to calculate the
-    aggregate cross-sectional area. The stem was then dissected along the vascular
-    cambium and the cross-sectional area of the water-conductive tissue was similarly
-    calculated. Water-conductive tissue was identified as the portion of the stem
-    remaining after dissection along the vascular cambium and removal of the bark
-    (phloem, cortex and epidermis). Examining stained cross-sections of the stem under
-    a light microscope substantiated identification of water-conductive tissue. (Hereafter,
-    the term conductive tissue refers to the water-conductive tissue.) This resulted
-    in two ratios of aggregate to conductive stem cross-sectional area, one at ~10
-    mm 2 and the second at ~25 mm 2 . This was done to account for changes in the
-    proportion of conductive and non-conductive tissue along the stem. The first ratio
-    was used to calculate variables at 5, 10 and 15 mm 2 of conductive tissue, and
-    the second ratio was applied at 20 and 30 mm 2 . Average aggregate cross-sectional
-    area of the stem where the conductive tissue was 10 mm 2 ranged from 11.3 mm 2
-    in Epacris pulchella , which had the thinnest bark, to 18.9 mm 2 in Angophora
-    costata , which had the thickest.
+  methods: Huber value calculated as the ratio of a stem's leaf area to its water conductive area, as details under method context.
 - var_in: LASA250
   unit_in: mm2_leaf/mm2_sapwood
   trait_name: huber_value
@@ -259,41 +327,7 @@ traits:
   basis_of_value: measurement
   replicates: 4
   method_context: 250mm long branch segment
-  methods: 'from Wright 2006; Leaf area and sapwood cross-sectional area were determined
-    for a 250 mm branch segment. In detail, No single best point exists to compare
-    traits such as LM/ SM, LA/SM and LA/SA when considering a set of species that
-    varies widely in canopy architecture and typical maximum height (here, approximately
-    20 cm to 85 m). We have used several approaches (Table 1). In one study, we made
-    measurements on the terminal twigs of each species, i.e. on a relatively standard
-    developmental unit (Westoby and Wright 2003). For species at Ash, GLP, Myall and
-    TRF, traits were measured at each of several different distances back down the
-    stem from the branch tip (Falster and Westoby 2005a, 2005b and unpublished, Pickup
-    et al. 2005). At GHP, RHM and RHW, traits were measured at a standard sapwood
-    cross-sectional area (10 mm2; Pickup et al. 2005). For the present re-analysis,
-    we took the raw data from the previous studies and, for every species possible,
-    calculated patterns of leaf and stem deployment at two standard points: at 250
-    mm distance from the branch tip (Ash, GLP, Myall and TRF) and at 10 mm2 stem (Ash,
-    Myall, TRF) or sapwood (GHP, GLP, RHM, RHW) crosssectional area (250 mm or 10
-    mm2 formulation denoted as subscript in trait abbreviations). This was done as
-    follows. For each individual plant, total leaf and stem dry mass at 250 mm distance
-    was estimated by straightline interpolation from values measured at the nearest
-    sampling points on either side of this distance. As the dry mass data tended to
-    display non-linear (power) relationships with distance from the branch tip, the
-    interpolated values were calculated from log10-log10- transformed data, then back-transformed
-    to the original scale. The same approach was used for interpolating data to the
-    standard stem (or sapwood) cross-sectional area. For individuals where measurements
-    had not been made on either side of the desired point but the nearest measurement
-    had been made within 25 mm of 250 mm or 1 mm2 of 10 mm2 cross-section (i.e. within
-    10% of the desired point), we extrapolated (rather than interpolated) the measured
-    data to the standard point. This allowed us to include a number of individuals
-    and species for which interpolation was not possible. Still, several large-leaved,
-    large-stemmed species from the TRF site could not be included in the 10-mm2 crosssection
-    dataset. No unusual tendencies in analyses, including the extrapolated data, were
-    seen in comparison to analyses including interpolated data only (details not shown).
-    To illustrate how species'' morphology varied at the two standard sampling points,
-    species-mean stem cross-sectional area varied between 1.2 and 258 mm2 at 250 mm
-    distance from the branch tip, while the distance from the branch tip at which
-    stem cross-sectional area reached 10 mm2 varied from 64 to 995 mm.'
+  methods: Huber value calculated as the ratio of a stem's leaf area to its water conductive area, as details under method context.
 - var_in: LASA1000
   unit_in: mm2_leaf/mm2_sapwood
   trait_name: huber_value
@@ -302,41 +336,7 @@ traits:
   basis_of_value: measurement
   replicates: 4
   method_context: 1000mm long branch segment
-  methods: 'from Wright 2006; Leaf area and sapwood cross-sectional area were determined
-    for a 250 mm branch segment. In detail, No single best point exists to compare
-    traits such as LM/ SM, LA/SM and LA/SA when considering a set of species that
-    varies widely in canopy architecture and typical maximum height (here, approximately
-    20 cm to 85 m). We have used several approaches (Table 1). In one study, we made
-    measurements on the terminal twigs of each species, i.e. on a relatively standard
-    developmental unit (Westoby and Wright 2003). For species at Ash, GLP, Myall and
-    TRF, traits were measured at each of several different distances back down the
-    stem from the branch tip (Falster and Westoby 2005a, 2005b and unpublished, Pickup
-    et al. 2005). At GHP, RHM and RHW, traits were measured at a standard sapwood
-    cross-sectional area (10 mm2; Pickup et al. 2005). For the present re-analysis,
-    we took the raw data from the previous studies and, for every species possible,
-    calculated patterns of leaf and stem deployment at two standard points: at 250
-    mm distance from the branch tip (Ash, GLP, Myall and TRF) and at 10 mm2 stem (Ash,
-    Myall, TRF) or sapwood (GHP, GLP, RHM, RHW) crosssectional area (250 mm or 10
-    mm2 formulation denoted as subscript in trait abbreviations). This was done as
-    follows. For each individual plant, total leaf and stem dry mass at 250 mm distance
-    was estimated by straightline interpolation from values measured at the nearest
-    sampling points on either side of this distance. As the dry mass data tended to
-    display non-linear (power) relationships with distance from the branch tip, the
-    interpolated values were calculated from log10-log10- transformed data, then back-transformed
-    to the original scale. The same approach was used for interpolating data to the
-    standard stem (or sapwood) cross-sectional area. For individuals where measurements
-    had not been made on either side of the desired point but the nearest measurement
-    had been made within 25 mm of 250 mm or 1 mm2 of 10 mm2 cross-section (i.e. within
-    10% of the desired point), we extrapolated (rather than interpolated) the measured
-    data to the standard point. This allowed us to include a number of individuals
-    and species for which interpolation was not possible. Still, several large-leaved,
-    large-stemmed species from the TRF site could not be included in the 10-mm2 crosssection
-    dataset. No unusual tendencies in analyses, including the extrapolated data, were
-    seen in comparison to analyses including interpolated data only (details not shown).
-    To illustrate how species'' morphology varied at the two standard sampling points,
-    species-mean stem cross-sectional area varied between 1.2 and 258 mm2 at 250 mm
-    distance from the branch tip, while the distance from the branch tip at which
-    stem cross-sectional area reached 10 mm2 varied from 64 to 995 mm.'
+  methods: Huber value calculated as the ratio of a stem's leaf area to its water conductive area, as details under method context.
 substitutions: .na
 taxonomic_updates:
 - find: Olearia pimelioides

--- a/data/RBGV_2022/metadata.yml
+++ b/data/RBGV_2022/metadata.yml
@@ -573,5 +573,8 @@ taxonomic_updates:
   reason: match_14. Automatic alignment with species-level canonical name in APC accepted
     when notes are ignored (2022-11-22)
   taxonomic_resolution: Species
-exclude_observations: .na
+exclude_observations:
+- variable: taxon_name
+  find: Cyrtomium falcatum 'Rochfordii', Dicentra formosa subsp. formosa 'Alba', Dodonaea viscosa 'Purpurea', Grevillea 'Poorinda Constance', Salix matsudana 'Tortuosa'
+  reason: excluding cultivars
 questions: .na

--- a/data/Richards_2008/metadata.yml
+++ b/data/Richards_2008/metadata.yml
@@ -230,7 +230,10 @@ dataset:
   custom_R_code: '
     data %>%
       group_by(name_original) %>%
-        mutate(across(c(`GF`, `LfForm`,`LfType`,`DecEv`,`Nfixer`,`photosynthetic pathway`), replace_duplicates_with_NA)) %>%
+        mutate(
+          across(c(`GF`, `LfForm`,`LfType`,`DecEv`,`Nfixer`,`photosynthetic pathway`), replace_duplicates_with_NA),
+          `SLA (cm2/g)` = ifelse(!is.na(`LMA (g/m2)`), 1/(`LMA (g/m2)`*10000), `SLA (cm2/g)`)
+        ) %>%
       ungroup()
   '
   collection_date: unknown/2009
@@ -854,18 +857,7 @@ traits:
   value_type: mean
   basis_of_value: measurement
   replicates: unknown
-  methods: From Leigh_2003, Leigh_2006, Leunig_1991, Richards_2008_2 (unpublished),
-    and Schortemeyer_0000; See original references, listed alphabetically under 'additional
-    references'
-- var_in: LMA (g/m2)
-  unit_in: g/m2
-  trait_name: leaf_mass_per_area
-  entity_type: population
-  value_type: mean
-  basis_of_value: measurement
-  replicates: unknown
-  methods: From Pearcy 1987; See original references, listed alphabetically under
-    'additional references'
+  methods: unknown
 - var_in: leaf longevity
   unit_in: month
   trait_name: leaf_lifespan

--- a/data/Sams_2017/metadata.yml
+++ b/data/Sams_2017/metadata.yml
@@ -182,7 +182,15 @@ locations:
     longitude (deg): 145.739885
     description: dry upland tropical rain forest
     notes: site values only apply to SLA data; other data sourced from the literature
-contexts: .na
+contexts:
+- context_property: entity type
+  category: method
+  var_in: method_context
+  values:
+  - value: multi-site means
+    description: These samples were colelcted at multiple sites, but they are assigned to the lat/lon of a single site; the data.csv file records the names of the multiple sites.
+  - value: population means
+    description: These samples were colelcted a single site.
 traits:
 - var_in: plant_height_unique
   unit_in: m
@@ -223,10 +231,11 @@ traits:
   value_type: mean
   basis_of_value: measurement
   replicates: individual.n
+  method_context: population means
   methods: SLA for most species were measured by Hoa Ran Lai from leaves collected
     by Michael Sams. Mean surface leaf area based on measurements of LLA and LM by
     Hao Ran Lai; samples vary per species. For species we could not obtain leaves
-    from we obtained species mean SLA from Metcalfe or Wells Trait database
+    from we obtained species mean SLA from Metcalfe or Wells Trait database.
 - var_in: sla.mean.multisite
   unit_in: mm2/mg
   trait_name: leaf_mass_per_area
@@ -234,11 +243,11 @@ traits:
   value_type: mean
   basis_of_value: measurement
   replicates: individual.n
+  method_context: multi-site means
   methods: SLA for most species were measured by Hoa Ran Lai from leaves collected
     by Michael Sams. Mean surface leaf area based on measurements of LLA and LM by
-    Hao Ran Lai; samples vary per species. These samples were colelcted at multiple
-    sites, but they are assigned to the lat/lon of a single site; the data.csv file
-    records the names of the multiple sites.
+    Hao Ran Lai; samples vary per species. For species we could not obtain leaves
+    from we obtained species mean SLA from Metcalfe or Wells Trait database.
 - var_in: seed_length_min_unique
   unit_in: mm
   trait_name: seed_length

--- a/data/Wenk_2022/metadata.yml
+++ b/data/Wenk_2022/metadata.yml
@@ -1744,5 +1744,11 @@ taxonomic_updates:
   reason: match_10_fuzzy. Imprecise fuzzy alignment with accepted canonical name in
     APC (2022-11-23)
   taxonomic_resolution: Species
-exclude_observations: .na
+exclude_observations:
+- variable: taxon_name
+  find: Cyrtomium falcatum 'Rochfordii', Dicentra formosa subsp. formosa 'Alba', Dodonaea viscosa 'Purpurea', Echinochloa polystachya 'Amity', Salix matsudana 'Tortuosa', Megathyrsus maximus var. maximus 'Hamil', Hymenachne amplexicaulis 'Olive', Grevillea 'Poorinda Constance', 	Platanus x hispanica 'Acerifolia'
+  reason: excluding cultivars
+- variable: taxon_name
+  find: Salix x sepulcralis nothovar. chrysocoma, Salix x sepulcralis nothovar. sepulcralis, Salix x fragilis nothovar. furcata, Salix x fragilis nothovar. fragilis
+  reason: excluding nothovarietas
 questions: .na

--- a/data/White_2020/metadata.yml
+++ b/data/White_2020/metadata.yml
@@ -5016,6 +5016,14 @@ taxonomic_updates:
   reason: match_06. Automatic alignment with synonymous term among known canonical
     names APC (2022-11-23)
   taxonomic_resolution: Species
+- find: Persoonia spp.
+  replace: Persoonia sp. [White_2020]
+  reason: Manual alignment to correct genus syntax (Elizabeth Wenk, 2022-11-30)
+  taxonomic_resolution: Genus
+- find: Callitris spp.
+  replace: Callitris sp. [White_2020]
+  reason: Manual alignment to correct genus syntax (Elizabeth Wenk, 2022-11-30)
+  taxonomic_resolution: Genus
 exclude_observations:
 - variable: taxon_name
   find: Dead tree, 'dead Acacia' stenophylla, 'dead Eucalyptus' camaldulensis var.

--- a/data/Wright_2006/metadata.yml
+++ b/data/Wright_2006/metadata.yml
@@ -84,7 +84,7 @@ contexts:
     description: Leaf area was determined for a shoot whose sapwood had a cross sectional
       area of 10 mm2.
   - value: 250mm long branch segment
-    description: Leaf area was determined for a 250 mm branch segment and sapwood cross-sectional area was determined where the branch was cut. In detail, WD was measured at 250-mm distance by Falster and Westoby. Pickup et al. measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could also be interpolated to 250 mm distance for species at the GLP site. WD was measured on stem segments 40-70 mm in length, following standard methods (Pickup et al. 2005).]
+    description: Leaf area was determined for a 250 mm branch segment and sapwood cross-sectional area was determined where the branch was cut.
   - value: 1000mm long branch segment
     description: Leaf area was determined for a 1000 mm branch segment and sapwood
       cross-sectional area was determined where the branch was cut.
@@ -97,7 +97,11 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 250mm long branch segment
-  methods: Wood density was measured following standard methods.
+  methods: WD was measured at 250-mm distance by Falster and Westoby. Pickup et al.
+    measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could
+    also be interpolated to 250 mm distance for species at the GLP site. WD was measured
+    on stem segments 40-70 mm in length, following standard methods (Pickup et al.
+    2005).
 - var_in: wd_1000
   unit_in: mg/mm3
   trait_name: wood_density
@@ -106,7 +110,8 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 1000mm long branch segment
-  methods: Wood density was measured following standard methods.
+  methods: These wood density values would have been measured on segments 1000 mm
+    in length, following standard methods.
 - var_in: leaf size
   unit_in: mm2
   trait_name: leaf_area

--- a/data/Wright_2006/metadata.yml
+++ b/data/Wright_2006/metadata.yml
@@ -84,7 +84,7 @@ contexts:
     description: Leaf area was determined for a shoot whose sapwood had a cross sectional
       area of 10 mm2.
   - value: 250mm long branch segment
-    description: Leaf area was determined for a 250 mm branch segment and sapwood cross-sectional area was determined where the branch was cut.
+    description: Leaf area was determined for a 250 mm branch segment and sapwood cross-sectional area was determined where the branch was cut. In detail, WD was measured at 250-mm distance by Falster and Westoby. Pickup et al. measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could also be interpolated to 250 mm distance for species at the GLP site. WD was measured on stem segments 40-70 mm in length, following standard methods (Pickup et al. 2005).]
   - value: 1000mm long branch segment
     description: Leaf area was determined for a 1000 mm branch segment and sapwood
       cross-sectional area was determined where the branch was cut.
@@ -97,11 +97,7 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 250mm long branch segment
-  methods: WD was measured at 250-mm distance by Falster and Westoby. Pickup et al.
-    measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could
-    also be interpolated to 250 mm distance for species at the GLP site. WD was measured
-    on stem segments 40-70 mm in length, following standard methods (Pickup et al.
-    2005).
+  methods: Wood density was measured following standard methods.
 - var_in: wd_1000
   unit_in: mg/mm3
   trait_name: wood_density
@@ -110,8 +106,7 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 1000mm long branch segment
-  methods: These wood density values would have been measured on segments 1000 mm
-    in length, following standard methods.
+  methods: Wood density was measured following standard methods.
 - var_in: leaf size
   unit_in: mm2
   trait_name: leaf_area

--- a/data/Wright_2006/metadata.yml
+++ b/data/Wright_2006/metadata.yml
@@ -84,8 +84,7 @@ contexts:
     description: Leaf area was determined for a shoot whose sapwood had a cross sectional
       area of 10 mm2.
   - value: 250mm long branch segment
-    description: Leaf area was determined for a 250 mm branch segment and sapwood
-      cross-sectional area was determined where the branch was cut.
+    description: Leaf area was determined for a 250 mm branch segment and sapwood cross-sectional area was determined where the branch was cut. In detail, WD was measured at 250-mm distance by Falster and Westoby. Pickup et al. measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could also be interpolated to 250 mm distance for species at the GLP site. WD was measured on stem segments 40-70 mm in length, following standard methods (Pickup et al. 2005).]
   - value: 1000mm long branch segment
     description: Leaf area was determined for a 1000 mm branch segment and sapwood
       cross-sectional area was determined where the branch was cut.
@@ -98,11 +97,7 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 250mm long branch segment
-  methods: WD was measured at 250-mm distance by Falster and Westoby. Pickup et al.
-    measured WD at 10 mm2 sapwood crosssectional area for all species, but WD could
-    also be interpolated to 250 mm distance for species at the GLP site. WD was measured
-    on stem segments 40-70 mm in length, following standard methods (Pickup et al.
-    2005).
+  methods: Wood density was measured following standard methods.
 - var_in: wd_1000
   unit_in: mg/mm3
   trait_name: wood_density
@@ -111,8 +106,7 @@ traits:
   basis_of_value: measurement
   replicates: unknown
   method_context: 1000mm long branch segment
-  methods: These wood density values would have been measured on segments 1000 mm
-    in length, following standard methods.
+  methods: Wood density was measured following standard methods.
 - var_in: leaf size
   unit_in: mm2
   trait_name: leaf_area

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -113,12 +113,18 @@ contexts:
   category: method
   var_in: method_context
   values:
-  - find: leaf morphology sample
-    value: leaf morphology sample
-    description: Leaf samples collected for leaf morphology measurements.
-  - find: gas exchange sample
-    value: gas exchange sample
-    description: Leaf samples collected for gas exchange measurements.
+  - value: leaf morphology sample
+    description: Measurements made on leaf samples collected for leaf morphology measurements. Five recently-matured, fully-expanded and undamaged leaves (including petioles) were collected from each individual
+  - value: gas exchange sample
+    description: Measurements made on leaf samples collected for gas exchange measurements.
+- context_property: nitrogen sample type
+  category: method
+  var_in: method_context2
+  values:
+  - value: Leaf N associated with isotope samples
+    description: Leaf lamina material used in photosynthetic measurements was oven-dried and pooled per species/age class, then analysed for 13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory, Australian National University, Canberra.
+  - value: Leaf N analysed with a LECO TruSpec CHN analyser
+    description: Total N concentration of leaf and soil samples was measured with a LECO TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations were calculated from mass-based concentrations and the mean SLA value for each species/age class.
 traits:
 - var_in: WD kg/m3
   unit_in: kg/m3
@@ -144,10 +150,9 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: leaf morphology sample
-  methods: Five recently-matured, fully-expanded and undamaged leaves (including petioles)
-    were collected from each individual for determination of one-sided projected leaf
-    area (flatbed scanner), oven-dried mass (70 deg C for at least 48 h) and thus
-    SLA (area per dry mass; cm2 g-1).
+  methods: One-sided projected leaf area was determined (flatbed scanner),
+    oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
+    cm2 g-1).
 - var_in: C%
   unit_in: '%'
   trait_name: leaf_C_per_dry_mass
@@ -167,11 +172,8 @@ traits:
   value_type: raw
   basis_of_value: measurement
   replicates: 1
-  methods: Total N concentration of leaf and soil samples was measured with a LECO
-    TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run
-    at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations
-    were calculated from mass-based concentrations and the mean SLA value for each
-    species/age class.
+  method_context2: Leaf N analysed with a LECO TruSpec CHN analyser
+  methods: Area-based leaf N calculated from mass-based concentrations.
 - var_in: P%
   unit_in: '%'
   trait_name: leaf_P_per_dry_mass
@@ -414,8 +416,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: gas exchange sample
-  methods: Specific leaf area (SLA) measurements made on the leaves on which photosynthesis
-    was measured. One-sided projected leaf area was determined (flatbed scanner),
+  methods: One-sided projected leaf area was determined (flatbed scanner),
     oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
     cm2 g-1).
 - var_in: Al
@@ -551,13 +552,8 @@ traits:
   value_type: raw
   basis_of_value: measurement
   replicates: 1
-  methods: Leaf N associated with isotope samples. Leaf lamina material used in photosynthetic
-    measurements was oven-dried and pooled per species/age class, then analysed for
-    13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory,
-    Australian National University, Canberra. The d13C provides an integrated measure
-    of the extent of CO2 drawdown during photosynthesis (Farquhar et al. 1982). We
-    also measured d13C on representative whole-leaf (including petiole) samples collected
-    during September 2010 (dry season).
+  method_context2: Leaf N associated with isotope samples
+  methods: Area-based leaf N calculated from mass-based concentrations.
 - var_in: d15N_bark
   unit_in: per mille
   trait_name: bark_delta15N

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -114,7 +114,7 @@ contexts:
   var_in: method_context
   values:
   - value: leaf morphology sample
-    description: Measurements made on leaf samples collected for leaf morphology measurements.
+    description: Measurements made on leaf samples collected for leaf morphology measurements. Five recently-matured, fully-expanded and undamaged leaves (including petioles) were collected from each individual
   - value: gas exchange sample
     description: Measurements made on leaf samples collected for gas exchange measurements.
 - context_property: nitrogen sample type
@@ -122,9 +122,9 @@ contexts:
   var_in: method_context2
   values:
   - value: Leaf N associated with isotope samples
-    description: Measurements of leaf N were made in conjunction with leaf N stable isotope analysis.
+    description: Leaf lamina material used in photosynthetic measurements was oven-dried and pooled per species/age class, then analysed for 13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory, Australian National University, Canberra.
   - value: Leaf N analysed with a LECO TruSpec CHN analyser
-    description: Measurements of leaf N were made in conjunction with leaf nutrient analysis.
+    description: Total N concentration of leaf and soil samples was measured with a LECO TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations were calculated from mass-based concentrations and the mean SLA value for each species/age class.
 traits:
 - var_in: WD kg/m3
   unit_in: kg/m3
@@ -150,10 +150,9 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: leaf morphology sample
-  methods: Five recently-matured, fully-expanded and undamaged leaves (including petioles)
-    were collected from each individual for determination of one-sided projected leaf
-    area (flatbed scanner), oven-dried mass (70 deg C for at least 48 h) and thus
-    SLA (area per dry mass; cm2 g-1).
+  methods: One-sided projected leaf area was determined (flatbed scanner),
+    oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
+    cm2 g-1).
 - var_in: C%
   unit_in: '%'
   trait_name: leaf_C_per_dry_mass
@@ -174,11 +173,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context2: Leaf N analysed with a LECO TruSpec CHN analyser
-  methods: Total N concentration of leaf and soil samples was measured with a LECO
-    TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run
-    at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations
-    were calculated from mass-based concentrations and the mean SLA value for each
-    species/age class.
+  methods: Area-based leaf N calculated from mass-based concentrations.
 - var_in: P%
   unit_in: '%'
   trait_name: leaf_P_per_dry_mass
@@ -421,8 +416,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: gas exchange sample
-  methods: Specific leaf area (SLA) measurements made on the leaves on which photosynthesis
-    was measured. One-sided projected leaf area was determined (flatbed scanner),
+  methods: One-sided projected leaf area was determined (flatbed scanner),
     oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
     cm2 g-1).
 - var_in: Al
@@ -559,13 +553,7 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context2: Leaf N associated with isotope samples
-  methods: Leaf N associated with isotope samples. Leaf lamina material used in photosynthetic
-    measurements was oven-dried and pooled per species/age class, then analysed for
-    13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory,
-    Australian National University, Canberra. The d13C provides an integrated measure
-    of the extent of CO2 drawdown during photosynthesis (Farquhar et al. 1982). We
-    also measured d13C on representative whole-leaf (including petiole) samples collected
-    during September 2010 (dry season).
+  methods: Area-based leaf N calculated from mass-based concentrations.
 - var_in: d15N_bark
   unit_in: per mille
   trait_name: bark_delta15N

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -114,7 +114,7 @@ contexts:
   var_in: method_context
   values:
   - value: leaf morphology sample
-    description: Measurements made on leaf samples collected for leaf morphology measurements. Five recently-matured, fully-expanded and undamaged leaves (including petioles) were collected from each individual
+    description: Measurements made on leaf samples collected for leaf morphology measurements.
   - value: gas exchange sample
     description: Measurements made on leaf samples collected for gas exchange measurements.
 - context_property: nitrogen sample type
@@ -122,9 +122,9 @@ contexts:
   var_in: method_context2
   values:
   - value: Leaf N associated with isotope samples
-    description: Leaf lamina material used in photosynthetic measurements was oven-dried and pooled per species/age class, then analysed for 13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory, Australian National University, Canberra.
+    description: Measurements of leaf N were made in conjunction with leaf N stable isotope analysis.
   - value: Leaf N analysed with a LECO TruSpec CHN analyser
-    description: Total N concentration of leaf and soil samples was measured with a LECO TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations were calculated from mass-based concentrations and the mean SLA value for each species/age class.
+    description: Measurements of leaf N were made in conjunction with leaf nutrient analysis.
 traits:
 - var_in: WD kg/m3
   unit_in: kg/m3
@@ -150,9 +150,10 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: leaf morphology sample
-  methods: One-sided projected leaf area was determined (flatbed scanner),
-    oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
-    cm2 g-1).
+  methods: Five recently-matured, fully-expanded and undamaged leaves (including petioles)
+    were collected from each individual for determination of one-sided projected leaf
+    area (flatbed scanner), oven-dried mass (70 deg C for at least 48 h) and thus
+    SLA (area per dry mass; cm2 g-1).
 - var_in: C%
   unit_in: '%'
   trait_name: leaf_C_per_dry_mass
@@ -173,7 +174,11 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context2: Leaf N analysed with a LECO TruSpec CHN analyser
-  methods: Area-based leaf N calculated from mass-based concentrations.
+  methods: Total N concentration of leaf and soil samples was measured with a LECO
+    TruSpec CHN analyser; total P by ICP-OES, on nitric acid digests (analyses run
+    at Appleton Lab, University of Queensland). Area-based leaf N and P concentrations
+    were calculated from mass-based concentrations and the mean SLA value for each
+    species/age class.
 - var_in: P%
   unit_in: '%'
   trait_name: leaf_P_per_dry_mass
@@ -416,7 +421,8 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context: gas exchange sample
-  methods: One-sided projected leaf area was determined (flatbed scanner),
+  methods: Specific leaf area (SLA) measurements made on the leaves on which photosynthesis
+    was measured. One-sided projected leaf area was determined (flatbed scanner),
     oven-dried mass (70 deg C for at least 48 h) and thus SLA (area per dry mass;
     cm2 g-1).
 - var_in: Al
@@ -553,7 +559,13 @@ traits:
   basis_of_value: measurement
   replicates: 1
   method_context2: Leaf N associated with isotope samples
-  methods: Area-based leaf N calculated from mass-based concentrations.
+  methods: Leaf N associated with isotope samples. Leaf lamina material used in photosynthetic
+    measurements was oven-dried and pooled per species/age class, then analysed for
+    13C/12C and 15N/14N stable isotope composition at the Stable Isotopes Laboratory,
+    Australian National University, Canberra. The d13C provides an integrated measure
+    of the extent of CO2 drawdown during photosynthesis (Farquhar et al. 1982). We
+    also measured d13C on representative whole-leaf (including petiole) samples collected
+    during September 2010 (dry season).
 - var_in: d15N_bark
   unit_in: per mille
   trait_name: bark_delta15N

--- a/inst/support/austraits.build_schema.yml
+++ b/inst/support/austraits.build_schema.yml
@@ -106,7 +106,6 @@ austraits:
       elements:
         dataset_id: *dataset_id
         trait_name: *trait_name
-        method_id: *method_id
         methods: &methods A textual description of the methods used to collect the trait data. Whenever available, methods are taken near-verbatim from the referenced source. Methods can include descriptions such as 'measured on botanical collections', 'data from the literature', or a detailed description of the field or lab methods used to collect the data.
         description: &description A 1-2 sentence description of the purpose of the study.
         sampling_strategy: &sampling_strategy A written description of how study locations were selected and how study individuals were selected. When available, this information is lifted verbatim from a published manuscript. For preserved specimens, this field ideally indicates which records were 'sampled' to measure a specific trait.

--- a/inst/support/austraits.build_schema.yml
+++ b/inst/support/austraits.build_schema.yml
@@ -106,6 +106,7 @@ austraits:
       elements:
         dataset_id: *dataset_id
         trait_name: *trait_name
+        method_id: *method_id
         methods: &methods A textual description of the methods used to collect the trait data. Whenever available, methods are taken near-verbatim from the referenced source. Methods can include descriptions such as 'measured on botanical collections', 'data from the literature', or a detailed description of the field or lab methods used to collect the data.
         description: &description A 1-2 sentence description of the purpose of the study.
         sampling_strategy: &sampling_strategy A written description of how study locations were selected and how study individuals were selected. When available, this information is lifted verbatim from a published manuscript. For preserved specimens, this field ideally indicates which records were 'sampled' to measure a specific trait.


### PR DESCRIPTION
Fixes to 3 separate issues that created duplicate rows in AusTraits

- Edits to metadata files to eliminate duplicate methods for a single trait
- Manually remove 18 duplicate taxon_names from taxon_list.csv (unsure what part of the old taxonomy.R workflow caused these, but will work out when we reinstate that in AusFlora)
- Small tweaks to process.R to eliminate taxon_name duplicates that were created when the currently accepted taxon_name was a different rank to a synonym, isonym, etc.