### PR TITLE
update tests to pass testthat 3.1.8

### DIFF
--- a/tests/build/test-custom.R
+++ b/tests/build/test-custom.R
@@ -5,9 +5,9 @@ testthat::test_that("get_month returns correct month",{
   expect_match(get_month(1), "Jan")
   expect_match(get_month(1), "Jan")
   expect_match(get_month(1.5), "Jan")
-  expect_equal(get_month(13), "NA")
-  expect_equal(get_month("Jan"), "NA")
-  expect_equal(get_month(NA), "NA")
+  expect_equal(get_month(13), as.character(NA))
+  expect_equal(get_month("Jan"), as.character(NA))
+  expect_equal(get_month(NA), as.character(NA))
 })
 
 testthat::test_that("format_flowering_months returns a single 12 character string",{
@@ -18,10 +18,10 @@ testthat::test_that("format_flowering_months returns a single 12 character strin
   expect_match(format_flowering_months(1, 12), "yyyyyyyyyyyy")
   expect_match(format_flowering_months(12, 12), "nnnnnnnnnnny")
   expect_equal(format_flowering_months(12, 6), "yyyyyynnnnny")
-  expect_equal(format_flowering_months(0, 6), "NA")
-  expect_equal(format_flowering_months(1, 13), "NA")
-  expect_equal(format_flowering_months(12, 13), "NA")
-  expect_equal(format_flowering_months(1, NA), "NA")
+  expect_equal(format_flowering_months(0, 6), as.character(NA))
+  expect_equal(format_flowering_months(1, 13), as.character(NA))
+  expect_equal(format_flowering_months(12, 13), as.character(NA))
+  expect_equal(format_flowering_months(1, NA), as.character(NA))
 })
 
 testthat::test_that("convert_month_range_vec_to_binary returns a single 12 character string",{
@@ -35,9 +35,9 @@ testthat::test_that("convert_month_range_vec_to_binary returns a single 12 chara
   expect_match(convert_month_range_vec_to_binary("Feb-Mar;Oct-Nov"), "nyynnnnnnyyn")
   expect_equal(convert_month_range_vec_to_binary("Mar,Apr"), "nnyynnnnnnnn")
   expect_equal(convert_month_range_vec_to_binary(c("Mar", "Apr")), c("nnynnnnnnnnn","nnnynnnnnnnn"))
-  expect_equal(convert_month_range_vec_to_binary("March"), "NA")
-  expect_equal(convert_month_range_vec_to_binary(3), "NA")
-  expect_equal(convert_month_range_vec_to_binary(NA), "NA")
+  expect_equal(convert_month_range_vec_to_binary("March"), as.character(NA))
+  expect_equal(convert_month_range_vec_to_binary(3), as.character(NA))
+  expect_equal(convert_month_range_vec_to_binary(NA), as.character(NA))
 })
 
 testthat::test_that("convert_01_ny returns correct character",{
@@ -48,7 +48,7 @@ testthat::test_that("convert_01_ny returns correct character",{
   expect_match(convert_01_ny("00"), "nn")
   expect_match(convert_01_ny("10"), "yn")
   expect_match(convert_01_ny("2"), "2")
-  expect_equal(convert_01_ny(NA), "NA")
+  expect_equal(convert_01_ny(NA), as.character(NA))
   expect_equal(convert_01_ny("NA"), "NA")
   expect_equal(convert_01_ny("a"), "a")
   expect_equal(convert_01_ny("abc"), "abc")

--- a/tests/testthat/test-xamples.R
+++ b/tests/testthat/test-xamples.R
@@ -61,7 +61,7 @@ testthat::test_that("test datasets", {
   # Similar to EX 3 but this time values should be filled in for traits that have a value specified
   Ex4 <- test_build_dataset(file.path(examples.dir, "test2.1-metadata.yml"), file.path(examples.dir, "test3-data.csv"), "Example 4", definitions, unit_conversions, schema, resource_metadata, taxon_list)
   
-  expect_equal(Ex4$traits$basis_of_record %>% unique, c("NA", "lab", "wild"))
+  expect_equal(Ex4$traits$basis_of_record %>% unique, c(NA, "lab", "wild"))
   expect_equal(Ex4$traits %>% filter(is.na(basis_of_record)) %>% nrow(), 352)
   expect_equal(Ex4$traits %>% filter(basis_of_record == "lab") %>% nrow(), 45)
   expect_equal(Ex4$traits %>% filter(basis_of_record == "wild") %>% nrow(), 9)
@@ -78,7 +78,7 @@ testthat::test_that("test datasets", {
   
   expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
                  filter(trait_name == "seed_dry_mass") %>%
-                 pull(basis_of_record) %>% unique, c("NA", "wild"))
+                 pull(basis_of_record) %>% unique, c(NA, "wild"))
   expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
                  filter(trait_name == "seed_dry_mass") %>%
                  pull(basis_of_record) %>% is.na %>% sum, 28)
@@ -92,7 +92,7 @@ testthat::test_that("test datasets", {
   # column values should take precedence followed by traits values, followed by locations and then dataset values
   Ex5 <- test_build_dataset(file.path(examples.dir, "test3-metadata.yml"), file.path(examples.dir, "test3-data.csv"), "Example 5", definitions, unit_conversions, schema, resource_metadata, taxon_list)
   
-  expect_equal(Ex5$traits$basis_of_record %>% unique, c("NA", "lab", "Cape_Tribulation"))
+  expect_equal(Ex5$traits$basis_of_record %>% unique, c(NA, "lab", "Cape_Tribulation"))
   expect_equal(Ex5$traits %>% filter(is.na(basis_of_record)) %>% nrow(), 81)
   expect_equal(Ex5$traits %>% filter(basis_of_record == "Cape_Tribulation") %>% nrow(), 315)
   expect_equal(Ex5$traits %>% filter(basis_of_record == "lab") %>% nrow(), 10)
@@ -111,7 +111,7 @@ testthat::test_that("test datasets", {
                  pull(basis_of_record) %>% grep(pattern ="wild") %>% length, 0)
   
   expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
-                 pull(basis_of_record) %>% unique, c("NA", "lab"))
+                 pull(basis_of_record) %>% unique, c(NA, "lab"))
   expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
                  pull(basis_of_record) %>% length, 91)
   expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%


### PR DESCRIPTION
testthat 3.1.8 outputs NA's without quotes, rather than with quotes. Changed representation of NA in various tests to accommodate this change, as the RMD check was failing on pull requests