### PR TITLE
Edits to "Complete Traits" datasets

### DIFF
--- a/data/Wenk_2022/metadata.yml
+++ b/data/Wenk_2022/metadata.yml
@@ -32,11 +32,13 @@ dataset:
         woodiness_to_use = stringr::str_replace(
           woodiness_to_use, "soft_woody", "semi_woody"),
         woodiness_to_use = stringr::str_replace(
-          woodiness_to_use, "woody_stemmed_monocot", "woody_like_stem")
+          woodiness_to_use, "woody_stemmed_monocot", "woody_like_stem"),
+        measurement_remarks = paste0(reference_category, ": ", references)
       )
     '
   collection_date: unknown/2022
   taxon_name: taxon_name
+  measurement_remarks: measurement_remarks
   description: A curated collection of plant growth form values that includes nearly
     all species in the Australian Plant Census (APC). Dataset is compiled from a combination
     of data extracted from state and national online floras, supplemented by the taxonomic

--- a/data/Wenk_2023/metadata.yml
+++ b/data/Wenk_2023/metadata.yml
@@ -21,9 +21,13 @@ contributors:
   dataset_curators: Elizabeth Wenk
 dataset:
   data_is_long_format: no
-  custom_R_code: .na
+  custom_R_code: '
+    data %>% 
+      mutate(measurement_remarks = paste0(source, ": ", citation))
+  '
   collection_date: unknown/2022
   taxon_name: taxon_name
+  measurement_remarks: measurement_remarks
   description: A curated collection of life history values that includes nearly all
     species in the Australian Plant Census (APC).
   basis_of_record: literature field

--- a/data/Wenk_2023/metadata.yml
+++ b/data/Wenk_2023/metadata.yml
@@ -23,7 +23,11 @@ dataset:
   data_is_long_format: no
   custom_R_code: '
     data %>% 
-      mutate(measurement_remarks = paste0(source, ": ", citation))
+      mutate(
+        measurement_remarks = paste0(source, ": ", citation),
+        life_history_scored = stringr::str_replace_all(life_history_scored, "\\(", "") ,
+        life_history_scored = stringr::str_replace_all(life_history_scored, "\\)", "") 
+      )
   '
   collection_date: unknown/2022
   taxon_name: taxon_name


### PR DESCRIPTION
Edits to `Wenk_2023` and `Wenk_2022` datasets:

- Approximately 100 taxa were being mistakenly excluded because one of the trait values had brackets around the trait value to designate it as "less common". As a result the entire trait value was being excluded.

- Adding sources into Wenk_2022, Wenk_2023 as measurement_remarks. The sources for all the manually looked up references for these datasets was in the data.csv files, but had not been mapped into AusTraits. Requested by reviewers of the Complete Traits paper.