### PR TITLE
Address potential data mistakes flagged by ANU students

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -4341,7 +4341,7 @@ traits:
         (at dispersal, mature); 'air dried' (at local ambient conditions); 'seed bank
         air dried' (to 15% relative humidity); and 'oven dried' (>100 deg C for a
         set number of hours; e.g. seed bank standard is 103 deg C for 17 hours). It
-        is expected that some observations in AusTraits mapped onto â€˜seed_dry_mass'
+        is expected that some observations in AusTraits mapped onto 'seed_dry_mass'
         will actually include both the seed and some dispersal tissue, if the two
         cannot easily be separated; these should be mapped to 'diaspore_dry_mass'.
       type: numeric
@@ -6720,7 +6720,7 @@ traits:
         their host plant. The trait `root_structures` includes specialised root structures
       type: categorical
       allowed_values_levels:
-        saprophyte: Plant that acquires nutrients from decaying biomass.        
+        saprophyte: Plant that acquires nutrients from decaying biomass.
         carnivorous: Plant that acquires some or most of its nutrients from animals or protozoa.
         nutrient_mining: Plant that uses a specialised root structure, such as cluster roots, to mine nutrients inaccessible to other plant taxa.
       entity_URI: https://w3id.org/APD/traits/trait_0030017

--- a/data/ABRS_1981/data.csv
+++ b/data/ABRS_1981/data.csv
@@ -13086,7 +13086,7 @@ Aloe parvibracteata,leaf length maximum,cm,40
 Aloe saponaria,leaf length maximum,cm,16
 Aloe vera,leaf length maximum,cm,60
 Alpinia arctiflora,leaf length maximum,cm,50
-Alpinia arundelliana,leaf length maximum,cm,25
+Alpinia arundelliana,leaf length maximum,mm,25
 Alpinia coerulea,leaf length maximum,cm,40
 Alpinia hylandii,leaf length maximum,cm,16
 Alpinia modesta,leaf length maximum,cm,30
@@ -13603,7 +13603,7 @@ Choretrum glomeratum var. glomeratum,leaf length maximum,,
 Choretrum lateriflorum,leaf length maximum,mm,2
 Choretrum pauciflorum,leaf length maximum,mm,1
 Choretrum pritzelii,leaf length maximum,mm,1.5
-Choretrum spicatum,leaf length maximum,cm,2.5
+Choretrum spicatum,leaf length maximum,mm,2.5
 Cinnamomum baileyanum,leaf length maximum,cm,13
 Cinnamomum laubatii,leaf length maximum,cm,14.5
 Cinnamomum oliveri,leaf length maximum,cm,17
@@ -13794,7 +13794,7 @@ Coopernookia chisholmii,leaf length maximum,cm,9
 Coopernookia georgei,leaf length maximum,cm,5
 Coopernookia polygalacea,leaf length maximum,cm,30
 Coopernookia scabridiuscula,leaf length maximum,cm,8
-Coopernookia strophiolata,leaf length maximum,cm,35
+Coopernookia strophiolata,leaf length maximum,mm,35
 Cordyline cannifolia,leaf length maximum,cm,50
 Cordyline congesta,leaf length maximum,cm,40
 Cordyline fruticosa,leaf length maximum,cm,80
@@ -14573,14 +14573,14 @@ Gonocarpus humilis,leaf length maximum,mm,18
 Gonocarpus implexus,leaf length maximum,mm,11
 Gonocarpus intricatus,leaf length maximum,cm,1.3
 Gonocarpus leptothecus,leaf length maximum,mm,30
-Gonocarpus longifolius,leaf length maximum,cm,25
+Gonocarpus longifolius,leaf length maximum,mm,25
 Gonocarpus mezianus,leaf length maximum,mm,17
 Gonocarpus micranthus,leaf length maximum,mm,13
 Gonocarpus micranthus subsp. micranthus,leaf length maximum,mm,7
 Gonocarpus micranthus subsp. ramosissimus,leaf length maximum,mm,13
 Gonocarpus montanus,leaf length maximum,mm,6
 Gonocarpus nodulosus,leaf length maximum,mm,6
-Gonocarpus oreophilus,leaf length maximum,cm,35
+Gonocarpus oreophilus,leaf length maximum,mm,35
 Gonocarpus paniculatus,leaf length maximum,cm,5
 Gonocarpus pithyoides,leaf length maximum,mm,15
 Gonocarpus pusillus,leaf length maximum,mm,8
@@ -17130,7 +17130,7 @@ Viscum whitei,leaf length maximum,cm,5.5
 Viscum whitei subsp. flexicaule,leaf length maximum,cm,5
 Viscum whitei subsp. whitei,leaf length maximum,cm,4
 Watsonia versfeldii var. alba,leaf length maximum,cm,120
-Wikstroemia indica,leaf length maximum,cm,80
+Wikstroemia indica,leaf length maximum,mm,80
 Wilkiea angustifolia,leaf length maximum,cm,21
 Wilkiea austroqueenslandica,leaf length maximum,cm,21
 Wilkiea cordata,leaf length maximum,cm,26
@@ -17389,7 +17389,7 @@ Aloe parvibracteata,leaf length minimum,cm,30
 Aloe saponaria,leaf length minimum,cm,12
 Aloe vera,leaf length minimum,cm,40
 Alpinia arctiflora,leaf length minimum,,
-Alpinia arundelliana,leaf length minimum,cm,12
+Alpinia arundelliana,leaf length minimum,mm,12
 Alpinia coerulea,leaf length minimum,,
 Alpinia hylandii,leaf length minimum,cm,10
 Alpinia modesta,leaf length minimum,cm,10
