### PR TITLE
Mistake in allowable ranges

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -173,8 +173,8 @@ traits:
       type: numeric
       units: g/g
       label: Bark ash content per dry mass
-      allowed_values_min: 0.01
-      allowed_values_max: 100.0
+      allowed_values_min: 0.0001
+      allowed_values_max: 1.0
     bark_cellulose_per_dry_mass:
       description: Bark cellulose per unit bark dry mass
       type: numeric
@@ -320,8 +320,8 @@ traits:
       type: numeric
       units: g/g
       label: Percentage of N accounted for by Rubisco
-      allowed_values_min: 5
-      allowed_values_max: 50
+      allowed_values_min: 0.01
+      allowed_values_max: 0.50
     leaf_sclerenchyma_P_per_fresh_mass:
       description: P content of sclerenchyma cells
       type: numeric
@@ -341,8 +341,8 @@ traits:
       type: numeric
       units: g/g
       label: Percentage of N accounted for by thylakoid proteins
-      allowed_values_min: 5
-      allowed_values_max: 30
+      allowed_values_min: 0.01
+      allowed_values_max: 0.30
     leaf_chlorophyll_per_area:
       description: Sum of chlorophyll A and B per leaf area
       type: numeric
@@ -718,8 +718,8 @@ traits:
       type: numeric
       units: g/g
       label: Proportion of fuel that was consumed by fire
-      allowed_values_min: 1
-      allowed_values_max: 100
+      allowed_values_min: .01
+      allowed_values_max: 1
     fire_rate_of_spread:
       description: Rate of spread. How fast the fire moves across the landscape.
       type: numeric
@@ -1452,8 +1452,8 @@ traits:
       type: numeric
       units: g/g
       label: Leaf ash content per dry mass
-      allowed_values_min: 0.01
-      allowed_values_max: 100.0
+      allowed_values_min: 0.0001
+      allowed_values_max: 1.0
     leaf_Al_per_dry_mass:
       description: Leaf aluminium (Al) content per unit leaf dry mass
       type: numeric
@@ -1697,8 +1697,8 @@ traits:
       type: numeric
       units: MPa
       label: Leaf hydraulic vulnerability
-      allowed_values_min: .001
-      allowed_values_max: 40
+      allowed_values_min: -40.0
+      allowed_values_max: -0.001
     leaf_K_per_area:
       description: Leaf potassium (K) content per unit leaf area
       type: numeric
@@ -2080,8 +2080,8 @@ traits:
       type: numeric
       units: MPa
       label: Leaf turgor loss point
-      allowed_values_min: .01
-      allowed_values_max: 100
+      allowed_values_min: -100
+      allowed_values_max: -.01
     leaf_relative_water_content_at_turgor_loss_point:
       description: Ratio of water in a fresh leaf to water in a leaf at turgor loss; calculated from a pressure-volume curve.
       type: numeric
@@ -3118,8 +3118,8 @@ traits:
       type: numeric
       units: g/g
       label: Senesced leaf carbon (C) content per unit leaf dry mass
-      allowed_values_min: 10.0
-      allowed_values_max: 100.0
+      allowed_values_min: 0.01
+      allowed_values_max: 1.0
     leaf_senesced_Ca_per_dry_mass:
       description: Senesced leaf calcium (Ca) content per unit leaf dry mass
       type: numeric

--- a/config/unit_conversions.csv
+++ b/config/unit_conversions.csv
@@ -81,6 +81,7 @@ umol/g,mmol/kg,x*1
 mmol/g,mmol/kg,x*1/1000
 mol/kg,umol/g,x*1000
 nmol/g/s,umol/g/s,x*0.001
+neg_nmol{CO2}/g/s,nmol{CO2}/g/s,x*-1
 mol/m2/s,mmol/m2/s,x*1000
 mmol/m2/MPa/s,mmol/m2/MPa/s,x*1
 kg/m2/MPa/s,mmol/m2/MPa/s,x*18015200

--- a/data/RBGV_2022/metadata.yml
+++ b/data/RBGV_2022/metadata.yml
@@ -46,7 +46,10 @@ dataset:
   data_is_long_format: no
   custom_R_code:      '
     data %>%
-      filter(str_detect(taxon_name, " "))
+      filter(str_detect(taxon_name, " ")) %>%
+      mutate(
+        woodiness_a = stringr::str_replace(woodiness_a, "soft_wood","semi_woody")
+      )
   '
   collection_date: unknown/2022
   taxon_name: taxon_name

--- a/data/White_2020/metadata.yml
+++ b/data/White_2020/metadata.yml
@@ -378,8 +378,7 @@ substitutions:
   replace: sharp_pointed_defence
 - trait_name: plant_physical_defence_structures
   find: 1
-  replace: sharp_pointed_defence
-  
+  replace: sharp_pointed_defence  
 - trait_name: seed_longevity_categorical
   find: 10
   replace: short_persistent
@@ -422,12 +421,36 @@ substitutions:
 - trait_name: plant_tolerance_water_logged_soils
   find: '<1_month'
   replace: less_than_1_month
+- trait_name: plant_tolerance_water_logged_soils
+  find: '<1_month 1-6_months'
+  replace: less_than_1_month 1-6_months
+- trait_name: plant_tolerance_water_logged_soils
+  find: '<1_month 1-6_months >6_months'
+  replace: less_than_1_month 1-6_months greater_than_6_months
+- trait_name: plant_tolerance_water_logged_soils
+  find: 'aquatic <1_month 1-6_months >6_months'
+  replace: aquatic less_than_1_month 1-6_months greater_than_6_months
+- trait_name: plant_tolerance_water_logged_soils
+  find: 'not_applicable <1_month 1-6_months >6_months'
+  replace: not_applicable less_than_1_month 1-6_months greater_than_6_months
 - trait_name: plant_tolerance_inundation
   find: '>6_months'
   replace: greater_than_6_months
 - trait_name: plant_tolerance_inundation
   find: '<1_month'
   replace: less_than_1_month
+- trait_name: plant_tolerance_inundation
+  find: '<1_month 1-6_months'
+  replace: less_than_1_month 1-6_months
+- trait_name: plant_tolerance_inundation
+  find: '<1_month 1-6_months >6_months'
+  replace: less_than_1_month 1-6_months greater_than_6_months
+- trait_name: plant_tolerance_inundation
+  find: 'aquatic <1_month 1-6_months >6_months'
+  replace: aquatic less_than_1_month 1-6_months greater_than_6_months
+- trait_name: plant_tolerance_inundation
+  find: 'not_applicable <1_month 1-6_months >6_months'
+  replace: not_applicable less_than_1_month 1-6_months greater_than_6_months
 - trait_name: vegetative_reproduction_ability
   find: 1
   replace: vegetative


### PR DESCRIPTION
When the units were updated, some changes to allowable ranges in the traits.yml file didn't get merged in. This is resulting in about ~4000 measurements being excluded.

Branch includes two other mistakes with substitutions.