### PR TITLE
Update syntax to dplyr 1.1.0

### DIFF
--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -59,7 +59,7 @@ dataset:
                 count = n()) %>%
       mutate(
         value_type_column = ifelse(count == 1,"raw","mean"),
-        across(where(is.character), ~na_if(.x, "NaN"))
+        across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~na_if(.x, "NaN"))
       ) %>%
       ungroup()
   '

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -59,6 +59,7 @@ dataset:
                 count = n()) %>%
       mutate(
         value_type_column = ifelse(count == 1,"raw","mean"),
+        across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~as.character(.x)),
         across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~na_if(.x, "NaN"))
       ) %>%
       ungroup()

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -51,10 +51,11 @@ dataset:
         Replicate = stringr::str_replace(Replicate,"-B1",""),
         Replicate = stringr::str_replace(Replicate,"-B2",""),
         Replicate = stringr::str_replace(Replicate,"-B3",""),
+        across(where(is.character), ~na_if(., "NaN"))
       ) %>% 
-      select(-Tree.id, -replicate_original, - Branch) %>% 
+      select(-Tree.id, -replicate_original, - Branch) %>%
       group_by(context, Site, Visit, Replicate, Species, Family, Genus, PFT) %>%
-      summarise(across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~mean(.x) %>% na_if("NaN"), na.rm = TRUE),
+      summarise(across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~mean(.x, na.rm = TRUE)),
                 across(Date, first),
                 count = n()) %>%
       mutate(value_type_column = ifelse(count == 1,"raw","mean")) %>%

--- a/data/Bloomfield_2018/metadata.yml
+++ b/data/Bloomfield_2018/metadata.yml
@@ -32,8 +32,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate_at(vars(`Rdark.a`), ~ na_if(., 0)) %>% 
       mutate(
+        across(`Rdark.a`, ~na_if(.x, 0)),
         Date = Date %>% dmy(), 
         context = ifelse(Site %in% c("Calperum mallee", "Great Western Woodlands", "Alice Mulga") & 
                           Visit == "Summer", "Summer_unfavourable", Visit),
@@ -50,15 +50,17 @@ dataset:
         Replicate = stringr::str_replace(Replicate,"-H-","-"),
         Replicate = stringr::str_replace(Replicate,"-B1",""),
         Replicate = stringr::str_replace(Replicate,"-B2",""),
-        Replicate = stringr::str_replace(Replicate,"-B3",""),
-        across(where(is.character), ~na_if(., "NaN"))
+        Replicate = stringr::str_replace(Replicate,"-B3","")
       ) %>% 
       select(-Tree.id, -replicate_original, - Branch) %>%
       group_by(context, Site, Visit, Replicate, Species, Family, Genus, PFT) %>%
       summarise(across(c(`A400.a_with_Weerasinghe_2014`:`wue1500`), ~mean(.x, na.rm = TRUE)),
                 across(Date, first),
                 count = n()) %>%
-      mutate(value_type_column = ifelse(count == 1,"raw","mean")) %>%
+      mutate(
+        value_type_column = ifelse(count == 1,"raw","mean"),
+        across(where(is.character), ~na_if(.x, "NaN"))
+      ) %>%
       ungroup()
   '
   collection_date: Date

--- a/data/Brock_1993/metadata.yml
+++ b/data/Brock_1993/metadata.yml
@@ -29,7 +29,7 @@ dataset:
         `leaf type`= ifelse(`leaf type` %in% c("articles", "palmate", "palm", "leafless"), NA, `leaf type`),
         leaf_lobation = ifelse(`leaf shape` == "lobed","lobed",NA),
         across(c("leaf length max (cm)", "leaf length min (cm)",
-                      "leaf width max (cm)", "leaf width min (cm)"), ~na_if(.,0)) 
+                      "leaf width max (cm)", "leaf width min (cm)"), ~na_if(.x,0)) 
       )
   '
   collection_date: unknown/1993

--- a/data/Buckton_2019/metadata.yml
+++ b/data/Buckton_2019/metadata.yml
@@ -35,11 +35,11 @@ dataset:
         collection_date = ifelse(is.na(collection_date),"2014/2014", collection_date)
       ) %>%
       group_by(Tree) %>%
-        mutate_at(vars(`Density`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`Density`), replace_duplicates_with_NA)) %>%
         mutate(observation_num = row_number()) %>%
       ungroup() %>%
       group_by(Species_name) %>%
-        mutate_at(vars(`Growth.Form`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`Growth.Form`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: collection_date

--- a/data/Burrows_2001/metadata.yml
+++ b/data/Burrows_2001/metadata.yml
@@ -23,7 +23,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(where(is.character), ~na_if(., ".na"))) %>%
+      mutate(across(where(is.character), ~na_if(.x, ".na"))) %>%
       group_by("Genus_species","SITE_text") %>%
         mutate(across(c(leaf_type,leaf_shape), replace_duplicates_with_NA)) %>%
       ungroup() %>%

--- a/data/Burrows_2001/metadata.yml
+++ b/data/Burrows_2001/metadata.yml
@@ -23,7 +23,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      na_if(".na") %>%
+      mutate(across(where(is.character), ~na_if(., ".na"))) %>%
       group_by("Genus_species","SITE_text") %>%
         mutate(across(c(leaf_type,leaf_shape), replace_duplicates_with_NA)) %>%
       ungroup() %>%

--- a/data/Burrows_2001/metadata.yml
+++ b/data/Burrows_2001/metadata.yml
@@ -23,7 +23,10 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(everything(), ~na_if(.x, ".na"))) %>%
+      mutate(
+        across(everything(), ~as.character(.x)),
+        across(everything(), ~na_if(.x, ".na"))
+      ) %>%
       group_by("Genus_species","SITE_text") %>%
         mutate(across(c(leaf_type,leaf_shape), replace_duplicates_with_NA)) %>%
       ungroup() %>%

--- a/data/Burrows_2001/metadata.yml
+++ b/data/Burrows_2001/metadata.yml
@@ -23,7 +23,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(where(is.character), ~na_if(.x, ".na"))) %>%
+      mutate(across(everything(), ~na_if(.x, ".na"))) %>%
       group_by("Genus_species","SITE_text") %>%
         mutate(across(c(leaf_type,leaf_shape), replace_duplicates_with_NA)) %>%
       ungroup() %>%

--- a/data/Catford_2014/metadata.yml
+++ b/data/Catford_2014/metadata.yml
@@ -36,8 +36,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      data %>% mutate(Taxa = str_replace(Taxa,"Austrodanthonia","Rytidosperma"))
     %>% mutate(site_name = "Yarrawonga") %>% mutate(str_replace(Taxa,"Austrodanthonia","Rytidosperma"))