@@ -17906,7 +17906,7 @@ Choretrum glomeratum var. glomeratum,leaf length minimum,,
 Choretrum lateriflorum,leaf length minimum,mm,1
 Choretrum pauciflorum,leaf length minimum,mm,0.5
 Choretrum pritzelii,leaf length minimum,,
-Choretrum spicatum,leaf length minimum,mm,15
+Choretrum spicatum,leaf length minimum,mm,1.5
 Cinnamomum baileyanum,leaf length minimum,cm,5
 Cinnamomum laubatii,leaf length minimum,cm,8
 Cinnamomum oliveri,leaf length minimum,cm,8.5
@@ -18097,7 +18097,7 @@ Coopernookia chisholmii,leaf length minimum,cm,4
 Coopernookia georgei,leaf length minimum,cm,2
 Coopernookia polygalacea,leaf length minimum,cm,12
 Coopernookia scabridiuscula,leaf length minimum,cm,4
-Coopernookia strophiolata,leaf length minimum,cm,10
+Coopernookia strophiolata,leaf length minimum,mm,10
 Cordyline cannifolia,leaf length minimum,cm,20
 Cordyline congesta,leaf length minimum,cm,30
 Cordyline fruticosa,leaf length minimum,cm,25
@@ -18876,14 +18876,14 @@ Gonocarpus humilis,leaf length minimum,mm,11
 Gonocarpus implexus,leaf length minimum,mm,6
 Gonocarpus intricatus,leaf length minimum,cm,1
 Gonocarpus leptothecus,leaf length minimum,mm,25
-Gonocarpus longifolius,leaf length minimum,cm,15
+Gonocarpus longifolius,leaf length minimum,mm,15
 Gonocarpus mezianus,leaf length minimum,mm,7
 Gonocarpus micranthus,leaf length minimum,mm,3
 Gonocarpus micranthus subsp. micranthus,leaf length minimum,mm,3
 Gonocarpus micranthus subsp. ramosissimus,leaf length minimum,mm,10
 Gonocarpus montanus,leaf length minimum,mm,3.5
 Gonocarpus nodulosus,leaf length minimum,mm,3
-Gonocarpus oreophilus,leaf length minimum,cm,10
+Gonocarpus oreophilus,leaf length minimum,mm,10
 Gonocarpus paniculatus,leaf length minimum,cm,2
 Gonocarpus pithyoides,leaf length minimum,mm,10
 Gonocarpus pusillus,leaf length minimum,mm,7

--- a/data/ABRS_1981/metadata.yml
+++ b/data/ABRS_1981/metadata.yml
@@ -17,7 +17,7 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: yes
-  custom_R_code:        '
+  custom_R_code: '
     data$i <- seq_len(nrow(data));
 
     data_numeric <- data %>%
@@ -83,13 +83,13 @@ dataset:
             value = ifelse(species_name %in% c("Stephania japonica var. discolor") &  trait == "lifeform","vine",value),
             value = ifelse(species_name %in% c("Caesalpinia subtropica") & trait == "lifeform","climber_woody",value),
             trait = ifelse(value %in% c("HE", "A", "E"), "plant_growth_substrate", trait),
-            value = ifelse(stringr::str_detect(species_name, "^Xanthorrhoea") & 
+            value = ifelse(stringr::str_detect(species_name, "^Xanthorrhoea") &
             stringr::str_detect(trait, "^leaf length"), NA, value)
       ) %>%
       group_by(species_name, trait) %>%
         distinct(value, .keep_all = TRUE) %>%
       ungroup()
-  '
+    '
   collection_date: unknown/2015
   taxon_name: species_name
   trait_name: trait
@@ -100,7 +100,10 @@ dataset:
   sampling_strategy: herbarium specimens
   original_file: STU
   notes: Request ackowledgment "Data was sourced from the Flora of Australia with
-    permission from the Australian Biological Resources Study"
+    permission from the Australian Biological Resources Study"; Choretrum spicatum
+    leaf_length in data.csv corrected to 15 to 1.5, leaf_length units corrected for
+    Alpinia arundelliana, Choretrum spicatum, Coopernookia strophiolata, Gonocarpus
+    longifolius, Gonocarpus oreophilus, Wikstroemia indica, due to likely typos.
 locations: .na
 contexts: .na
 traits:

--- a/data/ABRS_2023/metadata.yml
+++ b/data/ABRS_2023/metadata.yml
@@ -136,7 +136,7 @@ contexts:
     description: Trait value inferred from the value of a different trait.
   - value: inferred_from_taxonomy
     description: Trait value inferred from a higher level taxon description.
-- context_property: entity_measured
+- context_property: entity measured
   category: method_context
   var_in: entity_measured
 - context_property: replicate observations

--- a/data/Briggs_2010/metadata.yml
+++ b/data/Briggs_2010/metadata.yml
@@ -26,7 +26,13 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:        data %>% mutate(site_name = "Terrick Terrick National Park")
+  custom_R_code:   '
+    data %>%
+      mutate(
+        site_name = "Terrick Terrick National Park",
+        `Seed mass (mg)` = `Seed mass (mg)`/50
+      )
+    '
   collection_date: 2007/2007
   taxon_name: Scientific Name
   location_name: site_name
@@ -41,7 +47,8 @@ dataset:
     database.xls" extracted. Original copy of the excel file located in Google Drive
     in the folder "Morgan_2011_1 Morgan_2011_2 Morgan_2014 Angevin_2010 Briggs_2010
     Cross_2011 Lunt_2012 Roberts_2006 Scott_2010"
-  notes: none
+  notes: Divided all seed mass measurements by 50 (the number of replicates) as otherwise
+    the measurements are outliers (seem to be off by 50 times).
 locations:
   Terrick Terrick National Park:
     latitude (deg): -36.1738

