### PR TITLE
Becca 90 fix warnings

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -209,14 +209,14 @@ dataset_process <- function(filename_data_raw,
 
   # combine for final output
   list(
-       traits     = traits %>% dplyr::filter(is.na(.data$error)) %>% dplyr::select(-.data$error),
+       traits     = traits %>% dplyr::filter(is.na(.data$error)) %>% dplyr::select(-error),
        locations  = locations,
-       contexts   = context_ids$contexts %>% dplyr::select(-.data$var_in, -.data$find),
+       contexts   = context_ids$contexts %>% dplyr::select(-var_in, -find),
        methods    = methods,
        excluded_data = traits %>% dplyr::filter(!is.na(.data$error)) %>% 
-              dplyr::select(.data$error, everything()),
+              dplyr::select(error, everything()),
        taxonomic_updates = taxonomic_updates,
-       taxa       = taxonomic_updates %>% dplyr::select(taxon_name = .data$cleaned_name) %>% dplyr::distinct(),
+       taxa       = taxonomic_updates %>% dplyr::select(taxon_name = cleaned_name) %>% dplyr::distinct(),
        contributors = contributors,
        sources    = sources,
        definitions = definitions,
@@ -378,7 +378,7 @@ process_create_observation_id <- function(data) {
     dplyr::ungroup() 
   
   data %>%
-    dplyr::select(-.data$check_for_ind)
+    dplyr::select(-check_for_ind)
 }
 
 #' Function to generate seuqnece of integer ids from vector of names
@@ -429,7 +429,7 @@ process_format_contexts <- function(my_list, dataset_id) {
        purrr::map_df(f) %>%
        dplyr::mutate(dataset_id = dataset_id) %>%
        dplyr::select(
-         .data$dataset_id, .data$context_property, .data$category, .data$var_in,
+         dataset_id, context_property, category, var_in,
          dplyr::any_of(c("find", "value", "description"))
        )
 
@@ -453,11 +453,11 @@ process_format_contexts <- function(my_list, dataset_id) {
 process_create_context_ids <- function(data, contexts) {
   # select context_cols
   tmp <- contexts %>%
-    dplyr::select(.data$context_property, .data$var_in) %>%
+    dplyr::select(context_property, var_in) %>%
     dplyr::distinct()
 
   # Extract context columns
-  context_cols <- data %>% dplyr::select(tmp$var_in)
+  context_cols <- data %>% dplyr::select(var_in)
   names(context_cols) <- tmp$context_property
 
   # Find and replace values for each context property
@@ -483,7 +483,7 @@ process_create_context_ids <- function(data, contexts) {
   tmp <-
     contexts %>%
     #  dplyr::filter(category == v) %>%
-    dplyr::select(.data$context_property, .data$category, .data$value) %>%
+    dplyr::select(context_property, category, value) %>%
     dplyr::distinct()
 
   categories <- c("plot", "treatment", "entity_context", "temporal", "method") %>% subset(., . %in% tmp$category)
@@ -516,7 +516,7 @@ process_create_context_ids <- function(data, contexts) {
         id = .data$combined %>%
           as.factor() %>% as.integer() %>% make_id()
       ) %>%
-      dplyr::select(-.data$combined)
+      dplyr::select(-combined)
 
     ## store ids
     ids[[paste0(w, "_id")]] <- xxx[["id"]]
@@ -525,7 +525,7 @@ process_create_context_ids <- function(data, contexts) {
     for (v in vars) {
       id_link[[v]] <-
         xxx %>%
-        dplyr::select(dplyr::all_of(v), .data$id) %>%
+        dplyr::select(dplyr::all_of(v), id) %>%
         dplyr::filter(!is.na(.data$id)) %>%
         dplyr::distinct() %>%
         dplyr::rename(find = v) %>%
@@ -599,7 +599,7 @@ process_format_locations <- function(my_list, dataset_id, schema) {
         TRUE ~ 4)
     ) %>%
     dplyr::arrange(.data$location_id, .data$location_name, .data$i, .data$location_property) %>%
-    dplyr::select(-.data$i)
+    dplyr::select(-i)
   
   out
 }
@@ -1010,7 +1010,7 @@ process_parse_data <- function(data, dataset_id, metadata, contexts) {
                 parsing_id = parsing_id_tmp %>% as.character() %>% 
                 process_generate_id(prefix)
                     ) %>%
-              dplyr::select(-.data$parsing_id_tmp)
+              dplyr::select(-parsing_id_tmp)
   }
 
 
@@ -1226,7 +1226,7 @@ process_format_methods <- function(metadata, dataset_id, sources, contributors) 
         util_list_to_df2() %>%
         dplyr::filter(!is.na(.data$trait_name)) %>%
         dplyr::mutate(dataset_id = dataset_id) %>%
-        dplyr::select(dataset_id, .data$trait_name, .data$methods)
+        dplyr::select(dataset_id, trait_name, methods)
       ,
       # study methods
       metadata$dataset %>%
@@ -1458,15 +1458,15 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
   austraits_raw$taxonomic_updates <-
     austraits_raw$taxonomic_updates %>%
     dplyr::left_join(by = "cleaned_name",
-              taxa %>% dplyr::select(.data$cleaned_name, .data$cleaned_scientific_name_id, .data$cleaned_name_taxonomic_status,
-                                      .data$cleaned_name_alternative_taxonomic_status, .data$taxon_id, .data$taxon_name, .data$taxon_rank)
+              taxa %>% dplyr::select(cleaned_name, cleaned_scientific_name_id, cleaned_name_taxonomic_status,
+                                      cleaned_name_alternative_taxonomic_status, taxon_id, taxon_name, taxon_rank)
               ) %>%
     dplyr::mutate(
       taxonomic_resolution = ifelse(!is.na(.data$taxonomic_resolution) & .data$taxonomic_resolution != .data$taxon_rank, .data$taxon_rank, .data$taxonomic_resolution),
       taxonomic_resolution = ifelse(is.na(.data$taxonomic_resolution), .data$taxon_rank, .data$taxonomic_resolution)
     ) %>%
     dplyr::distinct() %>%
-    dplyr::select(-.data$taxon_rank) %>%
+    dplyr::select(-taxon_rank) %>%
     dplyr::arrange(.data$cleaned_name)
 
 
@@ -1474,14 +1474,14 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
     austraits_raw$traits %>%
     dplyr::rename(cleaned_name = .data$taxon_name) %>%
     dplyr::left_join(by = "cleaned_name",
-              taxa %>% dplyr::select(.data$cleaned_name, .data$taxon_name, .data$taxon_rank)
+              taxa %>% dplyr::select(cleaned_name, taxon_name, taxon_rank)
               ) %>%
-    dplyr::select(.data$dataset_id, .data$taxon_name, dplyr::everything()) %>%
+    dplyr::select(dataset_id, taxon_name, dplyr::everything()) %>%
     dplyr::mutate(
       taxon_name = ifelse(is.na(.data$taxon_name), .data$cleaned_name, .data$taxon_name),
       taxon_name = ifelse(stringr::str_detect(.data$cleaned_name, "\\["), .data$cleaned_name, .data$taxon_name)
     ) %>%
-    dplyr::select(-.data$cleaned_name)
+    dplyr::select(-cleaned_name)
   
 # names, identifiers for all genera
   genera_tmp <- taxa %>% 

--- a/R/process.R
+++ b/R/process.R
@@ -145,8 +145,8 @@ dataset_process <- function(filename_data_raw,
   if( nrow(locations) > 0 ) {
     traits <- 
       traits %>% 
-      dplyr::select(-.data$location_id) %>%
-      dplyr::left_join(by = c("location_name"), locations %>% dplyr::select(.data$location_name, .data$location_id) %>% dplyr::distinct())
+      dplyr::select(-location_id) %>%
+      dplyr::left_join(by = c("location_name"), locations %>% dplyr::select(location_name, location_id) %>% dplyr::distinct())
   }
 
   # Where missing, fill variables in traits table with values from locations
@@ -161,7 +161,7 @@ dataset_process <- function(filename_data_raw,
           dplyr::left_join(by = "location_id",
                             locations %>% 
                             tidyr::pivot_wider(names_from = "location_property", values_from = "value") %>%
-                            dplyr::select(.data$location_id, col_tmp = dplyr::any_of(v)) %>%
+                            dplyr::select(location_id, col_tmp = dplyr::any_of(v)) %>%
                             stats::na.omit()
                           )
       # Use location level value if present
@@ -188,7 +188,7 @@ dataset_process <- function(filename_data_raw,
   # Retrieve taxonomic details for known species
   taxonomic_updates <-
     traits %>%
-    dplyr::select(dataset_id, .data$original_name, cleaned_name = .data$taxon_name, taxonomic_resolution = .data$taxonomic_resolution) %>%
+    dplyr::select(dataset_id, original_name, cleaned_name = taxon_name, taxonomic_resolution = taxonomic_resolution) %>%
     dplyr::distinct() %>%
     dplyr::arrange(.data$cleaned_name)
 

--- a/R/process.R
+++ b/R/process.R
@@ -1486,15 +1486,15 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
 # names, identifiers for all genera
   genera_tmp <- taxa %>% 
     dplyr::filter(.data$taxon_rank %in% c("Genus", "genus")) %>%
-    dplyr::select(name_to_match_to = .data$taxon_name, .data$family, taxonomic_reference_genus = .data$taxonomic_reference, taxon_id_genus = .data$taxon_id,
-                  scientific_name_id_genus = .data$scientific_name_id, taxonomic_status_genus = .data$taxonomic_status) %>%
+    dplyr::select(name_to_match_to = taxon_name, family, taxonomic_reference_genus = taxonomic_reference, taxon_id_genus = taxon_id,
+                  scientific_name_id_genus = scientific_name_id, taxonomic_status_genus = taxonomic_status) %>%
     dplyr::distinct()
   
 # names, identifiers for all families in APC
   families_tmp <- taxa %>% 
     dplyr::filter(.data$taxon_rank %in% c("Familia", "family")) %>%
-    dplyr::select(name_to_match_to = .data$taxon_name, taxonomic_reference_family = .data$taxonomic_reference, taxon_id_family = .data$taxon_id,
-    scientific_name_id_family = .data$scientific_name_id, taxonomic_status_family = .data$taxonomic_status) %>%
+    dplyr::select(name_to_match_to = taxon_name, taxonomic_reference_family = taxonomic_reference, taxon_id_family = taxon_id,
+    scientific_name_id_family = scientific_name_id, taxonomic_status_family = taxonomic_status) %>%
     dplyr::distinct()
   
 ### Fill in columns for trinomial, binomial, genus, and family, as appropriate 
@@ -1502,11 +1502,11 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
 
   species_tmp <-
     austraits_raw$traits %>%
-    dplyr::select(.data$taxon_name, .data$taxonomic_resolution) %>%
+    dplyr::select(taxon_name, taxonomic_resolution) %>%
     dplyr::distinct() %>% 
     util_df_convert_character() %>%
     dplyr::left_join(by = "taxon_name",
-                     taxa %>% dplyr::select(.data$taxon_name, .data$taxon_rank, .data$family) %>% dplyr::distinct() %>% util_df_convert_character()
+                     taxa %>% dplyr::select(taxon_name, taxon_rank, family) %>% dplyr::distinct() %>% util_df_convert_character()
     ) 
 
 
@@ -1560,13 +1560,13 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
         taxon_distribution = ifelse(.data$taxon_rank %in% c("Familia", "family", "Genus", "genus"), NA, .data$taxon_distribution),
         establishment_means = ifelse(.data$taxon_rank %in% c("Familia", "family", "Genus", "genus"), NA, .data$establishment_means)
       ) %>% 
-      dplyr::select(-.data$taxon_id_genus, -.data$taxon_id_family, -.data$scientific_name_id_genus, -.data$scientific_name_id_family, 
-                    -.data$taxonomic_status_genus, -.data$taxonomic_status_family, -.data$taxonomic_reference_genus, -.data$taxonomic_reference_family,
-                    -.data$name_to_match_to, -.data$family_tmp) %>%
-      dplyr::select(.data$taxon_name, .data$taxonomic_reference, .data$taxon_rank, .data$trinomial, .data$binomial, 
-                    .data$genus, .data$family, .data$taxon_distribution, .data$establishment_means, 
-                    .data$taxonomic_status, .data$scientific_name, .data$scientific_name_authorship, .data$taxon_id, 
-                    .data$scientific_name_id)
+      dplyr::select(-taxon_id_genus, -taxon_id_family, -scientific_name_id_genus, -scientific_name_id_family, 
+                    -taxonomic_status_genus, -taxonomic_status_family, -taxonomic_reference_genus, -taxonomic_reference_family,
+                    -name_to_match_to, -family_tmp) %>%
+      dplyr::select(taxon_name, taxonomic_reference, taxon_rank, trinomial, binomial, 
+                    genus, family, taxon_distribution, establishment_means, 
+                    taxonomic_status, scientific_name, scientific_name_authorship, taxon_id, 
+                    scientific_name_id)
 
   austraits_raw$taxa <-
     species_tmp %>%
@@ -1578,11 +1578,11 @@ build_update_taxonomy <- function(austraits_raw, taxa) {
 
   austraits_raw$traits <-
     austraits_raw$traits %>%
-      dplyr::select(-.data$taxonomic_resolution, -.data$taxon_rank)
+      dplyr::select(-taxonomic_resolution, -taxon_rank)
 
   austraits_raw$excluded_data <-
     austraits_raw$excluded_data %>%
-      dplyr::select(-.data$taxonomic_resolution)
+      dplyr::select(-taxonomic_resolution)
 
   austraits_raw  
 }

--- a/R/process.R
+++ b/R/process.R
@@ -429,7 +429,7 @@ process_format_contexts <- function(my_list, dataset_id) {
        my_list %>%
        purrr::map_df(f) %>%
        dplyr::mutate(dataset_id = dataset_id) %>%
-       dplyr::select(dplyr::all_of(
+       dplyr::select(dplyr::any_of(
          c("dataset_id", "context_property", "category", "var_in",
          "find", "value", "description"))
          )

--- a/R/process.R
+++ b/R/process.R
@@ -457,7 +457,7 @@ process_create_context_ids <- function(data, contexts) {
     dplyr::distinct()
 
   # Extract context columns
-  context_cols <- data %>% dplyr::select(var_in)
+  context_cols <- data %>% dplyr::select(tmp$var_in)
   names(context_cols) <- tmp$context_property
 
   # Find and replace values for each context property

--- a/R/setup.R
+++ b/R/setup.R
@@ -814,11 +814,11 @@ build_find_taxon <- function(taxon_name, austraits, original_name = FALSE) {
 
   if (!original_name) {
     data <- data %>%
-      dplyr::select(name = taxon_name, .data$dataset_id) %>%
+      dplyr::select(name = taxon_name, dataset_id) %>%
       dplyr::distinct()
   } else {
     data <- data %>%
-      dplyr::select(name = original_name, .data$dataset_id) %>%
+      dplyr::select(name = original_name, dataset_id) %>%
       dplyr::distinct()
   }
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -814,11 +814,13 @@ build_find_taxon <- function(taxon_name, austraits, original_name = FALSE) {
 
   if (!original_name) {
     data <- data %>%
-      dplyr::select(dplyr::all_of(name = "taxon_name", "dataset_id")) %>%
+      dplyr::select(dplyr::all_of("taxon_name", "dataset_id")) %>%
+      rename(name = taxon_name) %>%
       dplyr::distinct()
   } else {
     data <- data %>%
-      dplyr::select(dplyr::all_of(name = "original_name", "dataset_id")) %>%
+      dplyr::select(dplyr::all_of("original_name", "dataset_id")) %>%
+      dplyr::rename(name = original_name) %>%
       dplyr::distinct()
   }
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -246,11 +246,11 @@ metadata_add_locations <- function(dataset_id, location_data) {
   location_name <- metadata_user_select_column("location_name", names(location_data))
 
   # From remaining variables, choose those to keep
-  location_sub <- dplyr::select(location_data, -!!location_name)
+  location_sub <- dplyr::select(dplyr::all_of(c("location_data"), -!!location_name))
   keep <- metadata_user_select_names(paste("Indicate all columns you wish to keep as distinct location_properties in ", dataset_id), names(location_sub))
 
   # Save and notify
-  metadata$locations <- dplyr::select(location_data, tidyr::one_of(keep)) %>%
+  metadata$locations <- dplyr::select(dplyr::all_of(c("location_data"), tidyr::one_of(keep))) %>%
             split(location_data[[location_name]]) %>% lapply(as.list)
 
   cat(sprintf("Following locations added to metadata for %s: %s\n\twith variables %s.\n\tPlease complete information in %s.\n\n", dataset_id, crayon::red(paste(names( metadata$locations), collapse = ", ")), crayon::red(paste(keep, collapse = ", ")), dataset_id %>% metadata_path_dataset_id()))
@@ -814,11 +814,11 @@ build_find_taxon <- function(taxon_name, austraits, original_name = FALSE) {
 
   if (!original_name) {
     data <- data %>%
-      dplyr::select(name = taxon_name, dataset_id) %>%
+      dplyr::select(dplyr::all_of(name = "taxon_name", "dataset_id")) %>%
       dplyr::distinct()
   } else {
     data <- data %>%
-      dplyr::select(name = original_name, dataset_id) %>%
+      dplyr::select(dplyr::all_of(name = "original_name", "dataset_id")) %>%
       dplyr::distinct()
   }
 

--- a/tests/testthat/functions.R
+++ b/tests/testthat/functions.R
@@ -87,7 +87,7 @@ test_build_dataset <- function(path_metadata, path_data, info, definitions, unit
   expect_no_error({
     build_config <- dataset_configure(path_metadata, definitions, unit_conversions)
   }, info = paste(info, " config"))
-  
+
   expect_no_error({
     build_dataset_raw <- dataset_process(path_data, build_config, schema, resource_metadata)
   }, info = paste(info, " dataset_process"))
@@ -95,7 +95,7 @@ test_build_dataset <- function(path_metadata, path_data, info, definitions, unit
   expect_no_error({
     build_dataset <- build_update_taxonomy(build_dataset_raw, taxon_list)
   }, info = paste(info, " update taxonomy"))
-  
+
   test_structure(build_dataset, info, schema, definitions, single_dataset = TRUE)
   
   build_dataset

--- a/tests/testthat/test-xamples.R
+++ b/tests/testthat/test-xamples.R
@@ -33,10 +33,10 @@ testthat::test_that("test datasets", {
   expect_equal(Ex2$traits$basis_of_record %>% unique, c("field", "lab"))
   expect_equal(Ex2$traits %>% filter(basis_of_record == "field") %>% nrow(), 361)
   expect_equal(Ex2$traits %>% filter(basis_of_record == "lab") %>% nrow(), 45)
-  expect_equal(Ex2$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex2$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% unique, "lab")
-  expect_equal(Ex2$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex2$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% length, 45)
   
@@ -66,23 +66,23 @@ testthat::test_that("test datasets", {
   expect_equal(Ex4$traits %>% filter(basis_of_record == "lab") %>% nrow(), 45)
   expect_equal(Ex4$traits %>% filter(basis_of_record == "wild") %>% nrow(), 9)
   
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% unique, c("lab"))
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% grep(pattern = "lab") %>% length , 45)
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% grep(pattern = "wild") %>% length , 0)
   
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "seed_dry_mass") %>%
                  pull(basis_of_record) %>% unique, c(NA, "wild"))
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "seed_dry_mass") %>%
                  pull(basis_of_record) %>% is.na %>% sum, 28)
-  expect_equal(Ex4$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex4$traits %>% select(dplyr::all_of(c("trait_name", "basis_of_record"))) %>% 
                  filter(trait_name == "seed_dry_mass") %>%
                  pull(basis_of_record) %>% grep(pattern = "wild") %>% length , 1)
   
@@ -98,40 +98,40 @@ testthat::test_that("test datasets", {
   expect_equal(Ex5$traits %>% filter(basis_of_record == "lab") %>% nrow(), 10)
   expect_equal(Ex5$traits %>% filter(basis_of_record == "wild") %>% nrow(), 0)
   
-  expect_equal(Ex5$traits %>% select(taxon_name, basis_of_record) %>% 
+  expect_equal(Ex5$traits %>% select(c("taxon_name", "basis_of_record")) %>% 
                  filter(taxon_name == "Trema aspera") %>% pull(basis_of_record) %>% unique, c("Cape_Tribulation"))
-  expect_equal(Ex5$traits %>% select(taxon_name, basis_of_record) %>% 
+  expect_equal(Ex5$traits %>% select(c("taxon_name", "basis_of_record")) %>% 
                  filter(taxon_name == "Trema aspera") %>% pull(basis_of_record) %>% length, 10)
   
-  expect_equal(Ex5$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex5$traits %>% select(c("trait_name", "basis_of_record")) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% grep(pattern ="lab") %>% length, 10)
-  expect_equal(Ex5$traits %>% select(trait_name, basis_of_record) %>% 
+  expect_equal(Ex5$traits %>% select(c("trait_name", "basis_of_record")) %>% 
                  filter(trait_name == "leaf_N_per_dry_mass") %>%
                  pull(basis_of_record) %>% grep(pattern ="wild") %>% length, 0)
   
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "01") %>%
                  pull(basis_of_record) %>% unique, c(NA, "lab"))
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "01") %>%
                  pull(basis_of_record) %>% length, 91)
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "01") %>%
                  pull(basis_of_record) %>% is.na %>% sum, 81)
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "01") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "01") %>%
                  pull(basis_of_record) %>% grep(pattern = "lab") %>% length, 10)
   
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "02") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "02") %>%
                  pull(basis_of_record) %>% unique, c("Cape_Tribulation"))
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "02") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "02") %>%
                  pull(basis_of_record) %>% length, 315)
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "02") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "02") %>%
                  pull(basis_of_record) %>% grep(pattern = "Cape_Tribulation") %>% length, 315)
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "02") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "02") %>%
                  pull(basis_of_record) %>% grep(pattern = "lab") %>% length, 0)