-    %>% mutate_at(c("Plant height max (m)","plant height min (m)","Leaf size (cm^2)"),
-    ~na_if(.,0)) %>% replace_na(list(Tree = 0, Gram = 0, Forb=0, Annual=0, Biennial=0,
+    %>% mutate(across(c("Plant height max (m)","plant height min (m)","Leaf size (cm^2)"),
+    ~na_if(.x,0))) %>% replace_na(list(Tree = 0, Gram = 0, Forb=0, Annual=0, Biennial=0,
     Perennial=0, rhizomes=0,stolons=0,`prostrate/decumbent`=0, Terrestrial=0, Tda=0,
     Tdr=0, Amphibious=0, Dispersal="", `dispersal 2`="", `dispersal 3`="")) %>% mutate(
     Tree = ifelse(Tree, "tree", ""), Gram = ifelse(Gram, "graminoid", ""), Forb =

--- a/data/Cernusak_2006/metadata.yml
+++ b/data/Cernusak_2006/metadata.yml
@@ -30,7 +30,7 @@ dataset:
         date = date %>% mdy()
       ) %>%  
       group_by(species) %>% 
-        mutate_at(vars(`specific leaf area (m2 kg-1)`), replace_duplicates_with_NA) %>% 
+        mutate(across(c(`specific leaf area (m2 kg-1)`), replace_duplicates_with_NA)) %>% 
       ungroup() %>%
       group_by(species, Tree, site_name, `burn_status`, `sampling_period`) %>%
         mutate(observation_number = row_number()) %>%

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -23,10 +23,12 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate(Date = Date %>% dmy()) %>% mutate_at(c("initial ci/ca","J
-    at Tleaf (umol e- m-2 s-1)", "J at 25 deg C (umol e- m-2 s-1)","initial photosynthesis
-    (umol m-2 s-1)","Amax- light curve (umol m-2 s-1)","Vcmax atTleaf (umol m-2 s-1)","Vcmax
-    at 25 deg C (umol m-2 s-1)"), ~na_if(.,".")) %>% rename(measurement_remarks = context)
+  custom_R_code: '
+    data %>%
+      mutate(Date = Date %>% dmy()) %>%
+      mutate(across(where(is.character), ~na_if(.,"."))) %>%
+      rename(measurement_remarks = context)
+  '
   collection_date: Date
   taxon_name: Species
   location_name: Site

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -25,8 +25,10 @@ dataset:
   data_is_long_format: no
   custom_R_code: '
     data %>%
-      mutate(Date = Date %>% dmy()) %>%
-      mutate(across(where(is.character), ~na_if(.x,"."))) %>%
+      mutate(
+        Date = Date %>% dmy(),
+        across(c(`Leaf area (mm2)`:`trans_at_Amax_mmol_m-2_s-1`), ~na_if(.x,"."))
+      ) %>%
       rename(measurement_remarks = context)
   '
   collection_date: Date

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -27,6 +27,7 @@ dataset:
     data %>%
       mutate(
         Date = Date %>% dmy(),
+        across(c(`Leaf area (mm2)`:`trans_at_Amax_mmol_m-2_s-1`), ~as.character(.x)),
         across(c(`Leaf area (mm2)`:`trans_at_Amax_mmol_m-2_s-1`), ~na_if(.x,"."))
       ) %>%
       rename(measurement_remarks = context)

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -26,7 +26,7 @@ dataset:
   custom_R_code: '
     data %>%
       mutate(Date = Date %>% dmy()) %>%
-      mutate(across(where(is.character), ~na_if(.,"."))) %>%
+      mutate(across(where(is.character), ~na_if(.x,"."))) %>%
       rename(measurement_remarks = context)
   '
   collection_date: Date

--- a/data/Cheal_2017/metadata.yml
+++ b/data/Cheal_2017/metadata.yml
@@ -48,7 +48,7 @@ dataset:
           "no_fire_cued_seeding",fire_cued_seeding)
       ) %>%
       group_by(Species) %>%
-        mutate_at(vars(`GEOPHYTE Y, N`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`GEOPHYTE Y, N`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: unknown/2017

--- a/data/Cheesman_2020/metadata.yml
+++ b/data/Cheesman_2020/metadata.yml
@@ -34,7 +34,7 @@ dataset:
         basis_of_record = ifelse(Treatment == "Drought","field_experiment","field")
       ) %>% 
       group_by(Species) %>% 
-        mutate_at(vars("Form"),replace_duplicates_with_NA) %>% 
+        mutate(across(c("Form"),replace_duplicates_with_NA)) %>% 
       ungroup()
   ' 
   collection_date: Data_Set

--- a/data/Choat_2006/metadata.yml
+++ b/data/Choat_2006/metadata.yml
@@ -48,9 +48,9 @@ dataset:
         Site = paste("Many Peaks site",Site), 
         Site = stringr::str_replace(Site, "Many Peaks site NA","Many Peaks"),
         individual_plant = paste(Species, Plant, sep ="_"),
-        Time = as.character(Time)
-      ) %>% 
-      mutate_at(vars(gs),~na_if(.,0))
+        Time = as.character(Time),
+        across(c(gs),~na_if(.x,0))
+      )
   '
   collection_date: 2000/2001
   taxon_name: Species

--- a/data/Clarke_2015/metadata.yml
+++ b/data/Clarke_2015/metadata.yml
@@ -37,7 +37,7 @@ dataset:
       distinct(`species records`, Ecosystem, `R+`,`S+`,`resp.type`, `Conserved R+`, `Conserved S+`) %>%
   group_by(`species records`, Ecosystem) %>%
     mutate(
-      across(c(`R+`,`S+`,`resp.type`), ~na_if(., "X")),
+      across(c(`R+`,`S+`,`resp.type`), ~na_if(.x, "X")),
       `R+` = paste(`R+`, collapse = " "),
       `S+` = paste(`S+`, collapse = " "),
       `resp.type` = paste(`resp.type`, collapse = " ")
@@ -49,9 +49,7 @@ dataset:
     `S+` = str_replace(`S+`, "no NA", "no"),
     `S+` = ifelse(`S+` %in% c("yes NA", "NA yes", "yes yes"), "yes", `S+`),
     storage_organ = ifelse(`resp.type` == "Lignotuber","lignotuber", NA),
-    resp.type = resp.type %>% na_if(.,"NA"),
-    `R+` = `R+` %>% na_if(.,"NA"),
-    `S+` = `S+` %>% na_if(.,"NA")
+    across(c(`R+`,`S+`,`resp.type`), ~na_if(.x,"NA"))
     )
   '
   collection_date: unknown/2015

--- a/data/Cross_2009/metadata.yml
+++ b/data/Cross_2009/metadata.yml
@@ -22,8 +22,13 @@ contributors:
   austraits_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate_at(c("Seed mass (mg)"), ~na_if(.,0)) %>% mutate(site_name
-    = "western Victoria")
+  custom_R_code: '
+    data %>%
+      mutate(
+        across(c("Seed mass (mg)"), ~na_if(.x,0)),
+        site_name = "western Victoria"
+      )
+  '
   collection_date: 2009/2009
   taxon_name: Scientific Name
   location_name: site_name

--- a/data/Curran_2009/metadata.yml
+++ b/data/Curran_2009/metadata.yml
@@ -35,7 +35,8 @@ dataset:
       mutate(
         stomatal_conductance_per_area_ambient = `gs (stomatal conductance, cm.s-1)`*10*38.97,
         individual_plant = paste(species,Site,`Tree #`, sep = "_"),
-        collection_date = `Sampling period`
+        collection_date = `Sampling period`,
+        across(c(`stomatal_conductance_per_area_ambient`,`gs (stomatal conductance, cm.s-1)`), ~na_if(.x, "0"))
       )
   '
   collection_date: collection_date

--- a/data/Curran_2009/metadata.yml
+++ b/data/Curran_2009/metadata.yml
@@ -36,6 +36,7 @@ dataset:
         stomatal_conductance_per_area_ambient = `gs (stomatal conductance, cm.s-1)`*10*38.97,
         individual_plant = paste(species,Site,`Tree #`, sep = "_"),
         collection_date = `Sampling period`,
+        across(c(`stomatal_conductance_per_area_ambient`,`gs (stomatal conductance, cm.s-1)`), ~as.character(.x)),
         across(c(`stomatal_conductance_per_area_ambient`,`gs (stomatal conductance, cm.s-1)`), ~na_if(.x, "0"))
       )
   '

--- a/data/Curtis_2012/metadata.yml
+++ b/data/Curtis_2012/metadata.yml
@@ -25,9 +25,14 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate(leaf_dry_matter_content = `Leaf dry weight (petiole
-    attached)`/`Leaf wet weight (petiole attached)`) %>% group_by(`Scientific Name`)
-    %>% mutate_at(vars(Habit, LH, Pend), replace_duplicates_with_NA) %>% ungroup()
+  custom_R_code: '
+    data %>%
+      mutate(
+        leaf_dry_matter_content = `Leaf dry weight (petiole attached)`/`Leaf wet weight (petiole attached)`) %>%
+      group_by(`Scientific Name`) %>%
+        mutate(across(c(Habit, LH, Pend), replace_duplicates_with_NA)) %>%
+      ungroup()
+  '
   collection_date: 2010/2010
   taxon_name: Scientific Name
   location_name: site_name

--- a/data/Dong_2017/metadata.yml
+++ b/data/Dong_2017/metadata.yml
@@ -43,7 +43,7 @@ dataset:
     data %>% 
       filter(Species != "decurrens/ heliosperma") %>%
       group_by(Genus_species) %>% 
-        mutate_at(vars(Nfixer), replace_duplicates_with_NA) %>%
+        mutate(across(c(Nfixer), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2011/2012

--- a/data/Duan_2015/metadata.yml
+++ b/data/Duan_2015/metadata.yml
@@ -37,9 +37,9 @@ dataset:
     data %>% 
       mutate(
         site = "University of Western Sydney",
-        Date = Date %>% dmy()
+        Date = Date %>% dmy(),
+        across(c("Cond (mol m-2 s-1)"), ~na_if(.x,0))
       ) %>% 
-      mutate_at(c("Cond (mol m-2 s-1)"), ~na_if(.,0)) %>% 
       subset(Day < 88) %>% 
       arrange(Potnum, Day) %>%
       group_by(Potnum, Temp, CO2, Water) %>%

--- a/data/Duncan_1998/metadata.yml
+++ b/data/Duncan_1998/metadata.yml
@@ -23,7 +23,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       group_by(`genus spp (ian)`) %>% 
-      mutate_at(vars(ps_path, stom_dis), replace_duplicates_with_NA) %>% 
+      mutate(across(c(ps_path, stom_dis), replace_duplicates_with_NA)) %>% 
       ungroup()
   '
   collection_date: 1998/1998

--- a/data/Dwyer_2018/metadata.yml
+++ b/data/Dwyer_2018/metadata.yml
@@ -37,7 +37,8 @@ dataset:
           wd_notes = last(wd_notes)
         ) %>%
       ungroup() %>%
-      mutate(
+      mutate(      
+        across(c(sla, stem_specific_density), ~as.character(.x)),
         across(c(sla, stem_specific_density), ~na_if(.x,"NaN")),
         site_name = "Bulli State Forest"
       )

--- a/data/Dwyer_2018/metadata.yml
+++ b/data/Dwyer_2018/metadata.yml
@@ -38,7 +38,7 @@ dataset:
         ) %>%
       ungroup() %>%
       mutate(
-        across(where(is.character), ~na_if(.x,"NaN")),
+        across(c(sla, stem_specific_density), ~na_if(.x,"NaN")),
         site_name = "Bulli State Forest"
       )
   '

--- a/data/Dwyer_2018/metadata.yml
+++ b/data/Dwyer_2018/metadata.yml
@@ -29,11 +29,12 @@ dataset:
   custom_R_code:      '
     data %>% 
       mutate(
-        individual_plant = paste(species, Ind_ID, sep = "_")
+        individual_plant = paste(species, Ind_ID, sep = "_"),
+        across(where(is.character), ~na_if(.,"NaN"))
       ) %>%
       group_by(individual_plant, species, Ind_ID, .drop = FALSE) %>%
         summarise(
-          across(c(sla, stem_specific_density), ~mean(.x) %>% na_if("NaN"), na.rm=TRUE),
+          across(c(sla, stem_specific_density), ~mean(.x, na.rm=TRUE)),
           wd_notes = last(wd_notes)
         ) %>%
       ungroup() %>%

--- a/data/Dwyer_2018/metadata.yml
+++ b/data/Dwyer_2018/metadata.yml
@@ -29,8 +29,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       mutate(
-        individual_plant = paste(species, Ind_ID, sep = "_"),
-        across(where(is.character), ~na_if(.,"NaN"))
+        individual_plant = paste(species, Ind_ID, sep = "_")
       ) %>%
       group_by(individual_plant, species, Ind_ID, .drop = FALSE) %>%
         summarise(
@@ -38,7 +37,10 @@ dataset:
           wd_notes = last(wd_notes)
         ) %>%
       ungroup() %>%
-      mutate(site_name = "Bulli State Forest")
+      mutate(
+        across(where(is.character), ~na_if(.x,"NaN")),
+        site_name = "Bulli State Forest"
+      )
   '
   collection_date: 2015/2015
   taxon_name: species

--- a/data/Falster_2005_2/metadata.yml
+++ b/data/Falster_2005_2/metadata.yml
@@ -30,9 +30,9 @@ dataset:
     data %>%
       mutate(`regeneration strategy` = ifelse(species == "Banksia serrata", "fire_killed resprouts", `regeneration strategy`))%>%
       group_by(species) %>%
-      mutate_at(vars(`height (m)`,`LMA (mm2mg-1)`,`Nmass (%)`,`leaf size (mm2)`,
+      mutate(across(c(`height (m)`,`LMA (mm2mg-1)`,`Nmass (%)`,`leaf size (mm2)`,
         `Stem tissue density (mg mm-3)`,`seed mass (mg)`, `regeneration strategy`),
-        replace_duplicates_with_NA) %>%
+        replace_duplicates_with_NA)) %>%
       ungroup() 
   '
   collection_date: 2002-09/2002-09

--- a/data/Farrell_2013/metadata.yml
+++ b/data/Farrell_2013/metadata.yml
@@ -32,7 +32,11 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(where(is.character), ~na_if(.x,"*")))
+      mutate(
+        across(everything(), ~na_if(.x,"*")),
+        across(c(`Stem mass fraction (SMF) g/g`), ~na_if(.x,"0"))
+      )
+
   '
   collection_date: 2011-02/2011-03
   taxon_name: Species

--- a/data/Farrell_2013/metadata.yml
+++ b/data/Farrell_2013/metadata.yml
@@ -32,7 +32,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(.cols = everything(), ~na_if(.,"*")))
+      mutate(across(where(is.character), ~na_if(.,"*")))
   '
   collection_date: 2011-02/2011-03
   taxon_name: Species