--- a/data/Kew_2019_1/metadata.yml
+++ b/data/Kew_2019_1/metadata.yml
@@ -46,21 +46,21 @@ dataset:
             "REFERENCE: ", original_dataset_id
         ),
         measurement_remarks = stringr::str_replace(
-            measurement_remarks, 
+            measurement_remarks,
             "MATERIAL: NA; ", ""),
         measurement_remarks = stringr::str_replace(
-            measurement_remarks, 
+            measurement_remarks,
             "NOTES: NA; ", "")
-      ) %>% 
-      filter(!original_dataset_id %in% c("Jurado_1991", "Moles_2000", "Milberg_1998")) %>% 
-      arrange(taxa, materialweigheddesc, thousandseedweight, original_dataset_id) %>% 
+      ) %>%
+      filter(!original_dataset_id %in% c("Jurado_1991", "Moles_2000", "Milberg_1998")) %>%
+      arrange(taxa, materialweigheddesc, thousandseedweight, original_dataset_id) %>%
       group_by(taxa, materialweigheddesc, thousandseedweight, seedweightnotes, weightprecision) %>%
       mutate(merged_ref = ifelse(length(unique(original_dataset_id)) == 1, original_dataset_id, paste0(original_dataset_id, collapse = "; "))) %>%
-      ungroup() %>% 
+      ungroup() %>%
       group_by(taxa, merged_ref) %>%
-      mutate(across(c(thousandseedweight, materialweigheddesc), replace_duplicates_with_NA)) %>% 
+      mutate(across(c(thousandseedweight, materialweigheddesc), replace_duplicates_with_NA)) %>%
       ungroup()
-  '
+    '
   collection_date: unknown/2019
   taxon_name: taxa
   source_id: original_dataset_id

--- a/data/Kew_2019_1/metadata.yml
+++ b/data/Kew_2019_1/metadata.yml
@@ -16,7 +16,7 @@ contributors:
   dataset_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:        '
+  custom_R_code: '
     data %>%
       mutate(
         ref_year = stringr::str_extract(refshort, "(?<!\\d)\\d{4}(?!\\d)"),
@@ -50,7 +50,17 @@ dataset:
             "MATERIAL: NA; ", ""),
         measurement_remarks = stringr::str_replace(
             measurement_remarks,
-            "NOTES: NA; ", "")
+            "NOTES: NA; ", ""),
+        seed_mass_method = case_when(
+          stringr::str_detect(seedweightnotes, "wet mass") ~ "Weight refers to wet mass of mature seed.",
+          stringr::str_detect(seedweightnotes, "air-dry|air dry|Air-dry") ~ "Weight refers to the air-dried mass of mature seed.",
+          stringr::str_detect(seedweightnotes, "oven dry|dried at|dried to|dried in|dried for") ~ "Weight refers to the oven-dried mass of mature seed.",
+          stringr::str_detect(seedweightnotes, "fresh|Fresh") ~ "Weight refers to fresh mass of mature seed.",
+          stringr::str_detect(seedweightnotes, "mean weight of 20 dry seeds|Dired seed") ~ "Weight refers to dry mass of mature seed.",
+          stringr::str_detect(seedweightnotes, "dry weight") & stringr::str_detect(seedweightnotes, "SE=") ~ "Weight refers to dry mass of mature seed.",
+          seedweightnotes %in% c("Dry weight", "Dry weight.", "dry", "Weight refers to seed dry mass", "Seed dry-weight.") ~ "Weight refers to dry mass of mature seed.",
+          TRUE ~ "Weight probably refers to dry mass (see measurement remarks)."
+        )
       ) %>%
       filter(!original_dataset_id %in% c("Jurado_1991", "Moles_2000", "Milberg_1998")) %>%
       arrange(taxa, materialweigheddesc, thousandseedweight, original_dataset_id) %>%
@@ -74,7 +84,29 @@ dataset:
   notes: Data provided for inclusion in AusTraits and subsequent reuse under a Creative
     Commons license. Data not to be used for Commercial Purposes.
 locations: .na
-contexts: .na
+contexts:
+- context_property: seed mass method
+  category: method_context
+  var_in: seed_mass_method
+  values:
+  - find: Weight probably refers to dry mass (see measurement remarks).
+    value: dry mass (assumed)
+    description: Weight probably refers to dry mass (see measurement remarks).
+  - find: Weight refers to the air-dried mass of mature seed.
+    value: air-dried mass
+    description: Weight refers to the air-dried mass of mature seed.
+  - find: Weight refers to the oven-dried mass of mature seed.
+    value: oven-dried mass
+    description: Weight refers to the oven-dried mass of mature seed.
+  - find: Weight refers to dry mass of mature seed.
+    value: dry mass
+    description: Weight refers to dry mass of mature seed.
+  - find: Weight refers to fresh mass of mature seed.
+    value: fresh mass
+    description: Weight refers to fresh mass of mature seed.
+  - find: Weight refers to wet mass of mature seed.
+    value: wet mass
+    description: Weight refers to wet mass of mature seed.
 traits:
 - var_in: thousandseedweight
   unit_in: mg

--- a/data/Kew_2019_1/metadata.yml
+++ b/data/Kew_2019_1/metadata.yml
@@ -59,8 +59,9 @@ dataset:
           stringr::str_detect(seedweightnotes, "mean weight of 20 dry seeds|Dired seed") ~ "Weight refers to dry mass of mature seed.",
           stringr::str_detect(seedweightnotes, "dry weight") & stringr::str_detect(seedweightnotes, "SE=") ~ "Weight refers to dry mass of mature seed.",
           seedweightnotes %in% c("Dry weight", "Dry weight.", "dry", "Weight refers to seed dry mass", "Seed dry-weight.") ~ "Weight refers to dry mass of mature seed.",
