### PR TITLE
Fix comments in fruiting_time and recruitment_time in traits.yml

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -7598,7 +7598,7 @@ traits:
       description: The months [UO:0000035] during which a plant [PO:0000003] produces
         fruit [PO:0009001] with mature [PATO:0001701] seeds [PO:0009010].;Months during
         which taxon produces fruit with mature seeds.
-      comments: Trait keyed as a sequences of 12 Ns (not flowering) and Ys (flowering),
+      comments: Trait keyed as a sequences of 12 Ns (not fruiting) and Ys (fruiting),
         representing the 12 months, starting with January.
       type: categorical
       entity_URI: https://w3id.org/APD/traits/trait_0030215
@@ -7607,7 +7607,7 @@ traits:
       description: The months [UO:0000035] during which seed [PO:0009010] germination
         [GO:0009845] and seedling establishment [EnvThes:20410] occurs.;The months
         during which seed germination and seedling establishment occurs.
-      comments: Trait keyed as a sequences of 12 Ns (not flowering) and Ys (flowering),
+      comments: Trait keyed as a sequences of 12 Ns (not recruiting) and Ys (recruiting),
         representing the 12 months, starting with January.
       type: categorical
       entity_URI: https://w3id.org/APD/traits/trait_0030216


### PR DESCRIPTION
Hi Austraits team

Thanks for all your efforts and setting a wonderful example for all of us trying to follow your path.

I believe the description of how 'fruiting_time' and 'recruitment_time' are coded in Austraits contained some mistakes (probably copied from flowering_time). But please ignore this pull request if I'm mistaken

Cheers