--- a/data/Farrell_2013/metadata.yml
+++ b/data/Farrell_2013/metadata.yml
@@ -32,7 +32,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(where(is.character), ~na_if(.,"*")))
+      mutate(across(where(is.character), ~na_if(.x,"*")))
   '
   collection_date: 2011-02/2011-03
   taxon_name: Species

--- a/data/Farrell_2013/metadata.yml
+++ b/data/Farrell_2013/metadata.yml
@@ -33,6 +33,7 @@ dataset:
   custom_R_code:      '
     data %>%
       mutate(
+        across(everything(), ~as.character(.x)),        
         across(everything(), ~na_if(.x,"*")),
         across(c(`Stem mass fraction (SMF) g/g`), ~na_if(.x,"0"))
       )

--- a/data/Firn_2019/metadata.yml
+++ b/data/Firn_2019/metadata.yml
@@ -42,7 +42,7 @@ dataset:
         blocks = paste(trt, block, sep = "-")
       ) %>% 
       group_by(Taxon) %>% 
-        mutate_at(vars(functional_group), replace_duplicates_with_NA) %>% 
+        mutate(across(c(functional_group), replace_duplicates_with_NA)) %>% 
       ungroup()
   '
   collection_date: year

--- a/data/Fonseca_2000/metadata.yml
+++ b/data/Fonseca_2000/metadata.yml
@@ -40,10 +40,10 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate_at(vars(`TRAIT Leaf Dry Mass UNITS g`), ~na_if(.,0)) %>%
+      mutate(across(c(`TRAIT Leaf Dry Mass UNITS g`), ~na_if(.x,0))) %>%
       group_by(name_original) %>%
-        mutate_at(vars(`TRAIT Growth Form CATEGORICAL EP epiphyte (mistletoe) F fern G grass H herb S shrub T tree V vine`),
-        replace_duplicates_with_NA) %>%
+        mutate(across(c(`TRAIT Growth Form CATEGORICAL EP epiphyte (mistletoe) F fern G grass H herb S shrub T tree V vine`),
+        replace_duplicates_with_NA)) %>%
       ungroup() %>%
       mutate(
         leaflet_area = ifelse(name_original %in% c("Acacia deanei",

--- a/data/Funk_2016/metadata.yml
+++ b/data/Funk_2016/metadata.yml
@@ -30,8 +30,7 @@ dataset:
 data %>%
   mutate(
     `Nut acq strat` = stringr::str_replace(`Nut acq strat`, "Nfixer/",""),
-    across(c(`Nut acq strat`, `Rt tp cat`, `Root depth (cm)`, `Height (mm)`,
-        `Aarea`, `Amass`, `PNUE`, `PPUE`, `WUE`, `Root type`), ~na_if(.,"MD")),
+    across(where(is.character), ~na_if(.,"MD")),
     Date = ifelse(Site == "Banksia woodland","2011-09/2011-11",NA),
     Date = ifelse(Site == "Coastal banksia woodland","2012-09/2012-11",Date)
   )

--- a/data/Funk_2016/metadata.yml
+++ b/data/Funk_2016/metadata.yml
@@ -30,7 +30,7 @@ dataset:
 data %>%
   mutate(
     `Nut acq strat` = stringr::str_replace(`Nut acq strat`, "Nfixer/",""),
-    across(where(is.character), ~na_if(.x,"MD")),
+    across(everything(), ~na_if(.x,"MD")),
     Date = ifelse(Site == "Banksia woodland","2011-09/2011-11",NA),
     Date = ifelse(Site == "Coastal banksia woodland","2012-09/2012-11",Date)
   )

--- a/data/Funk_2016/metadata.yml
+++ b/data/Funk_2016/metadata.yml
@@ -30,7 +30,7 @@ dataset:
 data %>%
   mutate(
     `Nut acq strat` = stringr::str_replace(`Nut acq strat`, "Nfixer/",""),
-    across(where(is.character), ~na_if(.,"MD")),
+    across(where(is.character), ~na_if(.x,"MD")),
     Date = ifelse(Site == "Banksia woodland","2011-09/2011-11",NA),
     Date = ifelse(Site == "Coastal banksia woodland","2012-09/2012-11",Date)
   )

--- a/data/Funk_2016/metadata.yml
+++ b/data/Funk_2016/metadata.yml
@@ -30,6 +30,7 @@ dataset:
 data %>%
   mutate(
     `Nut acq strat` = stringr::str_replace(`Nut acq strat`, "Nfixer/",""),
+    across(everything(), ~as.character(.x)),
     across(everything(), ~na_if(.x,"MD")),
     Date = ifelse(Site == "Banksia woodland","2011-09/2011-11",NA),
     Date = ifelse(Site == "Coastal banksia woodland","2012-09/2012-11",Date)

--- a/data/Geange_2017/metadata.yml
+++ b/data/Geange_2017/metadata.yml
@@ -28,8 +28,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate(across(c(`LMR`,`ABG_BG`), ~na_if(.,0))) %>%
       mutate(
+        across(c(`LMR`,`ABG_BG`), ~na_if(.x, 0)),
         leaf_dry_matter_content = dry_weight_g/fresh_weight_g, 
         leaf_water_content_per_saturated_mass = water_content_g/turgid_weight_g,
         site_name = "Australian National University glasshouse",

--- a/data/Geange_2020/metadata.yml
+++ b/data/Geange_2020/metadata.yml
@@ -26,15 +26,15 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      '
+  custom_R_code: '
     data %>% 
       mutate(
         root_mass_fraction = Root_Weight / (ABG_Weight + Root_Weight), 
         root_shoot_ratio = Root_Weight / ABG_Weight,
         leaf_area_ratio = Total_Leaf_Area / (ABG_Weight + Root_Weight),
-        Trip_Date = Trip_Date %>% my() %>% format.Date("%Y-%m") 
-      ) %>% 
-      mutate_at(vars(SLA),~na_if(.,0))
+        Trip_Date = Trip_Date %>% my() %>% format.Date("%Y-%m"),
+        across(c(SLA),~na_if(.x, 0))
+      )
   '
   collection_date: Trip_Date
   taxon_name: species

--- a/data/Gray_2019/metadata.yml
+++ b/data/Gray_2019/metadata.yml
@@ -30,16 +30,16 @@ dataset:
   custom_R_code:      '
     data %>% 
       group_by(Species) %>% 
-      mutate_at(vars(`Nmass (%)`,`Narea (g/m2)`,`Pmass (%)`,`LeafP_mass`,`Parea (g/m2)`),
-                replace_duplicates_with_NA) %>%
+      mutate(across(c(`Nmass (%)`,`Narea (g/m2)`,`Pmass (%)`,`LeafP_mass`,`Parea (g/m2)`),
+                replace_duplicates_with_NA)) %>%
       ungroup() %>%    
-      mutate(across(where(is.character), ~na_if(.,"NaN"))) %>%
       group_by(ID) %>% 
         summarise(
           across(c(Owner:Species), .fns = first),
           across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~mean(.x, na.rm = TRUE))
           ) %>%
-      ungroup()
+      ungroup() %>% 
+      mutate(across(where(is.character), ~na_if(.x, "NaN")))
   '
   collection_date: 2013-10/2013-10
   taxon_name: Species

--- a/data/Gray_2019/metadata.yml
+++ b/data/Gray_2019/metadata.yml
@@ -39,7 +39,7 @@ dataset:
           across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~mean(.x, na.rm = TRUE))
           ) %>%
       ungroup() %>% 
-      mutate(across(where(is.character), ~na_if(.x, "NaN")))
+      mutate(across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~na_if(.x, "NaN")))
   '
   collection_date: 2013-10/2013-10
   taxon_name: Species

--- a/data/Gray_2019/metadata.yml
+++ b/data/Gray_2019/metadata.yml
@@ -39,7 +39,10 @@ dataset:
           across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~mean(.x, na.rm = TRUE))
           ) %>%
       ungroup() %>% 
-      mutate(across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~na_if(.x, "NaN")))
+      mutate(
+        across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~as.character(.x)),
+        across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~na_if(.x, "NaN"))
+      )
   '
   collection_date: 2013-10/2013-10
   taxon_name: Species

--- a/data/Gray_2019/metadata.yml
+++ b/data/Gray_2019/metadata.yml
@@ -32,11 +32,12 @@ dataset:
       group_by(Species) %>% 
       mutate_at(vars(`Nmass (%)`,`Narea (g/m2)`,`Pmass (%)`,`LeafP_mass`,`Parea (g/m2)`),
                 replace_duplicates_with_NA) %>%