-          TRUE ~ "Weight probably refers to dry mass (see measurement remarks)."
-        )
+          TRUE ~ "Weight probably refers to dry mass (see measurement remarks)."),
+        thousandseedweight = ifelse(taxa == "Angophora bakeri", thousandseedweight/1000, thousandseedweight)
+
       ) %>%
       filter(!original_dataset_id %in% c("Jurado_1991", "Moles_2000", "Milberg_1998")) %>%
       arrange(taxa, materialweigheddesc, thousandseedweight, original_dataset_id) %>%
@@ -82,7 +83,8 @@ dataset:
   original_file: in raw data folder
   measurement_remarks: merged_ref
   notes: Data provided for inclusion in AusTraits and subsequent reuse under a Creative
-    Commons license. Data not to be used for Commercial Purposes.
+    Commons license. Data not to be used for Commercial Purposes. Seed weight for Angophora
+    bakeri divided by 1000 in custom_R_code due to extreme outlier.
 locations: .na
 contexts:
 - context_property: seed mass method

--- a/data/Kooyman_2011/metadata.yml
+++ b/data/Kooyman_2011/metadata.yml
@@ -38,7 +38,11 @@ dataset:
         `leaf width minimum (mm)` = ifelse(is.na(leaf_width_min_duplicate),`leaf width minimum (mm)`,NA),
         `leaf width maximum (mm)` = ifelse(is.na(leaf_width_max_duplicate),`leaf width maximum (mm)`,NA),
         `leaf length minimum (mm)` = ifelse(is.na(leaf_length_min_duplicate),`leaf length minimum (mm)`,NA),