-  expect_equal(Ex5$traits %>% select(location_id, basis_of_record) %>% filter(location_id == "02") %>%
+  expect_equal(Ex5$traits %>% select(c("location_id", "basis_of_record")) %>% filter(location_id == "02") %>%
                  pull(basis_of_record) %>% grep(pattern = "wild") %>% length, 0)
   
   expect_equal(Ex5$traits %>% pull(location_id) %>% unique, Ex5$locations %>% pull(location_id) %>% unique)
-  expect_equal(Ex5$traits %>% select(location_id) %>% unique() %>% nrow(), Ex5$locations %>% select(location_name) %>% unique() %>% nrow())
+  expect_equal(Ex5$traits %>% select(c("location_id")) %>% unique() %>% nrow(), Ex5$locations %>% select(c("location_name")) %>% unique() %>% nrow())
 
   # Example 6 - Tests focus on context and the various context identifiers
   # Based on Crous_2013


### PR DESCRIPTION
Extends PR #722 from @Becca-90, addressing #620 . As noted there

There have been some changes to syntax in some dplyr functions.
Specifically, use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.
It is also necessary in some circumstances to use either the ```all_of()``` or ```any_of()``` function with the ```select()``` function

See:
1. https://cran.r-project.org/web/packages/tidyselect/news/news.html
2. https://tidyselect.r-lib.org/reference/faq-external-vector.html

There also seems to be a problem using .data in the ```rename()``` function, changing this removed about 20 more warnings.

All select syntax has now been updated in the austraits/R folder of functions, most warnings have now gone but there are still 4 referring to line 140 of test-xamples.R that all say:

```
data %>% select(v)
```

should be changed to either:

```
data %>% select(all_of(v))
```
or
```
data %>% select(any_of(v))
```

Line 140 in test-xamples.R uses the function test_build_dataset