-      ungroup() %>%
+      ungroup() %>%    
+      mutate(across(where(is.character), ~na_if(.,"NaN"))) %>%
       group_by(ID) %>% 
         summarise(
           across(c(Owner:Species), .fns = first),
-          across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~mean(.x) %>% na_if("NaN"), na.rm = TRUE)
+          across(c(`Asat_area (micromol/m2/s)`:`Parea (g/m2)`), ~mean(.x, na.rm = TRUE))
           ) %>%
       ungroup()
   '

--- a/data/Groom_1997/metadata.yml
+++ b/data/Groom_1997/metadata.yml
@@ -37,8 +37,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      na_if(".na") %>% 
       mutate(
+        across(where(is.character), ~na_if(.,".na")),
         site_name = "southwest Australia",
         fire_response = ifelse(regeneration_mode == "NS", "fire_killed", "resprouts"),
         storage_organ = ifelse(regeneration_mode %in% c("RS","RS/EP","RS?"),"lignotuber", NA)

--- a/data/Groom_1997/metadata.yml
+++ b/data/Groom_1997/metadata.yml
@@ -38,7 +38,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       mutate(
-        across(where(is.character), ~na_if(.x, ".na")),
+        across(everything(), ~na_if(.x, ".na")),
         site_name = "southwest Australia",
         fire_response = ifelse(regeneration_mode == "NS", "fire_killed", "resprouts"),
         storage_organ = ifelse(regeneration_mode %in% c("RS","RS/EP","RS?"),"lignotuber", NA)

--- a/data/Groom_1997/metadata.yml
+++ b/data/Groom_1997/metadata.yml
@@ -38,7 +38,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       mutate(
-        across(where(is.character), ~na_if(.,".na")),
+        across(where(is.character), ~na_if(.x, ".na")),
         site_name = "southwest Australia",
         fire_response = ifelse(regeneration_mode == "NS", "fire_killed", "resprouts"),
         storage_organ = ifelse(regeneration_mode %in% c("RS","RS/EP","RS?"),"lignotuber", NA)

--- a/data/Groom_1997/metadata.yml
+++ b/data/Groom_1997/metadata.yml
@@ -38,6 +38,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       mutate(
+        across(everything(), ~as.character(.x)),
         across(everything(), ~na_if(.x, ".na")),
         site_name = "southwest Australia",
         fire_response = ifelse(regeneration_mode == "NS", "fire_killed", "resprouts"),

--- a/data/Groom_2010/metadata.yml
+++ b/data/Groom_2010/metadata.yml
@@ -56,11 +56,11 @@ dataset:
                             0, seed_dry_mass_mg), 
         `P_content_mg_g-1` = if_else(source %in% c("Kuo_1982","Denton_2007",
                             "Milberg_1998","Milberg_1997","Hocking_1982","Hocking_1986"),
-                            0, `P_content_mg_g-1`)
+                            0, `P_content_mg_g-1`),
+        across(c(`seed_dry_mass_mg`,`P_content_mg_g-1`), ~na_if(.x, 0))
       ) %>%
-      mutate_at(vars(`seed_dry_mass_mg`,`P_content_mg_g-1`), ~na_if(.,0)) %>%
       group_by(species) %>%
-        mutate_at(vars(`fire_response`, `serotiny`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`fire_response`, `serotiny`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: unknown/2010

--- a/data/Grootemaat_2015/metadata.yml
+++ b/data/Grootemaat_2015/metadata.yml
@@ -46,9 +46,9 @@ dataset:
     data %>% 
       filter(taxon != "NA NA") %>% 
       group_by(taxon) %>%  
-        mutate_at(vars(`N (%mass)`,`P (%mass)`,`lignin (%mass)`,`tannin (%mass)`,
-                `FMC (% odw)`,senesced_leaf_N_per_dry_mass,senesced_leaf_P_per_dry_mass),
-                ~ replace(.x, duplicated(.x),NA)) %>%
+        mutate(across(c(`N (%mass)`, `P (%mass)`, `lignin (%mass)`, `tannin (%mass)`,
+                `FMC (% odw)`, senesced_leaf_N_per_dry_mass, senesced_leaf_P_per_dry_mass),
+                ~ replace(.x, duplicated(.x), NA))) %>%
       ungroup() %>%
       mutate(
         row_number = row_number(),

--- a/data/Grootemaat_2017_1/metadata.yml
+++ b/data/Grootemaat_2017_1/metadata.yml
@@ -37,8 +37,8 @@ dataset:
                                       measurement_remarks)
       ) %>% 
       group_by(Material,Taxon) %>% 
-        mutate_at(vars(`Leaf moisture (at time of measuring) (%odw)`),
-                        ~replace(.x,duplicated(.x),NA)) %>% 
+        mutate(across(c(`Leaf moisture (at time of measuring) (%odw)`),
+                        ~replace(.x,duplicated(.x),NA))) %>% 
       ungroup()
   '
   collection_date: 2012-12/2015

--- a/data/Grubb_2008/metadata.yml
+++ b/data/Grubb_2008/metadata.yml
@@ -24,7 +24,7 @@ contributors:
   austraits_curators: Ian Wright
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate_at(c("SLA (cm2/g)"), ~na_if(.,0))
+  custom_R_code:      data %>% mutate(across(c("SLA (cm2/g)"), ~na_if(.x, 0)))
   collection_date: 2002/2002
   taxon_name: species
   location_name: site

--- a/data/Guilherme_Pereira_2019/metadata.yml
+++ b/data/Guilherme_Pereira_2019/metadata.yml
@@ -44,10 +44,14 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate_at(c("N (mature) (mg/g)"), ~na_if(.,0)) %>% mutate(site_name
-    = ifelse(Stage == "Stage_1","Quindalup Young",Stage), site_name = ifelse(site_name
-    == "Stage_3","Quindalup Old",site_name),site_name = ifelse(site_name == "Stage_4","Spearwood
-    West",site_name))
+  custom_R_code: '
+    data %>%
+      mutate(across(c("N (mature) (mg/g)"), ~na_if(.x, 0)),
+        site_name = ifelse(Stage == "Stage_1", "Quindalup Young", Stage),
+        site_name = ifelse(site_name == "Stage_3", "Quindalup Old", site_name),
+        site_name = ifelse(site_name == "Stage_4", "Spearwood West", site_name)
+      )
+  '
   collection_date: 2011-11-11/2011-11-17
   taxon_name: Species
   location_name: site_name

--- a/data/Jordan_2020/metadata.yml
+++ b/data/Jordan_2020/metadata.yml
@@ -105,7 +105,8 @@ dataset:
         leaf_compoundness = ifelse(is.na(leaf_compoundness2), leaf_compoundness, leaf_compoundness2),        
         leaf_lobation = ifelse(is.na(leaf_lobation2), leaf_lobation, leaf_lobation2),
         leaf_lobation = ifelse(is.na(leaf_lobation) & stringr::str_detect(leaf_lamina_division,"lobed"), "lobed", leaf_lobation),
-        leaf_margin = ifelse(is.na(leaf_margin) & stringr::str_detect(leaf_lamina_division,"entire"), "entire", leaf_margin)
+        leaf_margin = ifelse(is.na(leaf_margin) & stringr::str_detect(leaf_lamina_division,"entire"), "entire", leaf_margin),
+        across(c(`leaf_lamina_division`,`leaf_shape`), ~na_if(.x,""))
       )
   '
   collection_date: unknown/2020

--- a/data/Jurado_1991/metadata.yml
+++ b/data/Jurado_1991/metadata.yml
@@ -31,9 +31,9 @@ dataset:
         parasitic = ifelse(as.character(growth_form) == "6","parasitic",NA),
         `seed mass (mg)` = ifelse(is.na(filtering_column),`seed mass (mg)`,NA),
         plant_climbing_mechanism = ifelse(as.character(growth_form) == "10","twining",NA),
-        dispersal_appendage = NA
-      ) %>%
-      mutate_at(vars(`height (cm)`,`leaf area (mm2)`,`seed mass (mg)`), ~na_if(.,0)) %>% 
+        dispersal_appendage = NA,
+        across(c(`height (cm)`,`leaf area (mm2)`,`seed mass (mg)`), ~na_if(.x, 0))
+      ) %>% 
       move_values_to_new_trait(
         "dispersal mode 1=unassisted, 2=elaiosome, 3=flesh/aril, 4=adhesive, 5=wind", 
         "dispersal_appendage", 

--- a/data/Jurado_1991/metadata.yml
+++ b/data/Jurado_1991/metadata.yml
@@ -37,7 +37,8 @@ dataset:
       move_values_to_new_trait(
         "dispersal mode 1=unassisted, 2=elaiosome, 3=flesh/aril, 4=adhesive, 5=wind", 
         "dispersal_appendage", 
-        c("2","3"), c("2","3"), c("",""))
+        c("2","3"), c("2","3"), c("","")) %>%
+      mutate(across(c(`dispersal mode 1=unassisted, 2=elaiosome, 3=flesh/aril, 4=adhesive, 5=wind`), ~na_if(.x,"")))
   '
   collection_date: 1987/1989
   taxon_name: name_original

--- a/data/Kirkpatrick_2020/metadata.yml
+++ b/data/Kirkpatrick_2020/metadata.yml
@@ -29,7 +29,7 @@ dataset:
           as.character(Wind),
           as.character(`Bird/mammal`)),
         dispersal_syndrome = NA,