-        `leaf length maximum (mm)` = ifelse(is.na(leaf_length_max_duplicate),`leaf length maximum (mm)`,NA)
+        `leaf length maximum (mm)` = ifelse(is.na(leaf_length_max_duplicate),`leaf length maximum (mm)`,NA),
+        `seed length minimum (mm)` = ifelse(`Species_reconciled with updates and additions` == "Rhizophora mucronata", NA, `seed length minimum (mm)`),
+        `seed length maximum (mm)` = ifelse(`Species_reconciled with updates and additions` == "Rhizophora mucronata", NA, `seed length maximum (mm)`),
+        `seed width minimum (mm)` = ifelse(`Species_reconciled with updates and additions` == "Rhizophora mucronata", NA, `seed width minimum (mm)`),
+        `seed width maximum (mm)` = ifelse(`Species_reconciled with updates and additions` == "Rhizophora mucronata", NA, `seed width maximum (mm)`)
       ) %>%
       select(-`seed size categorical: <10mm`,-`seed size categorical: >10mm`,
       `wood density genus`, `wood density family`, -seed_width_min_duplicate, - seed_width_max_duplicate,
@@ -126,7 +130,8 @@ dataset:
     of the five areas; Cape York (CY) andWet Tropics (WT) in Qld, and Nightcap-Border
     Ranges (NB), Dorrigo (DO) and Washpool (WA) in NSW.
   original_file: Aust_RF_Traits_Kooyman_original.xls
-  notes: none
+  notes: Excluded seed widths and lengths for Rhizophora mucronata as seed length
+    seems to be for hypocotyl according to Flora of Australia.
 locations: .na
 contexts: .na
 traits:

--- a/data/Kooyman_2011/metadata.yml
+++ b/data/Kooyman_2011/metadata.yml
@@ -21,7 +21,7 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:          '
+  custom_R_code: '
     data %>%
       group_by(`Species_reconciled with updates and additions`) %>%
         mutate(across(c(`seed length maximum (mm)`,`seed length minimum (mm)`,

--- a/data/Laxton_2005/metadata.yml
+++ b/data/Laxton_2005/metadata.yml
@@ -22,10 +22,10 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:        '
+  custom_R_code: '
     data %>%
       mutate(SITE_ID = ifelse(is.na(SITE_ID),"unknown", SITE_ID))
-  '
+    '
   collection_date: 2002/2004
   taxon_name: species_name
   location_name: SITE_ID

--- a/data/Leishman_2007/metadata.yml
+++ b/data/Leishman_2007/metadata.yml
@@ -24,14 +24,14 @@ contributors:
 dataset:
   data_is_long_format: no
   custom_R_code:          '
-    data %>% 
+    data %>%
       mutate(
         across(c(`gs (molm-2s-1)`), ~na_if(.x, 0)),
         entity_to_use = ifelse(is.na(Replicate),"population","individual"),
         value_type_to_use = ifelse(is.na(Replicate),"mean","raw"),
         replicates_to_use = ifelse(is.na(Replicate),"3","1")
       )
-  '
+    '
   collection_date: unknown/2007
   taxon_name: Species
   location_name: site

--- a/data/McGlone_2015/data.csv
+++ b/data/McGlone_2015/data.csv
@@ -1136,7 +1136,7 @@ narrow endemic,victoria,tasmania,forest,family,species name,ht (m),ll (mm),lw (m
 0,0,1,1,Rutaceae,Acradenia frankliniae,10,70,10,compound,tree,NA,NA,Tasmania,Tassie_no_climbers,NA,NA,Tasmania,,Tasmania
 0,1,0,0,Cupressaceae,Callitris endlicheri,15,1,1,scale,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,0,Cupressaceae,Callitris glaucophylla,20,1,1,scale,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
-0,1,0,0,Gyrostemonaceae,Gyrostemon australasicus,,25,1.5,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
+0,1,0,0,Gyrostemonaceae,Gyrostemon australasicus,10,25,1.5,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 1,1,0,1,Araliaceae,Polyscias murrayi,24,160,90,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,1,Cunoniaceae,Eucryphia moorei,20,60,20,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,1,Elaeocarpaceae,Elaeocarpus holopetalus,16,70,30,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
@@ -1163,7 +1163,7 @@ narrow endemic,victoria,tasmania,forest,family,species name,ht (m),ll (mm),lw (m
 0,1,0,NA,Fabaceae,Acacia loderi,15,110,2,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia maidenii,12,180,22,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia melvillei,15,105,25,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
-0,1,0,NA,Fabaceae,Acacia mitchellii,,8,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
+0,1,0,NA,Fabaceae,Acacia mitchellii,30,8,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia nanodealbata,6,2.5,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia obliquinervia,15,170,50,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia obtusifolia,15,250,23,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria

--- a/data/McGlone_2015/data.csv
+++ b/data/McGlone_2015/data.csv
@@ -1136,7 +1136,7 @@ narrow endemic,victoria,tasmania,forest,family,species name,ht (m),ll (mm),lw (m
 0,0,1,1,Rutaceae,Acradenia frankliniae,10,70,10,compound,tree,NA,NA,Tasmania,Tassie_no_climbers,NA,NA,Tasmania,,Tasmania
 0,1,0,0,Cupressaceae,Callitris endlicheri,15,1,1,scale,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,0,Cupressaceae,Callitris glaucophylla,20,1,1,scale,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
-0,1,0,0,Gyrostemonaceae,Gyrostemon australasicus,10,25,1.5,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
+0,1,0,0,Gyrostemonaceae,Gyrostemon australasicus,,25,1.5,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 1,1,0,1,Araliaceae,Polyscias murrayi,24,160,90,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,1,Cunoniaceae,Eucryphia moorei,20,60,20,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,1,Elaeocarpaceae,Elaeocarpus holopetalus,16,70,30,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
@@ -1163,7 +1163,7 @@ narrow endemic,victoria,tasmania,forest,family,species name,ht (m),ll (mm),lw (m
 0,1,0,NA,Fabaceae,Acacia loderi,15,110,2,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia maidenii,12,180,22,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia melvillei,15,105,25,simple,tree,NA,NA,NA,NA,NA,Victoria_no_climbers,,Victoria,Victoria
-0,1,0,NA,Fabaceae,Acacia mitchellii,30,8,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
+0,1,0,NA,Fabaceae,Acacia mitchellii,,8,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia nanodealbata,6,2.5,1,compound,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia obliquinervia,15,170,50,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria
 0,1,0,NA,Fabaceae,Acacia obtusifolia,15,250,23,simple,tree,NA,NA,NA,NA,Victoria_forest,Victoria_no_climbers,,Victoria,Victoria

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -23,21 +23,23 @@ contributors:
 dataset:
   data_is_long_format: no
   custom_R_code:        '
-    data %>% 
+    data %>%
       mutate(
         woodiness = "woody",
         plant_growth_form = habit,
-        parasitic = ifelse(habit %in% c("parasite", "mistletoe"), "parasitic", NA),        
+        parasitic = ifelse(habit %in% c("parasite", "mistletoe"), "parasitic", NA),
         plant_growth_substrate = ifelse(habit %in% c("mistletoe"), "epiphyte", NA),
-        leaf_type = NA
-      ) %>% 
+        leaf_type = NA,
+        `ht (m)` = ifelse(`species name` == "Acacia mitchellii" & `ht (m)` == 30, NA, `ht (m)`),
+        `ht (m)` = ifelse(`species name` == "Gyrostemon australasicus" & `ht (m)` == 10, NA, `ht (m)`)
+      ) %>%
       distinct(`species name`, `ht (m)`, `ll (mm)`, `lw (mm)`, `leaf form`, `habit`, .keep_all = TRUE) %>%
       move_values_to_new_trait(
         "leaf form", "leaf_type",
         "scale", "scale", ""
       ) %>%
-      mutate(across(c(`leaf form`), ~na_if(.x,"")))
-  '
+      mutate(across(c(`leaf form`), ~na_if(.x,""))) %>%
+    '
   collection_date: 2014/2014
   taxon_name: species name
   location_name: sites

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -22,16 +22,14 @@ contributors:
   dataset_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:        '
+  custom_R_code: '
     data %>%
       mutate(
         woodiness = "woody",
         plant_growth_form = habit,
         parasitic = ifelse(habit %in% c("parasite", "mistletoe"), "parasitic", NA),
         plant_growth_substrate = ifelse(habit %in% c("mistletoe"), "epiphyte", NA),
-        leaf_type = NA,
-        `ht (m)` = ifelse(`species name` == "Acacia mitchellii" & `ht (m)` == 30, NA, `ht (m)`),
-        `ht (m)` = ifelse(`species name` == "Gyrostemon australasicus" & `ht (m)` == 10, NA, `ht (m)`)
+        leaf_type = NA
       ) %>%
       distinct(`species name`, `ht (m)`, `ll (mm)`, `lw (mm)`, `leaf form`, `habit`, .keep_all = TRUE) %>%
       move_values_to_new_trait(
@@ -58,7 +56,8 @@ dataset:
     Walsh, N.G. & Entwistle, T.J. 1997. Flora of Victoria Volume 4. Chatswood. Enkata
     Press.
   original_file: Woody plants in Tasmania and Victoria.xls
-  notes: none
+  notes: plant_height values for Acacia mitchellii and Gyrostemon australasicus have
+    been removed from data.csv as outliers
 locations:
   state not specified:
     latitude (deg): .na.real

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -38,7 +38,7 @@ dataset:
         "leaf form", "leaf_type",
         "scale", "scale", ""
       ) %>%
-      mutate(across(c(`leaf form`), ~na_if(.x,""))) %>%
+      mutate(across(c(`leaf form`), ~na_if(.x,"")))
     '
   collection_date: 2014/2014
   taxon_name: species name

--- a/data/McGlone_2015/metadata.yml
+++ b/data/McGlone_2015/metadata.yml
@@ -29,7 +29,9 @@ dataset:
         plant_growth_form = habit,
         parasitic = ifelse(habit %in% c("parasite", "mistletoe"), "parasitic", NA),
         plant_growth_substrate = ifelse(habit %in% c("mistletoe"), "epiphyte", NA),
-        leaf_type = NA
+        leaf_type = NA,
+        `ht (m)` = ifelse(`species name` == "Acacia mitchellii" & `ht (m)` == 30, NA, `ht (m)`),
+        `ht (m)` = ifelse(`species name` == "Gyrostemon australasicus" & `ht (m)` == 10, NA, `ht (m)`)
       ) %>%
       distinct(`species name`, `ht (m)`, `ll (mm)`, `lw (mm)`, `leaf form`, `habit`, .keep_all = TRUE) %>%
       move_values_to_new_trait(
@@ -57,7 +59,7 @@ dataset:
     Press.
   original_file: Woody plants in Tasmania and Victoria.xls
   notes: plant_height values for Acacia mitchellii and Gyrostemon australasicus have
-    been removed from data.csv as outliers
+    been removed as outliers, using `custom_R_code`
 locations:
   state not specified:
     latitude (deg): .na.real

--- a/data/Mokany_2015/metadata.yml
+++ b/data/Mokany_2015/metadata.yml
@@ -49,7 +49,7 @@ dataset:
         leaflet_area = ifelse(`Spp Name` == "Acacia dealbata", `Leaf_Area_cm2`, NA),
         `Leaf_Area_cm2` = ifelse(`Spp Name` == "Acacia dealbata", NA, `Leaf_Area_cm2`)
       )
-  '
+    '
   collection_date: 2015/2015
   taxon_name: Spp Name
   description: These data provide observed and interpolated functional trait values

--- a/data/Mokany_2015/metadata.yml
+++ b/data/Mokany_2015/metadata.yml
@@ -47,7 +47,8 @@ dataset:
       mutate(
         across(c(plant_height_unique_values), ~na_if(.x, 0)),
         leaflet_area = ifelse(`Spp Name` == "Acacia dealbata", `Leaf_Area_cm2`, NA),
-        `Leaf_Area_cm2` = ifelse(`Spp Name` == "Acacia dealbata", NA, `Leaf_Area_cm2`)
+        `Leaf_Area_cm2` = ifelse(`Spp Name` == "Acacia dealbata", NA, `Leaf_Area_cm2`),
+        `Plant_height_(m)` = ifelse(`Spp Name` == "Boronia nana", NA, `Plant_height_(m)`)
       )
     '
   collection_date: 2015/2015

--- a/data/Mokany_2015/metadata.yml
+++ b/data/Mokany_2015/metadata.yml
@@ -48,7 +48,8 @@ dataset:
         across(c(plant_height_unique_values), ~na_if(.x, 0)),
         leaflet_area = ifelse(`Spp Name` == "Acacia dealbata", `Leaf_Area_cm2`, NA),
         `Leaf_Area_cm2` = ifelse(`Spp Name` == "Acacia dealbata", NA, `Leaf_Area_cm2`),
-        `Plant_height_(m)` = ifelse(`Spp Name` == "Boronia nana", NA, `Plant_height_(m)`)
+        `Plant_height_(m)` = ifelse(`Spp Name` == "Boronia nana", NA, `Plant_height_(m)`),
+        `Plant_height_(m)` = ifelse(`Spp Name` == "Diplarrena moraea", NA, `Plant_height_(m)`)
       )
     '
   collection_date: 2015/2015
@@ -75,7 +76,8 @@ dataset:
     are identical to those in Barlow_1981, CPBR_2002, GrassBase_2014, RBGSYD_2014,
     SAH_2014, TMAG_2009, and WAH_1998 have been removed. Harden 2000 and Maslin and
     Tame 2001 are not included as secondary references, because AusTraits includes
-    references that supercede these.
+    references that supercede these. Excluded values for plant_height for Boronia
+    nana and Diplarrena moraea in custom_R_code.
 locations: .na
 contexts: .na
 traits:

--- a/data/Morgan_2014/metadata.yml
+++ b/data/Morgan_2014/metadata.yml
@@ -23,7 +23,7 @@ dataset:
         row_number = row_number()
       ) %>%
       filter(!row_number %in% c(208,209,210,211))
-  '
+    '
   collection_date: 2004/2014
   taxon_name: Scientific Name
   location_name: site_name
@@ -34,7 +34,7 @@ dataset:
   life_stage: adult
   sampling_strategy: This is an alpine species dataset collected between Mt Nelse-Bogong
     High Plains-Mt Hotham in Victoria.
-  original_file: relevent data from the file "2014  updated plant functional trait
+  original_file: Relevant data from the file "2014  updated plant functional trait
     database.xls" extracted. Original copy of the excel file located in Google Drive
     in the folder "Morgan_2011_1 Morgan_2011_2 Morgan_2014 Angevin_2010 Briggs_2010
     Cross_2011 Lunt_2012 Roberts_2006 Scott_2010"

--- a/data/Morgan_2014/metadata.yml
+++ b/data/Morgan_2014/metadata.yml
@@ -20,7 +20,8 @@ dataset:
     data %>%
       mutate(
         site_name = "Mt Nelse-Bogong High Plains-Mt Hotham",
-        row_number = row_number()
+        row_number = row_number(),
+        `Seed mass (mg)` = ifelse(`Scientific Name` == "Ewartia nubigena", `Seed mass (mg)`/1000, `Seed mass (mg)`)
       ) %>%
       filter(!row_number %in% c(208,209,210,211))
     '
@@ -41,7 +42,8 @@ dataset:
   notes: This dataset might also include some data from John Morgan's database not
     specifically associated with a campaign; there are 10 duplicate values with Venn_2011,
     but these are spread across species and traits without any notable pattern, and
-    are left in.
+    are left in. Corrected value for Ewartia nubigena in custom_R_code according to
+    Venn_2011.
 locations:
   Mt Nelse-Bogong High Plains-Mt Hotham:
     latitude (deg): -36.87

--- a/data/Prior_2022/metadata.yml
+++ b/data/Prior_2022/metadata.yml
@@ -241,7 +241,7 @@ contexts:
   - value: High
     description: Fire intensity high, with char height of >5m. Actual char height
       values are in the raw data.csv file.
-- context_property: Canopy scorch (%)
+- context_property: canopy scorch (%)
   category: plot_context
   var_in: Scorch
 - context_property: DBH (cm) [mean (min-max)]

--- a/data/SAH_2014/data.csv
+++ b/data/SAH_2014/data.csv
@@ -2226,7 +2226,7 @@ Eucalyptus striaticalyx,8,11,cm,2.5,3.5,cm,NA,10,m
 Eucalyptus cneorifolia,5,10,cm,0.6,1,cm,NA,10,m
 Eucalyptus flindersii,7,14,cm,1,2,cm,NA,10,m
 Eucalyptus oleosa,6,14,cm,1,2,cm,NA,10,m
-Eucalyptus porosa,6,9,cm,0.6,25,cm,NA,10,m
+Eucalyptus porosa,6,9,cm,0.6,2.5,cm,NA,10,m
 Eucalyptus rugosa,5,10,cm,1,3,cm,NA,10,m
 Eucalyptus socialis,6,14,cm,1,2,cm,NA,10,m
 Eucalyptus viridis,5,16,cm,0.3,0.5,cm,NA,10,m

--- a/data/SAH_2014/data.csv
+++ b/data/SAH_2014/data.csv
@@ -2226,7 +2226,7 @@ Eucalyptus striaticalyx,8,11,cm,2.5,3.5,cm,NA,10,m
 Eucalyptus cneorifolia,5,10,cm,0.6,1,cm,NA,10,m
 Eucalyptus flindersii,7,14,cm,1,2,cm,NA,10,m
 Eucalyptus oleosa,6,14,cm,1,2,cm,NA,10,m
-Eucalyptus porosa,6,9,cm,0.6,2.5,cm,NA,10,m
+Eucalyptus porosa,6,9,cm,0.6,25,cm,NA,10,m
 Eucalyptus rugosa,5,10,cm,1,3,cm,NA,10,m
 Eucalyptus socialis,6,14,cm,1,2,cm,NA,10,m
 Eucalyptus viridis,5,16,cm,0.3,0.5,cm,NA,10,m

--- a/data/SAH_2014/metadata.yml
+++ b/data/SAH_2014/metadata.yml
@@ -17,7 +17,7 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:        '
+  custom_R_code: '
     data %>%
       mutate(
         leaf_length_unit_numeric = ifelse(leaf_length_unit == "cm", 10, NA),
@@ -34,7 +34,7 @@ dataset:
         plant_height_max = plant_height_max * plant_height_unit_numeric,
         plant_height_min = plant_height_min * plant_height_unit_numeric
       )
-  '
+    '
   collection_date: unknown/1986
   taxon_name: species
   description: Taxonomic treatment - Flora of South Australia
@@ -43,7 +43,9 @@ dataset:
   sampling_strategy: Herbarium specimens and other herbarium curated data from South
     Australia
   original_file: .na
-  notes: Request acknowledgement of "State Herbarium of South Australia"
+  notes: Request acknowledgement of "State Herbarium of South Australia"; `data.csv`
+    has been modified to change Eucalyptus porosa `leaf_width` value from 25 cm to
+    2.5, due to likely typo.
 locations: .na
 contexts: .na
 traits:

--- a/data/SAH_2014/metadata.yml
+++ b/data/SAH_2014/metadata.yml
@@ -20,6 +20,7 @@ dataset:
   custom_R_code: '
     data %>%
       mutate(
+        leaf_width_max = ifelse(species == "Eucalyptus porosa", leaf_width_max/10, leaf_width_max),
         leaf_length_unit_numeric = ifelse(leaf_length_unit == "cm", 10, NA),
         leaf_length_unit_numeric = ifelse(leaf_length_unit == "mm", 1, leaf_length_unit_numeric),
         leaf_length_max = leaf_length_max * leaf_length_unit_numeric,
@@ -43,9 +44,9 @@ dataset:
   sampling_strategy: Herbarium specimens and other herbarium curated data from South
     Australia
   original_file: .na
-  notes: Request acknowledgement of "State Herbarium of South Australia"; `data.csv`
-    has been modified to change Eucalyptus porosa `leaf_width` value from 25 cm to
-    2.5, due to likely typo.
+  notes: Request acknowledgement of "State Herbarium of South Australia"; Eucalyptus
+    porosa `leaf_width` value has been modified from 25 cm to 2.5, due to likely typo,
+    in custom_R_code.
 locations: .na
 contexts: .na
 traits:

--- a/data/SAH_2023/metadata.yml
+++ b/data/SAH_2023/metadata.yml
@@ -98,7 +98,7 @@ dataset:
       group_by(taxon_name, trait_name, entity_measured, value_type) %>%
         mutate(observation_number = row_number()) %>%
       ungroup()
-  '
+    '
   collection_date: unknown/2022
   taxon_name: taxon_name
   trait_name: trait_name

--- a/data/Venn_2011/metadata.yml
+++ b/data/Venn_2011/metadata.yml
@@ -29,7 +29,13 @@ contributors:
   dataset_curators: Rachael Gallagher
 dataset:
   data_is_long_format: no
-  custom_R_code:        data %>% mutate(site = "Main Range, Kosciuszko National Park")
+  custom_R_code:   '
+    data %>%
+      mutate(
+        site = "Main Range, Kosciuszko National Park",
+        `MEAN SEED MASS (g)` = ifelse(SPECIES == "Ewartia nubigena", `MEAN SEED MASS (g)`/1000, `MEAN SEED MASS (g)`)
+      )
+    '
   collection_date: 2008/2009
   taxon_name: SPECIES
   location_name: site
@@ -81,7 +87,8 @@ dataset:
     dynamics. In addition, these traits are indicative of functional characteristics
     (Mason et al. 2003) and are also directly linked to ecosystem functioning.
   original_file: AusTraits database_SV.xls
-  notes: .na
+  notes: Corrected value for Ewartia nubigena from supposed grams to micrograms in
+    custom_R_code.
 locations:
   Main Range, Kosciuszko National Park:
     latitude (deg): -36.417

--- a/data/WAH_2023_1/metadata.yml
+++ b/data/WAH_2023_1/metadata.yml
@@ -123,7 +123,7 @@ dataset:
         entity_measured = ifelse(category %in% c("capsule", "silicula"), "fruit", entity_measured),
       )  %>%
       distinct(source, taxon_name, trait_name, trait_value, units, value_type, inferred, category, .keep_all = TRUE)
-  '
+    '
   collection_date: unknown/2022
   taxon_name: taxon_name
   trait_name: trait_name
@@ -163,7 +163,7 @@ contexts:
     description: Trait value scored directly from taxon description.
   - value: inferred_from_taxonomy
     description: Trait value inferred from a higher level taxon description.
-- context_property: entity_measured
+- context_property: entity measured
   category: method_context
   var_in: entity_measured
 traits:

--- a/data/WAH_2023_2/metadata.yml
+++ b/data/WAH_2023_2/metadata.yml
@@ -124,7 +124,7 @@ dataset:
       )  %>%
       distinct(source, taxon_name, trait_name, trait_value, units, value_type, inferred, category, .keep_all = TRUE) %>%
       mutate(entity_measured = ifelse(is.na(entity_measured), "unknown", entity_measured))
-  '
+    '
   collection_date: unknown/2022
   taxon_name: taxon_name
   trait_name: trait_name

--- a/data/Williams_2011/metadata.yml
+++ b/data/Williams_2011/metadata.yml
@@ -72,6 +72,7 @@ dataset:
         stem_growth_habit = NA_character_,
         parasitic = NA_character_,
         plant_succulence = NA_character_,
+        `Seed Mass_filtered` = ifelse(Species %in% c("Aphanes australiana", "Dianella tasmanica", "Patersonia sericea"), NA, `Seed Mass_filtered`)
       ) %>%
       subset(`Extant/Extinct` == 1 & `Native/Exotic` == 0) %>%
       move_values_to_new_trait(
@@ -115,7 +116,8 @@ dataset:
     datasets known to have been sources for this compilation (mainly botanical collections,
     but also some datasets from John Morgan's lab, Trevor Meers data, and a few datasets
     from Macquarie University labs, Leishman_1992 and Hughes_1992 in particular) have
-    been filtered out
+    been filtered out. Excluded seed masses for Aphanes australiana, Dianella tasmanica,
+    and Patersonia sericea in custom_R_code.
 locations:
   grows in Adelaide:
     latitude (deg): NA

--- a/data/Williams_2011/metadata.yml
+++ b/data/Williams_2011/metadata.yml
@@ -63,7 +63,7 @@ contributors:
   dataset_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code:        '
+  custom_R_code: '
     data %>%
       mutate(
         Clonality = paste0(Clonality,Clonality_b),

--- a/data/Williams_2011/metadata.yml
+++ b/data/Williams_2011/metadata.yml
@@ -98,7 +98,7 @@ dataset:
         c("succulent","succulent_stems"),
         c("11","12")
       )
-  '
+    '
   collection_date: 2011/2013
   taxon_name: Species
   location_name: context

--- a/data/Wilson_2004/metadata.yml
+++ b/data/Wilson_2004/metadata.yml
@@ -43,7 +43,7 @@ dataset:
       group_by(Species) %>%
         mutate(across(c(resprouting_capacity), replace_duplicates_with_NA)) %>%
       ungroup()
-  '
+    '
   collection_date: unknown/2004
   taxon_name: Species
   source_id: source_id
@@ -106,7 +106,7 @@ locations:
     notes: A distinct water catchment of approximately 220,000 ha and is located on
       the Swan Coastal Plain just north of Perth.
 contexts:
-- context_property: scoring method
+- context_property: trait scoring method
   category: method_context
   var_in: context
   values:


### PR DESCRIPTION
Fixes #775
- I collapsed some duplicate context property names
- Removed a special character from traits.yml but @ehwenk not sure if this is allowed with the new APD workflow
- ABRS_1981 measurements will apparently be removed anyway with @ehwenk's work cleaning duplicates
- Fixed issues and documented in another column here:

[AusTraits.potential.errors.-.Sheet1.csv](https://github.com/traitecoevo/austraits.build/files/13519251/AusTraits.potential.errors.-.Sheet1.csv)