-        dispersers = dispersers %>% na_if(.,"NA")
+        across(c(dispersers), ~na_if(.x, "NA"))
       ) %>% 
         move_values_to_new_trait(
           "dispersers", "dispersal_syndrome", 

--- a/data/Kooyman_2011/metadata.yml
+++ b/data/Kooyman_2011/metadata.yml
@@ -24,9 +24,9 @@ dataset:
   custom_R_code:      '
     data %>% 
       group_by(`Species_reconciled with updates and additions`) %>%
-        mutate_at(vars(`seed length maximum (mm)`,`seed length minimum (mm)`,
+        mutate(across(c(`seed length maximum (mm)`,`seed length minimum (mm)`,
         `seed width maximum (mm)`,`seed width minimum (mm)`,`leaves lobed`), 
-        list(~ replace(.,duplicated(.),NA))) %>%
+        list(~ replace(.,duplicated(.),NA)))) %>%
       ungroup() %>%
       mutate(
         `Height (m)` = ifelse(is.na(plant_height_duplicate),`Height (m)`,NA), 

--- a/data/Laliberte_2012/metadata.yml
+++ b/data/Laliberte_2012/metadata.yml
@@ -32,11 +32,11 @@ dataset:
       mutate(
         n_fixer = stringr::str_extract(strategy, "[Nn]itrogen fixer"),
         roots = stringr::str_replace(strategy, ", Nitrogen fixer", ""),
-        collection.date = collection.date %>% dmy()
-      ) %>% 
-      mutate_at(vars(`Mo_mature`), ~na_if(.,0)) %>%
+        collection.date = collection.date %>% dmy(),
+        across(c(`Mo_mature`), ~na_if(.x, 0))
+      ) %>%
       group_by(species) %>%
-        mutate_at(vars(`growthform`,`n_fixer`,`roots`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`growthform`,`n_fixer`,`roots`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: collection.date

--- a/data/Leishman_1992/metadata.yml
+++ b/data/Leishman_1992/metadata.yml
@@ -29,9 +29,10 @@ dataset:
       mutate(
         site_name = "Louth",
         parasitic = ifelse(`growth form`=="stem parasite","stem_parasitic", NA),
-        parasitic = ifelse(`growth form`=="root parasite","root_parasitic", parasitic)
-      ) %>%
-      mutate_at(vars(`height (cm)_filtered`,`leaf area (mm2)`,`seed mass (mg)`,`diaspore weight (mg)`),~na_if(.,0))
+        parasitic = ifelse(`growth form`=="root parasite","root_parasitic", parasitic),
+        across(c(`height (cm)_filtered`,`leaf area (mm2)`,`seed mass (mg)`,
+        `diaspore weight (mg)`), ~na_if(.x, 0))
+      )
   '
   collection_date: 1996/1996
   taxon_name: SPECIES

--- a/data/Leishman_1995/metadata.yml
+++ b/data/Leishman_1995/metadata.yml
@@ -44,8 +44,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate_at(vars(`Height (cm)_filtered`,`Seed mass (mg)_filtered`),~na_if(.,0)) %>% 
       mutate(
+        across(c(`Height (cm)_filtered`,`Seed mass (mg)_filtered`), ~na_if(.x, 0)),
         dispersal_appendage = NA,
         dispersers = NA,
         fruit_fleshiness = NA,

--- a/data/Leishman_2007/metadata.yml
+++ b/data/Leishman_2007/metadata.yml
@@ -25,8 +25,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate_at(vars(`gs (molm-2s-1)`),~na_if(.,0)) %>%
       mutate(
+        across(c(`gs (molm-2s-1)`), ~na_if(.x, 0)),
         entity_to_use = ifelse(is.na(Replicate),"population","individual"),
         value_type_to_use = ifelse(is.na(Replicate),"mean","raw"),
         replicates_to_use = ifelse(is.na(Replicate),"3","1")

--- a/data/Lim_2017/metadata.yml
+++ b/data/Lim_2017/metadata.yml
@@ -52,7 +52,7 @@ dataset:
         Date = Date %>% str_replace("Apr", "Apr-2012") %>% dmy()
       ) %>%
       group_by(Species) %>%
-        mutate_at(vars("plant_growth_form"),replace_duplicates_with_NA) %>%
+        mutate(across(c(plant_growth_form), replace_duplicates_with_NA)) %>%
       ungroup() %>%
       bind_rows(heightdata)
   '

--- a/data/MacinnisNg_2016/metadata.yml
+++ b/data/MacinnisNg_2016/metadata.yml
@@ -37,7 +37,7 @@ dataset:
         across(c(`Hydraulic condictivity`,`HC per branch TA`,`HC per leaf area`,`HC per SW area`), ~na_if(.x, 0))
       )
   '
-  collection_date: collection)_date
+  collection_date: collection_date
   taxon_name: species
   location_name: site
   individual_id: individual_id

--- a/data/MacinnisNg_2016/metadata.yml
+++ b/data/MacinnisNg_2016/metadata.yml
@@ -26,18 +26,18 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      '
+  custom_R_code: '
     data %>% 
       mutate(
         site = "Crookwell",
         stem_hydraulic_conductivity = 10*`Hydraulic condictivity`,
         individual_id = ifelse(is.na(tree),paste0("x",format(row_number(),000)),paste0("tree",format(tree,00))),
-        collection_date = ifelse(season == "winter", "2003-07", "2004-01")
-      ) %>%
-      mutate_at(vars(`SLA`),replace_duplicates_with_NA) %>% 
-      mutate_at(vars(`Hydraulic condictivity`,`HC per branch TA`,`HC per leaf area`,`HC per SW area`), ~na_if(.,0))
+        collection_date = ifelse(season == "winter", "2003-07", "2004-01"),
+        across(c(`SLA`), replace_duplicates_with_NA),
+        across(c(`Hydraulic condictivity`,`HC per branch TA`,`HC per leaf area`,`HC per SW area`), ~na_if(.x, 0))
+      )
   '
-  collection_date: collection_date
+  collection_date: collection)_date
   taxon_name: species
   location_name: site
   individual_id: individual_id

--- a/data/McCarthy_2017/metadata.yml
+++ b/data/McCarthy_2017/metadata.yml
@@ -32,8 +32,8 @@ dataset:
   data_is_long_format: yes
   custom_R_code:      '
     data %>% 
-      mutate_at(c("Value"), ~na_if(.,0)) %>% 
       mutate(
+        across(c("Value"), ~na_if(.x, 0)),
         replicates = 1,
         individual_identifier = paste(Species, site_name, Individual,sep="_")
       ) %>%

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -35,7 +35,8 @@ dataset:
       move_values_to_new_trait(
         "leaf form", "leaf_type",
         "scale", "scale", ""
-      )
+      ) %>%
+      mutate(across(c(`leaf form`), ~na_if(.x,"")))
   '
   collection_date: 2014/2014
   taxon_name: species name

--- a/data/Metcalfe_2009/metadata.yml
+++ b/data/Metcalfe_2009/metadata.yml
@@ -62,7 +62,8 @@ dataset:
       ) %>%
       move_values_to_new_trait(
         "Growth_form", "stem_growth_habit", "scrambler", "scrambler", "climber"
-      )
+      ) %>%      
+      mutate(across(c(Fruit_type, Growth_form), ~na_if(.x,"")))
 '
   collection_date: 2005/2005
   taxon_name: species_name

--- a/data/Mokany_2008/metadata.yml
+++ b/data/Mokany_2008/metadata.yml
@@ -28,8 +28,8 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate_at(vars(`Root:Shoot ratio`),~na_if(.,0)) %>% 
       mutate(
+        across(c(`Root:Shoot ratio`), ~na_if(.x, 0)),
         Date_plant_traits = Date_plant_traits %>% dmy(),
         entity_type_column = ifelse(is.na(Replicate),"population","individual"),
         value_type_column = ifelse(is.na(Replicate),"mean","raw"),

--- a/data/Mokany_2008/metadata.yml
+++ b/data/Mokany_2008/metadata.yml
@@ -36,9 +36,12 @@ dataset:
         root_dry_matter_content = coalesce(
               as.character(`Root Dry Matter Content (RDMC dry mass / fresh mass)`),
               as.character(`Root Dry Matter Content (RDMC)`)),
-        specific_root_area = coalesce(
-              as.character(`Specific Root Area (SRA root surface area / dry mass) (mm2.g-1)`),
-              as.character(`Specific Root Area (SRA) (m2.kg-1)`))
+        specific_root_area = ifelse(
+          !is.na(`Specific Root Area (SRA root surface area / dry mass) (mm2.g-1)`),
+                `Specific Root Area (SRA root surface area / dry mass) (mm2.g-1)`, NA),
+        specific_root_area = ifelse(
+          !is.na(`Specific Root Area (SRA) (m2.kg-1)`),`Specific Root Area (SRA) (m2.kg-1)`*1000,
+                `Specific Root Area (SRA root surface area / dry mass) (mm2.g-1)`)
       )
   '
   collection_date: Date_plant_traits

--- a/data/Mokany_2015/metadata.yml
+++ b/data/Mokany_2015/metadata.yml
@@ -42,10 +42,10 @@ contributors:
   austraits_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:      '
+  custom_R_code: '
     data %>%
-      mutate_at(vars(plant_height_unique_values),~na_if(.,0)) %>%
       mutate(
+        across(c(plant_height_unique_values), ~na_if(.x, 0)),
         leaflet_area = ifelse(`Spp Name` == "Acacia dealbata", `Leaf_Area_cm2`, NA),
         `Leaf_Area_cm2` = ifelse(`Spp Name` == "Acacia dealbata", NA, `Leaf_Area_cm2`)
       )

--- a/data/Moore_2019/metadata.yml
+++ b/data/Moore_2019/metadata.yml
@@ -24,9 +24,11 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate_at(vars(`leaf_area (mm2)`,`specific_leaf_area (mm2/mg)`), ~na_if(.,0)) %>%
-      mutate(date = ifelse(date == "2005-2006","2005/2006", date %>%
-                mdy(quiet=TRUE) %>% as.character))
+      mutate(
+        across(c(`leaf_area (mm2)`,`specific_leaf_area (mm2/mg)`), ~na_if(.x, 0)),
+        date = ifelse(date == "2005-2006","2005/2006", date %>%
+                mdy(quiet=TRUE) %>% as.character)
+      )
   '
   collection_date: date
   taxon_name: taxon

--- a/data/Morgan_2011_1/metadata.yml
+++ b/data/Morgan_2011_1/metadata.yml
@@ -15,8 +15,13 @@ contributors:
   austraits_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:      data %>% mutate(site_name = "Victoria") %>% mutate_at(c("Height (cm)"),
-    ~na_if(.,0))
+  custom_R_code: '
+    data %>%
+      mutate(
+        site_name = "Victoria",
+        across(c("Height (cm)"), ~na_if(.x, 0))
+      )
+  '
   collection_date: 2011/2011
   taxon_name: Scientific Name
   location_name: site_name

--- a/data/NTH_2014/metadata.yml
+++ b/data/NTH_2014/metadata.yml
@@ -72,6 +72,7 @@ dataset:
         c("succulent", "succulent"),
         c("herb", "herb")
       ) %>%
+      mutate(across(everything(), ~na_if(.x, ""))) %>%
       separate_range("leaf length (mm)", "leaf_length_min", "leaf_length_max") %>% 
       separate_range("leaf width (mm)", "leaf_width_min", "leaf_width_max") %>%
       separate_range("seed length (mm)", "seed_length_min", "seed_length_max") %>% 

--- a/data/NTH_2014/metadata.yml
+++ b/data/NTH_2014/metadata.yml
@@ -72,12 +72,15 @@ dataset:
         c("succulent", "succulent"),
         c("herb", "herb")
       ) %>%
-      mutate(across(everything(), ~na_if(.x, ""))) %>%
       separate_range("leaf length (mm)", "leaf_length_min", "leaf_length_max") %>% 
       separate_range("leaf width (mm)", "leaf_width_min", "leaf_width_max") %>%
       separate_range("seed length (mm)", "seed_length_min", "seed_length_max") %>% 
       separate_range("seed diameter (mm)", "seed_width_min", "seed_width_max") %>% 
-      separate_range("seed depth (mm)", "seed_depth_min", "seed_depth_max")
+      separate_range("seed depth (mm)", "seed_depth_min", "seed_depth_max") %>%
+      mutate(
+        across(everything(), ~as.character(.x)),
+        across(everything(), ~na_if(.x, ""))
+      )
   '    
   collection_date: unknown/2014
   taxon_name: species_name

--- a/data/Niinemets_2009/metadata.yml
+++ b/data/Niinemets_2009/metadata.yml
@@ -33,7 +33,7 @@ dataset:
   custom_R_code:      '
     data %>%
       group_by(Species) %>%
-        mutate_at(vars(`N-fixing`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`N-fixing`), replace_duplicates_with_NA)) %>%
       ungroup()
     '
   collection_date: 2006/2006

--- a/data/OReillyNugent_2018/metadata.yml
+++ b/data/OReillyNugent_2018/metadata.yml
@@ -37,7 +37,7 @@ dataset:
           replicate = sum(replicate)
         ) %>%
         ungroup() %>%
-      mutate_at(vars(max_height, max_canopy), ~na_if(.,-Inf));
+      mutate(across(c(max_height, max_canopy), ~na_if(.x, -Inf)));
 
     data %>% 
       mutate(row_count = dplyr::row_number()) %>%

--- a/data/Ooi_2007/metadata.yml
+++ b/data/Ooi_2007/metadata.yml
@@ -31,7 +31,7 @@ dataset:
     data %>% 
       mutate(`DATE OF COLLECTION` = `DATE OF COLLECTION` %>% dmy()) %>% 
       group_by(SPECIES) %>%
-        mutate_at(vars(DORM_TYPE), replace_duplicates_with_NA) %>%
+        mutate(across(c(DORM_TYPE), replace_duplicates_with_NA)) %>%
       ungroup() %>%
       mutate(
         `SEED WEIGHT multiplier` = ifelse(row_number() %in% c(4603, 4673, 8936, 12050, 12283, 12576, 14503), NA, 1),

--- a/data/Pickering_2014/metadata.yml
+++ b/data/Pickering_2014/metadata.yml
@@ -44,7 +44,7 @@ dataset:
   data_is_long_format: no
   custom_R_code: '
     data %>% 
-      mutate_at(c("LDMC (mg/g-1)"),~na_if(.,0)) %>%
+      mutate(across(c("LDMC (mg/g-1)"),~na_if(.x, 0))) %>%
     group_by(Species) %>%
       mutate(across(c(GF), replace_duplicates_with_NA)) %>%
     ungroup()

--- a/data/Prior_2003/metadata.yml
+++ b/data/Prior_2003/metadata.yml
@@ -48,8 +48,8 @@ dataset:
         leaf_dry_matter_content = 1 - `water%`
       ) %>% 
       group_by(Species) %>%
-        mutate_at(vars("leaf longevity","growth form","leaf type","photosynthetic pathway","Nfixer"),
-            replace_duplicates_with_NA) %>%
+        mutate(across(c("leaf longevity","growth form","leaf type","photosynthetic pathway","Nfixer"),
+            replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2003/2003

--- a/data/Reynolds_2018/metadata.yml
+++ b/data/Reynolds_2018/metadata.yml
@@ -30,7 +30,7 @@ dataset:
     data %>%
       mutate(site_name = "University of Queensland") %>%
         group_by(Species) %>%
-          mutate_at(vars(SeedMass), replace_duplicates_with_NA) %>%
+          mutate(across(c(SeedMass), replace_duplicates_with_NA)) %>%
         ungroup()
   '
   collection_date: 2014/2014

--- a/data/Richards_2003/metadata.yml
+++ b/data/Richards_2003/metadata.yml
@@ -29,10 +29,12 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate(`Ni (mg/kg)` = stringr::str_replace(`Ni (mg/kg)`,"< ","")) %>%
-      mutate_at(vars(`Stomatal conductance_HalogenLight`),~na_if(.,0)) %>%
+      mutate(
+        `Ni (mg/kg)` = stringr::str_replace(`Ni (mg/kg)`,"< ",""),
+        across(c(`Stomatal conductance_HalogenLight`), ~na_if(.x, 0))
+      ) %>%
       group_by(Species) %>%
-        mutate_at(vars(`Nfixer`,`mycorrhizae`),replace_duplicates_with_NA) %>%
+        mutate(across(c(`Nfixer`,`mycorrhizae`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 1999/2000

--- a/data/Schmidt_2003/metadata.yml
+++ b/data/Schmidt_2003/metadata.yml
@@ -63,10 +63,10 @@ dataset:
         phenology = ifelse(species_name == "Petalostigma quadriloculare", "facultative_drought_deciduous evergreen", phenology),
         root_structure = ifelse(species_name == "Lophostemon lactifluus", "ectomycorrhizal arbuscular_mycorrhizal", root_structure),
         root_structure = ifelse(species_name == "Cartonema spicatum", "non_mycorrhizal", root_structure),
-        TRIP = ifelse(is.na(TRIP),1,TRIP)
-      ) %>% 
-      mutate_at(vars(`life_history`,`regen_strategy`), ~na_if(.,"")) %>%
-      mutate_at(vars(`leaf_water_content`), ~na_if(.,0)) %>%
+        TRIP = ifelse(is.na(TRIP),1,TRIP),
+        across(c(`life_history`,`regen_strategy`), ~na_if(.x, "")),
+        across(c(`leaf_water_content`), ~na_if(.x, 0))
+      ) %>%
       group_by(species_name) %>%
         mutate(
           across(c(`regen_strategy`,`root_structure`,`C3C4`,`Nfixer`,`plant_growth_form`,

--- a/data/Schmidt_2010/metadata.yml
+++ b/data/Schmidt_2010/metadata.yml
@@ -29,7 +29,7 @@ dataset:
         date_sampled = ifelse(Date == "Feb","1998-02","1998-11")
       ) %>%
       group_by(name_matched) %>%
-        mutate_at(vars(`C3C4`, `Nfixer`, `growth form`, `leaf_type`, `deciduous/evergreen`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`C3C4`, `Nfixer`, `growth form`, `leaf_type`, `deciduous/evergreen`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: date_sampled

--- a/data/Schulze_2006_2/metadata.yml
+++ b/data/Schulze_2006_2/metadata.yml
@@ -46,7 +46,7 @@ dataset:
   custom_R_code:      '
     data %>%
       group_by(Species) %>%
-        mutate_at(vars(`Sprouter or obligate Seeder`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`Sprouter or obligate Seeder`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2003/2003

--- a/data/Schulze_2014/metadata.yml
+++ b/data/Schulze_2014/metadata.yml
@@ -69,8 +69,8 @@ dataset:
       ) %>%
       mutate(`leaf type` = ifelse(`leaf type` %in% c("linearly", "lanceolat"), "leaf", `leaf type`)) %>%
       group_by(species_name) %>%
-        mutate_at(vars(`physical_defence`,`leaf type`, leaf_type, `leaf_compoundness`, `Deciduous`,
-        `Life-form`,`N2 fixing`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`physical_defence`,`leaf type`, leaf_type, `leaf_compoundness`, `Deciduous`,
+        `Life-form`,`N2 fixing`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: Date_to_use_edited

--- a/data/Schulze_2014/raw/metadata_original.yml
+++ b/data/Schulze_2014/raw/metadata_original.yml
@@ -385,9 +385,16 @@ config:
     taxon_name: species_name
     site_name: site_name
     date: date_sampled
-  custom_R_code: data %>% mutate(date_sampled = date_sampled %>% mdy()) %>% group_by(`species_name`)
-    %>% mutate_at(vars(physical_defence,`leaf type`,leaf_compoundness),funs(replace(.,duplicated(.),NA)))
-    %>% ungroup()
+  custom_R_code: '
+    data %>% 
+      mutate(
+        date_sampled = date_sampled %>% mdy()
+      ) %>%
+      group_by(`species_name`) %>%
+        mutate(across(c(physical_defence,`leaf type`,leaf_compoundness),
+          replace_duplicates_with_NA))) %>%
+      ungroup()
+    '
 traits:
 - var_in: leaf type
   unit_in: .na

--- a/data/Soliveres_2012/metadata.yml
+++ b/data/Soliveres_2012/metadata.yml
@@ -36,7 +36,8 @@ dataset:
         c("Fleshy-fruited","fleshy_fruit"),
         c("fleshy","fleshy"),
         c("","")
-      )
+      ) %>%
+      mutate(across(everything(), ~na_if(.x, "")))
   '
   collection_date: 2012/2012
   taxon_name: name_original

--- a/data/Soper_2014/metadata.yml
+++ b/data/Soper_2014/metadata.yml
@@ -34,7 +34,7 @@ dataset:
         plant_growth_substrate = NA_character_
       ) %>%
       group_by(species_name_edited) %>%
-        mutate_at(vars(`PLANT GROUP`), replace_duplicates_with_NA) %>%
+        mutate(across(c(`PLANT GROUP`), replace_duplicates_with_NA)) %>%
       ungroup() %>%
       move_values_to_new_trait(
         "PLANT GROUP", "plant_growth_substrate", "Mistletoe", "epiphyte", ""

--- a/data/TMAG_2009/metadata.yml
+++ b/data/TMAG_2009/metadata.yml
@@ -47,7 +47,10 @@ dataset:
         "leaf shape", "leaf_base_shape",
         c("cuneate","hastate"), c("cuneate","hastate"), c("","")
       ) %>%
-      mutate(across(everything(), ~na_if(.x, "")))
+      mutate(
+        across(everything(), ~as.character(.x)),
+        across(everything(), ~na_if(.x, ""))
+      )
   '
   collection_date: unknown/2009
   taxon_name: taxon

--- a/data/TMAG_2009/metadata.yml
+++ b/data/TMAG_2009/metadata.yml
@@ -46,7 +46,8 @@ dataset:
       move_values_to_new_trait(
         "leaf shape", "leaf_base_shape",
         c("cuneate","hastate"), c("cuneate","hastate"), c("","")
-      )
+      ) %>%
+      mutate(across(everything(), ~na_if(.x, "")))
   '
   collection_date: unknown/2009
   taxon_name: taxon

--- a/data/Vesk_2007/metadata.yml
+++ b/data/Vesk_2007/metadata.yml
@@ -23,7 +23,7 @@ dataset:
         stem_growth_habit = ifelse(`plant_growth_form` == "prostrate shrub", "prostrate", NA)
       ) %>%
       group_by(Spp_Name) %>%
-       mutate_at(vars(c(`plant_growth_form`,`stem_growth_habit`)), replace_duplicates_with_NA) %>%
+       mutate(across(c(`plant_growth_form`,`stem_growth_habit`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2007/2007

--- a/data/WAH_1998/metadata.yml
+++ b/data/WAH_1998/metadata.yml
@@ -69,7 +69,10 @@ dataset:
         "leaf type (compound/simple)", "leaf_type",
         "leafless", "leafless", ""
       ) %>%
-      mutate(across(everything(), ~na_if(.x, "")))
+      mutate(
+        across(everything(), ~as.character(.x)),
+        across(everything(), ~na_if(.x, ""))
+      )
   '
   collection_date: unknown/1998
   taxon_name: SPECIES

--- a/data/WAH_1998/metadata.yml
+++ b/data/WAH_1998/metadata.yml
@@ -68,7 +68,8 @@ dataset:
       move_values_to_new_trait(
         "leaf type (compound/simple)", "leaf_type",
         "leafless", "leafless", ""
-      )
+      ) %>%
+      mutate(across(everything(), ~na_if(.x, "")))
   '
   collection_date: unknown/1998
   taxon_name: SPECIES

--- a/data/WAH_2022_2/metadata.yml
+++ b/data/WAH_2022_2/metadata.yml
@@ -65,7 +65,8 @@ dataset:
          `plant_growth_substrate_a`, `sex_type_a`), replace_duplicates_with_NA),
           plant_growth_form_a = ifelse(all(!is.na(plant_growth_form_a)), paste(plant_growth_form_a, collapse = " "), plant_growth_form_a),
           stem_growth_habit_a = ifelse(all(!is.na(stem_growth_habit_a)), paste(stem_growth_habit_a, collapse = " "), stem_growth_habit_a),
-         across(c(`plant_growth_form_a`, `stem_growth_habit_a`), replace_duplicates_with_NA)
+          across(c(`plant_growth_form_a`, `stem_growth_habit_a`), replace_duplicates_with_NA),
+          woodiness_a = stringr::str_replace(woodiness_a, "soft_wood","semi_woody")
         ) %>%
       ungroup()
   '

--- a/data/Weerasinghe_2014/metadata.yml
+++ b/data/Weerasinghe_2014/metadata.yml
@@ -35,7 +35,7 @@ dataset:
   custom_R_code:      '
     data %>%
       mutate(
-        across(c(`Photo`,`Cond`,`Ci`,`Trmmol`,`Rdark`), ~na_if(.,"-")),
+        across(where(is.character), ~na_if(.,"-")),
         Date = Date %>% dmy(),
         individual_id = paste(`Forest location`, Species, replicate, sep = "_"),
         `replicates for columns 18 to 25` = str_replace(`replicates for columns 18 to 25`, "4-Mar","3-4")

--- a/data/Weerasinghe_2014/metadata.yml
+++ b/data/Weerasinghe_2014/metadata.yml
@@ -35,6 +35,7 @@ dataset:
   custom_R_code:      '
     data %>%
       mutate(
+        across(everything(), ~as.character(.x)),        
         across(everything(), ~na_if(.x, "-")),
         Date = Date %>% dmy(),
         individual_id = paste(`Forest location`, Species, replicate, sep = "_"),
@@ -49,6 +50,7 @@ dataset:
           ) %>%
       ungroup() %>%
       mutate(
+        across(everything(), ~as.character(.x)),
         across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~na_if(.x, "nan")),
         across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~na_if(.x, "NaN")),
       )

--- a/data/Weerasinghe_2014/metadata.yml
+++ b/data/Weerasinghe_2014/metadata.yml
@@ -35,7 +35,7 @@ dataset:
   custom_R_code:      '
     data %>%
       mutate(
-        across(where(is.character), ~na_if(.,"-")),
+        across(where(is.character), ~na_if(.x, "-")),
         Date = Date %>% dmy(),
         individual_id = paste(`Forest location`, Species, replicate, sep = "_"),
         `replicates for columns 18 to 25` = str_replace(`replicates for columns 18 to 25`, "4-Mar","3-4")
@@ -44,7 +44,7 @@ dataset:
       group_by(Date, Species, `Forest location`, `Canopy location`, replicate, site_name, individual_id) %>% 
         mutate(across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), .fns=as.numeric)) %>% 
         summarise(
-          across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~mean(.x) %>% na_if("NaN"), na.rm = TRUE),
+          across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~mean(.x, na.rm = TRUE)),
           across(c(`value_type for columns 18 to 25`, `replicates for columns 18 to 25`), .fns=first)
           ) %>%
       ungroup()

--- a/data/Weerasinghe_2014/metadata.yml
+++ b/data/Weerasinghe_2014/metadata.yml
@@ -35,7 +35,7 @@ dataset:
   custom_R_code:      '
     data %>%
       mutate(
-        across(where(is.character), ~na_if(.x, "-")),
+        across(everything(), ~na_if(.x, "-")),
         Date = Date %>% dmy(),
         individual_id = paste(`Forest location`, Species, replicate, sep = "_"),
         `replicates for columns 18 to 25` = str_replace(`replicates for columns 18 to 25`, "4-Mar","3-4")
@@ -47,7 +47,11 @@ dataset:
           across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~mean(.x, na.rm = TRUE)),
           across(c(`value_type for columns 18 to 25`, `replicates for columns 18 to 25`), .fns=first)
           ) %>%
-      ungroup()
+      ungroup() %>%
+      mutate(
+        across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~na_if(.x, "nan")),
+        across(c(Photo:Rdark, `LMA_g_m-2`:`N_P_ratio`, `soluble_sugars_mg_g-1`:`TNC_g_m-2`), ~na_if(.x, "NaN")),
+      )
   '
   collection_date: Date
   taxon_name: Species

--- a/data/Wells_2012/metadata.yml
+++ b/data/Wells_2012/metadata.yml
@@ -68,9 +68,9 @@ dataset:
       leaf_vs_leaflet = case_when(
         `L1Lflt2` == "1" ~ "measurements made on leaves",
         `L1Lflt2` == "2" ~ "measurements made on leaflets"
-      )                       
-    ) %>% 
-        mutate_at(vars(`LA`,`LtLeaf`,`LMA`,`LWC`), ~na_if(.,0)) %>%
+      ),
+      across(c(`LA`,`LtLeaf`,`LMA`,`LWC`), ~na_if(.x, 0))
+    ) %>%
         bind_rows(seedling_traits) %>%
         bind_rows(adult_traits) %>%
         mutate(

--- a/data/Westoby_2004/metadata.yml
+++ b/data/Westoby_2004/metadata.yml
@@ -21,7 +21,7 @@ dataset:
     data %>%
       mutate(`leaf type`= ifelse(str_detect(name_original,"Synoum"),"simple compound",`leaf type`)) %>%
       group_by(name_original) %>%
-        mutate_at(vars(`leaf type`),replace_duplicates_with_NA) %>%
+        mutate(across(c(`leaf type`), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2003/2003

--- a/data/Westoby_2014/metadata.yml
+++ b/data/Westoby_2014/metadata.yml
@@ -122,7 +122,7 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      mutate_at(vars(`gl Mo (mg/kg)`,`gl Na (mg/g)`), ~na_if(.,0))
+      mutate(across(c(`gl Mo (mg/kg)`,`gl Na (mg/g)`), ~na_if(.x, 0)))
   '
   collection_date: 2011/2012
   taxon_name: Genus_species

--- a/data/Wheeler_2002/data.csv
+++ b/data/Wheeler_2002/data.csv
@@ -290,7 +290,7 @@ Calycopeplus,oligandrus,Calycopeplus oligandrus,tree,perennial,,5,7,25,1,2,linea
 Monotaxis,grandiflora,Monotaxis grandiflora,shrub,perennial,,0.3,5,12,1,1,linear,simple
 Monotaxis,occidentalis,Monotaxis occidentalis,herb,perennial,,0.2,1.5,12,1,3,ovate,simple
 Phyllanthus,calycinus,Phyllanthus calycinus,shrub,perennial,,5,5,22,3,7,elliptic,simple
-Poranthera,huegelii,Poranthera huegelii,shrub,perennial,,0.4,6,20,`,1,linear,simple
+Poranthera,huegelii,Poranthera huegelii,shrub,perennial,,0.4,6,20,,1,linear,simple
 Poranthera,microphylla,Poranthera microphylla,herb,annual,,0.45,4,27,1,3.5,ovate,simple
 Pseudanthus,virgatus,Pseudanthus virgatus,shrub,perennial,,0.5,3,10,1,2.5,ovate,simple
 Ricinocarpos,glaucus,Ricinocarpos glaucus,shrub,perennial,,2,7,50,1,3,linear,simple

--- a/data/Wheeler_2002/metadata.yml
+++ b/data/Wheeler_2002/metadata.yml
@@ -24,16 +24,14 @@ dataset:
     data %>% 
       mutate(
         leaf_lobation = ifelse(`leaf type` == "lobed" | `leaf shape` == "lobed",
-                      "lobed", "unlobed"), 
+                              "lobed", "unlobed"), 
         `leaf shape` = ifelse(`leaf shape` == "lobed", NA, `leaf shape`),
         `leaf type` = ifelse(`leaf type` == "lobed", NA, `leaf type`),
         plant_growth_substrate = ifelse(`growth form`=="aquatic","aquatic",NA),
         parasitic = ifelse(`growth form`=="parasitic","parasitic", NA),
-        plant_photosynthetic_organ = ifelse(`leaf shape`=="articles","cladode", NA)
+        plant_photosynthetic_organ = ifelse(`leaf shape`=="articles","cladode", NA),
+        across(c(`min leaf length (mm)`,`max leaf length (mm)`,`max leaf width (mm)`,`min leaf width (mm)`), ~na_if(.x, 0))
       )
-    %>% mutate(across(all_of(c(`min leaf length (mm)`,`max leaf length (mm)`,
-                      `min leaf width (mm)`,`max leaf width (mm)`)), ~na_if(.,0))) %>% 
-        mutate(across(all_of(`min leaf width (mm)`), ~na_if(.,"`")))
   '
   collection_date: 2014/2014
   taxon_name: binomial

--- a/data/Wheeler_2002/metadata.yml
+++ b/data/Wheeler_2002/metadata.yml
@@ -31,9 +31,9 @@ dataset:
         parasitic = ifelse(`growth form`=="parasitic","parasitic", NA),
         plant_photosynthetic_organ = ifelse(`leaf shape`=="articles","cladode", NA)
       )
-    %>% mutate_at(vars(`min leaf length (mm)`,`max leaf length (mm)`,
-                      `min leaf width (mm)`,`max leaf width (mm)`), ~na_if(.,0)) %>% 
-        mutate_at(vars(`min leaf width (mm)`), ~na_if(.,"`"))
+    %>% mutate(across(all_of(c(`min leaf length (mm)`,`max leaf length (mm)`,
+                      `min leaf width (mm)`,`max leaf width (mm)`)), ~na_if(.,0))) %>% 
+        mutate(across(all_of(`min leaf width (mm)`), ~na_if(.,"`")))
   '
   collection_date: 2014/2014
   taxon_name: binomial

--- a/data/Wright_2001/metadata.yml
+++ b/data/Wright_2001/metadata.yml
@@ -28,8 +28,10 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>% 
-      mutate(rainfall = Site) %>%
-      mutate_at(vars(`reserve_M (mg)`), ~na_if(.,0)) %>%
+      mutate(
+        rainfall = Site,
+        across(c(`reserve_M (mg)`), ~na_if(.x, 0))
+      ) %>%
       group_by(spp, Site) %>%
         mutate(observation_num = dplyr::row_number()) %>%
       ungroup()

--- a/data/Wright_2008/metadata.yml
+++ b/data/Wright_2008/metadata.yml
@@ -28,7 +28,7 @@ dataset:
   custom_R_code:      '
     data %>% 
       group_by(Species) %>%
-        mutate_at(vars(Nfixer), replace_duplicates_with_NA) %>%
+        mutate(across(c(Nfixer), replace_duplicates_with_NA)) %>%
       ungroup()
   '
   collection_date: 2008/2008

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -34,17 +34,19 @@ dataset:
         new_date = new_date %>% mdy(quiet=TRUE) %>% as.character(),
         date_WD = date_WD %>% dmy(quiet=TRUE) %>% as.character(),
         date_merged = coalesce(new_date, date_WD, as.character(date_by_month)),
-        individual = paste(Species, site_name, age, Rep, sep = "_"),
-        across(where(is.character), ~na_if(.,"nan")),
-        across(where(is.character), ~na_if(.,"NaN"))
+        individual = paste(Species, site_name, age, Rep, sep = "_")
       ) %>%
         select(-date_by_month, -new_date, -date_WD, -sample_date, - notes, -spp, -`Pith diam (mm)`, -context) %>% 
         group_by(site_name, season, Species, age, Rep, individual) %>% 
           summarise(
-            across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~mean(.x), na.rm = TRUE),
+            across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~mean(.x, na.rm = TRUE)),
             date_merged = first(date_merged)
           ) %>% 
-        ungroup()
+        ungroup() %>%
+        mutate(
+          across(where(is.character), ~na_if(.x, "nan")),
+          across(where(is.character), ~na_if(.x, "NaN"))
+        )
   '
   collection_date: date_merged
   taxon_name: Species

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -44,6 +44,7 @@ dataset:
           ) %>% 
         ungroup() %>%
         mutate(
+          across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~as.character(.x)),
           across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~na_if(.x, "nan")),
           across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~na_if(.x, "NaN"))
         )

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -35,8 +35,8 @@ dataset:
         date_WD = date_WD %>% dmy(quiet=TRUE) %>% as.character(),
         date_merged = coalesce(new_date, date_WD, as.character(date_by_month)),
         individual = paste(Species, site_name, age, Rep, sep = "_"),
-        across(everything(), ~na_if(.,"nan")),
-        across(everything(), ~na_if(.,"NaN"))
+        across(where(is.character), ~na_if(.,"nan")),
+        across(where(is.character), ~na_if(.,"NaN"))
       ) %>%
         select(-date_by_month, -new_date, -date_WD, -sample_date, - notes, -spp, -`Pith diam (mm)`, -context) %>% 
         group_by(site_name, season, Species, age, Rep, individual) %>% 

--- a/data/Wright_2019/metadata.yml
+++ b/data/Wright_2019/metadata.yml
@@ -44,8 +44,8 @@ dataset:
           ) %>% 
         ungroup() %>%
         mutate(
-          across(where(is.character), ~na_if(.x, "nan")),
-          across(where(is.character), ~na_if(.x, "NaN"))
+          across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~na_if(.x, "nan")),
+          across(c(`WD kg/m3`:`gas_ d13C_leaf`), ~na_if(.x, "NaN"))
         )
   '
   collection_date: date_merged

--- a/data/Wright_2019/raw/metadata.yml
+++ b/data/Wright_2019/raw/metadata.yml
@@ -76,8 +76,13 @@ config:
   variable_match:
     taxon_name: Species
     site_name: site_name
-  custom_R_code: data %>% mutate(site_name = "Howard_Springs") %>% mutate_at(c("Cu"),
-    ~na_if(.,0))
+  custom_R_code: '
+    data %>%
+      mutate(
+        site_name = "Howard_Springs",
+        across(c("Cu"), ~na_if(.x, 0))
+      )
+  '
 traits:
 - var_in: WD kg/m3
   unit_in: kg/m3

--- a/scripts/custom.R
+++ b/scripts/custom.R
@@ -274,14 +274,16 @@ move_values_to_new_trait <- function(data, original_trait, new_trait, original_v
        for (j in 1:length(original_values)) {
             
             i <- data[[original_trait]] == original_values[[j]]
+            i <- ifelse(is.na(i),"FALSE",i)
             
             data[[new_trait]] = ifelse(i, values_for_new_trait[[j]], data[[new_trait]])
             data[[original_trait]] = ifelse(i, values_to_keep[[j]], data[[original_trait]])
             data
        }
          
-  data = data %>% mutate_all(na_if,"")
-
+  #data = data %>% mutate_all(na_if,"")
+  data %>% mutate(across(where(is.character), ~na_if(., "")))
+  
   return(data)
 
 }

--- a/scripts/custom.R
+++ b/scripts/custom.R
@@ -282,7 +282,7 @@ move_values_to_new_trait <- function(data, original_trait, new_trait, original_v
        }
          
   #data = data %>% mutate_all(na_if,"")
-  data %>% mutate(across(where(is.character), ~na_if(., "")))
+  data %>% mutate(across(where(is.character), ~na_if(.x, "")))
   
   return(data)
 

--- a/scripts/custom.R
+++ b/scripts/custom.R
@@ -281,7 +281,7 @@ move_values_to_new_trait <- function(data, original_trait, new_trait, original_v
             data
        }
          
-    data = data %>% mutate(across(everything(), ~na_if(.x, "")))
+    #data = data %>% mutate(across(everything(), ~na_if(.x, "")))
   
   return(data)
 

--- a/scripts/custom.R
+++ b/scripts/custom.R
@@ -281,8 +281,7 @@ move_values_to_new_trait <- function(data, original_trait, new_trait, original_v
             data
        }
          
-  #data = data %>% mutate_all(na_if,"")
-  data %>% mutate(across(where(is.character), ~na_if(.x, "")))
+    data = data %>% mutate(across(everything(), ~na_if(.x, "")))
   
   return(data)
 


### PR DESCRIPTION
updating syntax to be compliant with newly released dplyr 1.1.0

these were mostly changes in custom_R_code that were now breaking

as part of htis change all uses of `mutate_at` and `mutate_all` have now been replaced with the newer variants `mutate(across())`. This was not yet a breaking issue, but the dplyr help pages indicated it would be soon.