### PR TITLE
Fix molar units

### DIFF
--- a/config/traits.yml
+++ b/config/traits.yml
@@ -1315,7 +1315,7 @@ traits:
         content.;The ratio of the mass of chlorophyll in a leaf to leaf area, where
         chlorophyll content is the sum of chlorophyll a and chlorophyll b content.
       type: numeric
-      units: umol/m2
+      units: umol{chlorophyll}/m2
       allowed_values_min: 10.0
       allowed_values_max: 2000.0
       entity_URI: https://w3id.org/APD/traits/trait_0002081
@@ -1329,7 +1329,7 @@ traits:
         leaf dry mass, where chlorophyll content is the sum of chlorophyll a and chlorophyll
         b content.
       type: numeric
-      units: mmol/kg
+      units: mmol{chlorophyll}/kg
       allowed_values_min: 0.1
       allowed_values_max: 15.0
       entity_URI: https://w3id.org/APD/traits/trait_0002082
@@ -1339,7 +1339,7 @@ traits:
         a [CHEBI:18230] in a leaf [PO:0025034] to leaf area [PATO:0001323].;The ratio
         of the mass of chlorophyll a in a leaf to leaf area.
       type: numeric
-      units: umol/m2
+      units: umol{chlorophyllA}/m2
       allowed_values_min: 50.0
       allowed_values_max: 2000.0
       entity_URI: https://w3id.org/APD/traits/trait_0002083
@@ -1349,7 +1349,7 @@ traits:
         a [CHEBI:18230] in a leaf [PO:0025034] to leaf dry mass [TO:0001014].;The
         ratio of the mass of chlorophyll a in a leaf to leaf dry mass.
       type: numeric
-      units: mmol/kg
+      units: mmol{chlorophyllA}/kg
       allowed_values_min: 0.1
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0002084
@@ -1359,7 +1359,7 @@ traits:
         b [CHEBI:27888] in a leaf [PO:0025034] to leaf area [PATO:0001323].;The ratio
         of the mass of chlorophyll b in a leaf to leaf area.
       type: numeric
-      units: umol/m2
+      units: umol{chlorophyllB}/m2
       allowed_values_min: 10.0
       allowed_values_max: 1000.0
       entity_URI: https://w3id.org/APD/traits/trait_0002085
@@ -1369,7 +1369,7 @@ traits:
         b [CHEBI:27888] in a leaf [PO:0025034] to leaf dry mass [TO:0001014].;The
         ratio of the mass of chlorophyll b in a leaf to leaf dry mass.
       type: numeric
-      units: mmol/kg
+      units: mmol{chlorophyllB}/kg
       allowed_values_min: 0.01
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0002086
@@ -1380,7 +1380,7 @@ traits:
         in the leaf.;The ratio of the mass of chlorophyll a in a leaf to the mass
         of chlorophyll b in the leaf.
       type: numeric
-      units: umol/umol
+      units: umol{chlorophyllA}/umol{chlorophyllB}
       allowed_values_min: 0.1
       allowed_values_max: 6.0
       entity_URI: https://w3id.org/APD/traits/trait_0002087
@@ -6460,7 +6460,7 @@ traits:
         in the literature despite the fact it is not normalised to path length and
         therefore is a "conductance" not a "conductivity".
       type: numeric
-      units: mmol/m2/MPa/s
+      units: mmol{H2O}/m2/MPa/s
       allowed_values_min: 0.1
       allowed_values_max: 100.0
       entity_URI: https://w3id.org/APD/traits/trait_0021017
@@ -6503,7 +6503,7 @@ traits:
         a measure of the rate [PATO:0000161] of water [CHEBI:15377] movement [NCIT:C37994]
         from a leaf lamina [PO:0020039] to the inside of the leaf.
       type: numeric
-      units: umol/m2/MPa/s
+      units: umol{H2O}/m2/MPa/s
       allowed_values_min: -100.0
       allowed_values_max: 100.0
       entity_URI: XX

--- a/config/traits.yml
+++ b/config/traits.yml
@@ -1007,7 +1007,7 @@ traits:
         [APD:glossary/40044].;The ratio of the mass of calcium in epidermal cells
         to epidermal cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 500.0
       entity_URI: https://w3id.org/APD/traits/trait_0001611
@@ -1017,7 +1017,7 @@ traits:
         [CHEBI:22984] in the hypodermis [PO:0005051] to hypodermis fresh mass [APD:glossary/40044].;The
         ratio of the mass of calcium in the hypodermis to hypodermis fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 500.0
       entity_URI: https://w3id.org/APD/traits/trait_0001612
@@ -1029,7 +1029,7 @@ traits:
         [APD:glossary/40044].;The ratio of the mass of calcium in parenchyma cells
         to parenchyma cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 500.0
       entity_URI: https://w3id.org/APD/traits/trait_0001613
@@ -1041,7 +1041,7 @@ traits:
         cell fresh mass [APD:glossary/40044].;The ratio of the mass of calcium in
         palisade mesophyll cells to palisade mesophyll cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 100.0
       entity_URI: https://w3id.org/APD/traits/trait_0001614
@@ -1052,7 +1052,7 @@ traits:
         mass [APD:glossary/40044].;The ratio of the mass of calcium in sclerenchyma
         cells to sclerenchyma cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 100.0
       entity_URI: https://w3id.org/APD/traits/trait_0001615
@@ -1063,7 +1063,7 @@ traits:
         fresh mass [APD:glossary/40044].;The ratio of the mass of calcium in spongy
         mesophyll cells to spongy mesophyll cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{Ca}/g
       allowed_values_min: 1.0
       allowed_values_max: 1000.0
       entity_URI: https://w3id.org/APD/traits/trait_0001616
@@ -1074,7 +1074,7 @@ traits:
         [APD:glossary/40044].;The ratio of the mass of phosphorus in epidermal cells
         to epidermal cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0001661
@@ -1084,7 +1084,7 @@ traits:
         [CHEBI:28659] in the hypodermis [PO:0005051] to hypodermis fresh mass [APD:glossary/40044].;The
         ratio of the mass of phosphorus in the hypodermis to hypodermis fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0001662
@@ -1096,7 +1096,7 @@ traits:
         [APD:glossary/40044].;The ratio of the mass of phosphorus in parenchyma cells
         to parenchyma cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0001663
@@ -1108,7 +1108,7 @@ traits:
         cell fresh mass [APD:glossary/40044].;The ratio of the mass of phosphorus
         in palisade mesophyll cells to palisade mesophyll cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 30.0
       entity_URI: https://w3id.org/APD/traits/trait_0001664
@@ -1119,7 +1119,7 @@ traits:
         mass [APD:glossary/40044].;The ratio of the mass of phosphorus in sclerenchyma
         cells to sclerenchyma cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0001665
@@ -1131,7 +1131,7 @@ traits:
         fresh mass [APD:glossary/40044].;The ratio of the mass of phosphorus in spongy
         mesophyll cells to spongy mesophyll cell fresh mass.
       type: numeric
-      units: umol/g
+      units: umol{P}/g
       allowed_values_min: 0.0
       allowed_values_max: 30.0
       entity_URI: https://w3id.org/APD/traits/trait_0001666
@@ -1293,7 +1293,7 @@ traits:
         [CHEBI:23044] in a leaf [PO:0025034] to leaf area [PATO:0001323].;The ratio
         of the mass of carotenoids in a leaf to leaf area.
       type: numeric
-      units: umol/m2
+      units: umol{carotenoid}/m2
       allowed_values_min: 10.0
       allowed_values_max: 1000.0
       entity_URI: https://w3id.org/APD/traits/trait_0002055
@@ -1303,7 +1303,7 @@ traits:
         [CHEBI:23044] in a leaf [PO:0025034] to leaf dry mass [TO:0001014].;The ratio
         of the mass of carotenoids in a leaf to leaf dry mass.
       type: numeric
-      units: mmol/kg
+      units: mmol{carotenoid}/kg
       allowed_values_min: 0.1
       allowed_values_max: 10.0
       entity_URI: https://w3id.org/APD/traits/trait_0002056
@@ -5694,7 +5694,7 @@ traits:
         temperature as a context property as Jmax is very sensitive to changes in
         temperature. Measurements made at 25 deg C should be mapped to `leaf_photosynthesis_Jmax_per_area_25C`
       type: numeric
-      units: umol/m2/s
+      units: umol{CO2}/m2/s
       allowed_values_min: 10.0
       allowed_values_max: 800.0
       entity_URI: https://w3id.org/APD/traits/trait_0020410
@@ -5717,7 +5717,7 @@ traits:
         at a temperature of 25 deg C.  Measurements made at other temperatures should
         be mapped to `leaf_photosynthesis_Jmax_per_area`
       type: numeric
-      units: umol/m2/s
+      units: umol{CO2}/m2/s
       allowed_values_min: 35.0
       allowed_values_max: 800.0
       entity_URI: https://w3id.org/APD/traits/trait_0020411
@@ -5738,7 +5738,7 @@ traits:
       comments: Jmax values are very dependent on leaf temperature, so leaf temperature
         needs to be included as a context property.
       type: numeric
-      units: umol/g/s
+      units: umol{CO2}/g/s
       allowed_values_min: 0.0
       allowed_values_max: 3.0
       entity_URI: https://w3id.org/APD/traits/trait_0020412
@@ -5761,7 +5761,7 @@ traits:
         temperature as a context property as Vcmax is very sensitive to changes in
         temperature. Measurements made at 25 deg C should be mapped to `leaf_photosynthesis_Vcmax_per_area_25C`
       type: numeric
-      units: umol/m2/s
+      units: umol{CO2}/m2/s
       allowed_values_min: 10.0
       allowed_values_max: 300.0
       entity_URI: https://w3id.org/APD/traits/trait_0020413
@@ -5784,7 +5784,7 @@ traits:
         at a temperature of 25 deg C.  Measurements made at other temperatures should
         be mapped to `leaf_photosynthesis_Vcmax_per_area`
       type: numeric
-      units: umol/m2/s
+      units: umol{CO2}/m2/s
       allowed_values_min: 10.0
       allowed_values_max: 300.0
       entity_URI: https://w3id.org/APD/traits/trait_0020414
@@ -5805,7 +5805,7 @@ traits:
       comments: Vcmax values are very dependent on leaf temperature, so leaf temperature
         needs to be included as a context property.
       type: numeric
-      units: umol/g/s
+      units: umol{CO2}/g/s
       allowed_values_min: 0.0
       allowed_values_max: 2.0
       entity_URI: https://w3id.org/APD/traits/trait_0020415

--- a/config/unit_conversions.csv
+++ b/config/unit_conversions.csv
@@ -107,7 +107,16 @@ mol{H2O}/m2,mol{H2O}/m2,x*1
 umol{CO2}/mol{H2O}/m2/s,mmol{CO2}/mol{H2O}/m2/s,x*1/1000
 ppm,umol{CO2}/mol,x*1
 ppm,umol/mol,x*1
-mmol{carotenoid}/kg,mmol{carotenoid}/g,x*0.001
+mmol{carotenoid}/g,mmol{carotenoid}/kg,x*1000
+umol{carotenoid}/g,mmol{carotenoid}/kg,x*1
+umol{chlorophyll}/g,mmol{chlorophyll}/kg,x*1
+umol{chlorophyll}/kg,mmol{chlorophyll}/kg,x/1000
+umol{chlorophyllA}/g,mmol{chlorophyllA}/kg,x*1
+umol{chlorophyllB}/g,mmol{chlorophyllB}/kg,x*1
+mmol{chlorophyll}/g,mmol{chlorophyll}/kg,x*1000
+mmol{chlorophyllA}/g,mmol{chlorophyllA}/kg,x*1000
+mmol{chlorophyllB}/g,mmol{chlorophyllB}/kg,x*1000
+mol{chlorophyllA}/mol{chlorophyllB},umol{chlorophyllA}/umol{chlorophyllB},x*1
 umol{CO2}/kg/s,umol{CO2}/g/s,x*0.001
 umol{CO2}/kg/s,nmol{CO2}/g/s,x*1
 mmol{CO2}/g/s,umol{CO2}/g/s,x*1000

--- a/config/unit_conversions.csv
+++ b/config/unit_conversions.csv
@@ -107,6 +107,7 @@ mol{H2O}/m2,mol{H2O}/m2,x*1
 umol{CO2}/mol{H2O}/m2/s,mmol{CO2}/mol{H2O}/m2/s,x*1/1000
 ppm,umol{CO2}/mol,x*1
 ppm,umol/mol,x*1
+mmol{carotenoid}/kg,mmol{carotenoid}/g,x*0.001
 umol{CO2}/kg/s,umol{CO2}/g/s,x*0.001
 umol{CO2}/kg/s,nmol{CO2}/g/s,x*1
 mmol{CO2}/g/s,umol{CO2}/g/s,x*1000

--- a/data/Blackman_2010/metadata.yml
+++ b/data/Blackman_2010/metadata.yml
@@ -113,7 +113,7 @@ traits:
     placed in an oven at 70C for at least 3 d, and LMA was calculated as the ratio
     between the dry leaf mass and leaf area.
 - var_in: Kleaf_mmol_m2_s_Mpa
-  unit_in: mmol/m2/MPa/s
+  unit_in: mmol{H2O}/m2/MPa/s
   trait_name: leaf_specific_hydraulic_conductance
   entity_type: population
   value_type: mean

--- a/data/Bryant_2021/metadata.yml
+++ b/data/Bryant_2021/metadata.yml
@@ -158,7 +158,7 @@ traits:
     chamber was opened for resampling. See manuscript for calculation of foliar water
     uptake (FWU; mol H2O/m2).
 - var_in: Ksurf.avg_Psi_umol H2O/m^2/s/Mpa
-  unit_in: umol/m2/MPa/s
+  unit_in: umol{H2O}/m2/MPa/s
   trait_name: leaf_conductance_surface_water
   entity_type: individual
   value_type: raw
@@ -205,7 +205,7 @@ traits:
     protocol as seasonality FWU kinetics, however, with only four leaf pairs from
     each branch arrayed over an 8 hr period (t = 2, 4, 6, 8 hr).
 - var_in: Ksurf.LN_umol H2O m-2 s-1 MPa-1
-  unit_in: umol/m2/MPa/s
+  unit_in: umol{H2O}/m2/MPa/s
   trait_name: leaf_conductance_surface_water
   entity_type: individual
   value_type: raw

--- a/data/Bryant_2021_2/metadata.yml
+++ b/data/Bryant_2021_2/metadata.yml
@@ -357,7 +357,7 @@ traits:
     1998; Supporting Information).
   tissue_type: stem
 - var_in: Kleaf
-  unit_in: mmol/m2/MPa/s
+  unit_in: mmol{H2O}/m2/MPa/s
   trait_name: leaf_specific_hydraulic_conductance
   entity_type: individual
   value_type: raw
@@ -379,7 +379,7 @@ traits:
     - psi-leaf). where E is the transpiration rate and psi-stem - psi-leaf represents
     the water potential gradient between the transpiring leaf and stem.nknown
 - var_in: Kplant
-  unit_in: mmol/m2/MPa
+  unit_in: mmol{H2O}/m2/MPa
   trait_name: .na
   entity_type: individual
   value_type: raw

--- a/data/Cernusak_2011/metadata.yml
+++ b/data/Cernusak_2011/metadata.yml
@@ -226,7 +226,7 @@ traits:
     followed by dissolution in 1 M H2SO4 and phosphate detection by automated molybdate
     colorimetry (Lachat Quickchem 8500, Hach Ltd, Loveland, CO, USA).
 - var_in: Vcmax atTleaf (umol m-2 s-1)
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: .na
   entity_type: individual
   value_type: raw
@@ -242,7 +242,7 @@ traits:
     provides estimates of these parameters normalized to 25 deg C to facilitate comparisons
     with measurements made at other leaf temperatures.
 - var_in: Vcmax at 25 deg C (umol m-2 s-1)
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area
   entity_type: individual
   value_type: raw
@@ -261,7 +261,7 @@ traits:
     leaf temperature and the column 'Tleaf (deg C)' indicates the leaf temperatures
     during gas exchange measurements.
 - var_in: J at Tleaf (umol e- m-2 s-1)
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: .na
   entity_type: individual
   value_type: raw
@@ -277,7 +277,7 @@ traits:
     provides estimates of these parameters normalized to 25 deg C to facilitate comparisons
     with measurements made at other leaf temperatures.
 - var_in: J at 25 deg C (umol e- m-2 s-1)
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area_25C
   entity_type: individual
   value_type: raw

--- a/data/Cheesman_2020/metadata.yml
+++ b/data/Cheesman_2020/metadata.yml
@@ -242,7 +242,7 @@ traits:
     irradiance (A-I) curves) were made on at least two leaves of 71 species collected,
     using a Licor 6400 Portable Photosynthesis machine (LI-COR, Lincoln, NE, USA).
 - var_in: Vcmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area
   entity_type: individual
   value_type: raw
@@ -253,7 +253,7 @@ traits:
     irradiance (A-I) curves) were made on at least two leaves of 71 species collected,
     using a Licor 6400 Portable Photosynthesis machine (LI-COR, Lincoln, NE, USA).
 - var_in: jmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area
   entity_type: individual
   value_type: raw

--- a/data/Crous_2013/metadata.yml
+++ b/data/Crous_2013/metadata.yml
@@ -168,7 +168,7 @@ contexts:
   var_in: PlotSite
 traits:
 - var_in: Vcmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area
   entity_type: individual
   value_type: maximum
@@ -398,7 +398,7 @@ traits:
     See manuscript for additional details on how humidity was controlled in the experimental
     chambers to minimize stomatal closure.
 - var_in: Jmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area
   entity_type: individual
   value_type: maximum
@@ -433,7 +433,7 @@ traits:
     See manuscript for additional details on how humidity was controlled in the experimental
     chambers to minimize stomatal closure.
 - var_in: Jmax25
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area_25C
   entity_type: individual
   value_type: raw
@@ -468,7 +468,7 @@ traits:
     See manuscript for additional details on how humidity was controlled in the experimental
     chambers to minimize stomatal closure.
 - var_in: Vcmax25
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area
   entity_type: individual
   value_type: raw

--- a/data/Ellsworth_2015/metadata.yml
+++ b/data/Ellsworth_2015/metadata.yml
@@ -487,7 +487,7 @@ traits:
     were completely reversible as described in Laing et al. (1974) (see Supporting
     Information Fig. S1).
 - var_in: Vcmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area
   entity_type: individual
   value_type: raw
@@ -581,7 +581,7 @@ traits:
     oxygenase activity of Rubisco is considered limiting, following equations in Farquhar
     et al. (1980).
 - var_in: Jmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area
   entity_type: individual
   value_type: raw
@@ -942,7 +942,7 @@ traits:
     were completely reversible as described in Laing et al. (1974) (see Supporting
     Information Fig. S1).
 - var_in: Vcmax_mass
-  unit_in: nmol/g/s
+  unit_in: nmol{CO2}/g/s
   trait_name: leaf_photosynthesis_Vcmax_per_mass
   entity_type: individual
   value_type: raw
@@ -1036,7 +1036,7 @@ traits:
     oxygenase activity of Rubisco is considered limiting, following equations in Farquhar
     et al. (1980).
 - var_in: Jmax_mass
-  unit_in: nmol/g/s
+  unit_in: nmol{CO2}/g/s
   trait_name: leaf_photosynthesis_Jmax_per_mass
   entity_type: individual
   value_type: raw

--- a/data/Ghannoum_2010/metadata.yml
+++ b/data/Ghannoum_2010/metadata.yml
@@ -416,7 +416,7 @@ traits:
   replicates: 1
   methods: g of soluble protein per m2 of leaf (Bradford Assay)
 - var_in: ChlAandB (umol m-2)
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: raw
@@ -424,7 +424,7 @@ traits:
   replicates: 1
   methods: sum of chlorophyll A and B (units, umol m-2) (acetone colourmetric assay)
 - var_in: ChlAB
-  unit_in: umol/umol
+  unit_in: umol{chlorophyllA}/umol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
   entity_type: individual
   value_type: raw

--- a/data/Hayes_2018/metadata.yml
+++ b/data/Hayes_2018/metadata.yml
@@ -135,7 +135,7 @@ locations:
 contexts: .na
 traits:
 - var_in: epidermis_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_epidermis_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -200,7 +200,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: hypodermis_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_hypodermis_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -265,7 +265,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: internal_parenchyma_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_internal_parenchyma_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -330,7 +330,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: palisade_mesophyll_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_palisade_mesophyll_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -395,7 +395,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: sclerenchyma_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_sclerenchyma_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -460,7 +460,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: spongy_mesophyll_Ca
-  unit_in: umol/g
+  unit_in: umol{Ca}/g
   trait_name: leaf_spongy_mesophyll_Ca_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -525,7 +525,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: epidermis_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_epidermis_P_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -590,7 +590,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: hypodermis_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_hypodermis_P_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -655,7 +655,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: internal_parenchyma_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_internal_parenchyma_P_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -720,7 +720,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: palisade_mesophyll_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_palisade_mesophyll_P_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -785,7 +785,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: sclerenchyma_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_sclerenchyma_P_per_fresh_mass
   entity_type: individual
   value_type: mean
@@ -850,7 +850,7 @@ traits:
     low levels of P; however, quantitation of [P] from regions of interest was still
     readily achievable (Figure S1f-h).'
 - var_in: spongy_mesophyll_P
-  unit_in: umol/g
+  unit_in: umol{P}/g
   trait_name: leaf_spongy_mesophyll_P_per_fresh_mass
   entity_type: individual
   value_type: mean

--- a/data/Huang_2015/metadata.yml
+++ b/data/Huang_2015/metadata.yml
@@ -531,7 +531,7 @@ traits:
     [CO2] in the cuvette to 1800 ul l-1 were taken and five replicate seedlings were
     measured per genotype and treatment.
 - var_in: Vcmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area_25C
   entity_type: individual
   value_type: raw
@@ -549,7 +549,7 @@ traits:
     and Jmax were then corrected to a common temperature of 25C for comparisons between
     treatments
 - var_in: Jmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area_25C
   entity_type: individual
   value_type: raw

--- a/data/Leigh_2003/metadata.yml
+++ b/data/Leigh_2003/metadata.yml
@@ -89,7 +89,7 @@ traits:
     and weighed. For each plant, the total area of the 20 leaves was divided by their
     total mass to obtain SLA.
 - var_in: chlorophyll
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: raw

--- a/data/Leigh_2006/metadata.yml
+++ b/data/Leigh_2006/metadata.yml
@@ -362,7 +362,7 @@ traits:
     flowers from several plants of each sex were pooled. The same procedure was used
     for fruits.
 - var_in: Chla+b umol/m2
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: raw

--- a/data/MacinnisNg_2016/metadata.yml
+++ b/data/MacinnisNg_2016/metadata.yml
@@ -297,7 +297,7 @@ traits:
     rate was measured on three leaves on three plants in each plot, with two plots
     at each site (a total of 18 samples per site).
 - var_in: ETRmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area
   entity_type: individual
   value_type: mean

--- a/data/Niinemets_2009/metadata.yml
+++ b/data/Niinemets_2009/metadata.yml
@@ -526,7 +526,7 @@ traits:
     had stabilized, commonly 1-2 min after leaf darkening, the dark respiration rate
     was recorded.
 - var_in: Jmax/mass
-  unit_in: umol/g/s
+  unit_in: umol{CO2}/g/s
   trait_name: leaf_photosynthesis_Jmax_per_mass
   entity_type: individual
   value_type: raw
@@ -555,7 +555,7 @@ traits:
     source (Li-Cor Inc., 2004) were used to estimate the amount of light absorbed,
     Qabs. JETR was then determined (Schreiber et al., 1994; equation in cited manuscript).
 - var_in: Vcmax/mass
-  unit_in: umol/g/s
+  unit_in: umol{CO2}/g/s
   trait_name: leaf_photosynthesis_Vcmax_per_mass
   entity_type: individual
   value_type: raw
@@ -584,7 +584,7 @@ traits:
     source (Li-Cor Inc., 2004) were used to estimate the amount of light absorbed,
     Qabs. JETR was then determined (Schreiber et al., 1994; equation in cited manuscript).
 - var_in: Jmax/area
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Jmax_per_area_25C
   entity_type: individual
   value_type: raw
@@ -598,7 +598,7 @@ traits:
     were measured at eight ambient CO2 concentrations between 50 lmol mol-1 and 2000
     lmol mol-1.
 - var_in: Average Vcmax
-  unit_in: umol/m2/s
+  unit_in: umol{CO2}/m2/s
   trait_name: leaf_photosynthesis_Vcmax_per_area_25C
   entity_type: individual
   value_type: raw

--- a/data/Prior_2003/metadata.yml
+++ b/data/Prior_2003/metadata.yml
@@ -450,7 +450,7 @@ traits:
     weighed to determine saturated mass. Dry mass was determined after leaves were
     dried for a minimum of 48 h at 70degC
 - var_in: leaf chlorophyll (umol/g)
-  unit_in: umol/g
+  unit_in: umol{chlorophyll}/g
   trait_name: leaf_chlorophyll_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -460,7 +460,7 @@ traits:
     Minolta, Osaka, Japan), which was calibrated for each species individually using
     the extraction method of Coombs et al. (1985).
 - var_in: leaf_chlorophyll_per_area_umol/m2
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: raw

--- a/data/Richards_2008/metadata.yml
+++ b/data/Richards_2008/metadata.yml
@@ -950,7 +950,7 @@ traits:
   methods: From Feller_1980; See original reference, listed alphabetically under 'additional
     references'
 - var_in: leaf_chlorophyll_umol_per_m2
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: population
   value_type: mean

--- a/data/Smith_1996/metadata.yml
+++ b/data/Smith_1996/metadata.yml
@@ -277,7 +277,7 @@ traits:
   replicates: 1
   methods: Fresh mass of leaves
 - var_in: chlorophyll_A_B_ratio
-  unit_in: umol/umol
+  unit_in: umol{chlorophyllA}/umol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
   entity_type: individual
   value_type: raw
@@ -305,7 +305,7 @@ traits:
     using this formula: (20.7*A647 - 4.62*A664)/FW.CHL*VOL.CHL*1E-4 (%), with chlorophyll
     A/B the ratio of chlorophyll A and B concentrations'
 - var_in: leaf_chlorophyll_per_dry_mass
-  unit_in: umol/g
+  unit_in: umol{chlorophyll}/g
   trait_name: leaf_chlorophyll_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -333,7 +333,7 @@ traits:
     using this formula: (20.7*A647 - 4.62*A664)/FW.CHL*VOL.CHL*1E-4 (%), with total
     chlorophyll concentration the sum of these chlorophyll A and B concentrations'
 - var_in: leaf_chlorophyll_A_per_dry_mass
-  unit_in: umol/g
+  unit_in: umol{chlorophyllA}/g
   trait_name: leaf_chlorophyll_A_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -359,7 +359,7 @@ traits:
     Chlorophyll A concentration is then calculated using the following formula: (12.7*A664
     - 2.79*A647)/FW.CHL*VOL.CHL*1E-4 (%)'
 - var_in: leaf_chlorophyll_B_per_dry_mass
-  unit_in: umol/g
+  unit_in: umol{chlorophyllB}/g
   trait_name: leaf_chlorophyll_B_per_dry_mass
   entity_type: individual
   value_type: raw

--- a/data/Smith_2012/metadata.yml
+++ b/data/Smith_2012/metadata.yml
@@ -347,7 +347,7 @@ traits:
     Wicklow, Ireland); total non-structural carbohydrate (TNC) was calculated as the
     sum of soluble sugar and starch.
 - var_in: ChlAandB (umol m-2)
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: mean
@@ -366,7 +366,7 @@ traits:
     determined on aliquots of the supernatant using a Coomassie Plus kit (VWR International,
     Brisbane, Qld).
 - var_in: ChlAB
-  unit_in: umol/umol
+  unit_in: umol{chlorophyllA}/umol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
   entity_type: individual
   value_type: mean

--- a/data/Warren_2005/metadata.yml
+++ b/data/Warren_2005/metadata.yml
@@ -173,7 +173,7 @@ traits:
     leaves per tree were collected for subsequent morphological measurements and chemical
     analyses.
 - var_in: Photo (nmol/g H2O/s)
-  unit_in: nmol{CO2}/gH20/s
+  unit_in: nmol{CO2}/g{H20}/s
   trait_name: .na
   entity_type: population
   value_type: mean

--- a/data/Warren_2006/metadata.yml
+++ b/data/Warren_2006/metadata.yml
@@ -25,7 +25,7 @@ dataset:
   custom_R_code:        '
     data %>% 
       mutate(
-        `carotenoid_content(mmol g-1)` = `Carot/Chl(mmol mol-1)`*`[Chl](mmol g-1)`/1000,
+        `carotenoid_content(mmol g-1)` = `Carot/Chl(mmol mol-1)`*`[Chl](mmol g-1)`/1000000000,
         leaf_dry_matter_content = 1/`FW/DW`,
         context = paste0(`Annual rainfall(mm a-1)`,"MAP_",`Driest quarter rainfall(mm a-1)`,"driestQ_",`Evaporation (mm a-1)`,"ET"),
         context = ifelse(context == "NAMAP_NAdriestQ_NAET", NA, context)
@@ -307,7 +307,7 @@ traits:
     (Warren et al. 2000b). The fraction of N present as Rubisco was calculated assuming
     that Rubisco is 16.7% N by weight.
 - var_in: '[Chl](mmol g-1)'
-  unit_in: mmol{chlorophyll}/g
+  unit_in: umol{chlorophyll}/kg
   trait_name: leaf_chlorophyll_per_dry_mass
   entity_type: population
   value_type: mean
@@ -318,7 +318,7 @@ traits:
     (1994). Thylakoid N was calculated from chlorophyll concentrations using an empirical
     relationship (Evans 1989): 50 mol thylakoid N mol-1 chlorophyll. This relationship
     is widely used and varies little among species or as a function of rainfall (Evans
-    1989).'
+    1989). (Units off by 1000000, so made an assumption)'
 - var_in: Chl a /b(mol mol-1)
   unit_in: mol{chlorophyllA}/mol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
@@ -381,7 +381,7 @@ traits:
     is widely used and varies little among species or as a function of rainfall (Evans
     1989). The paper reports `Carot/Chl(mmol mol-1)`, which was converted to carotenoid
     content as follows: carotenoid_content(mmol g-1) = `Carot/Chl(mmol mol-1)`*`[Chl](mmol
-    g-1)`/1000'
+    g-1)`/1000, but then corrected for error in chlorophyll units.'
 substitutions: .na
 taxonomic_updates:
 - find: Eucalyptus badgensis

--- a/data/Warren_2006/metadata.yml
+++ b/data/Warren_2006/metadata.yml
@@ -368,7 +368,7 @@ traits:
     is widely used and varies little among species or as a function of rainfall (Evans
     1989).'
 - var_in: carotenoid_content(mmol g-1)
-  unit_in: mmol/g
+  unit_in: mmol{carotenoid}/g
   trait_name: leaf_carotenoid_per_dry_mass
   entity_type: population
   value_type: mean

--- a/data/Warren_2006/metadata.yml
+++ b/data/Warren_2006/metadata.yml
@@ -307,7 +307,7 @@ traits:
     (Warren et al. 2000b). The fraction of N present as Rubisco was calculated assuming
     that Rubisco is 16.7% N by weight.
 - var_in: '[Chl](mmol g-1)'
-  unit_in: mmol/g
+  unit_in: mmol{chlorophyll}/g
   trait_name: leaf_chlorophyll_per_dry_mass
   entity_type: population
   value_type: mean
@@ -320,7 +320,7 @@ traits:
     is widely used and varies little among species or as a function of rainfall (Evans
     1989).'
 - var_in: Chl a /b(mol mol-1)
-  unit_in: mol/mol
+  unit_in: mol{chlorophyllA}/mol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
   entity_type: population
   value_type: mean

--- a/data/Westoby_2014/metadata.yml
+++ b/data/Westoby_2014/metadata.yml
@@ -792,7 +792,7 @@ traits:
   replicates: 3
   methods: sapwood area
 - var_in: E (mmol/m2/s)
-  unit_in: mmol/m2/s
+  unit_in: mmol{H2O}/m2/s
   trait_name: .na.character
   entity_type: population
   value_type: mean

--- a/data/Westoby_2014/metadata.yml
+++ b/data/Westoby_2014/metadata.yml
@@ -916,7 +916,7 @@ traits:
   methods: Metal concentrations in leaves and stems were determined using inductively
     coupled plasma spectroscopy after acid digestion.
 - var_in: K_leaf_max (mmol/m2/s/Mpa)
-  unit_in: mmol/m2/MPa/s
+  unit_in: mmol{H2O}/m2/MPa/s
   trait_name: leaf_specific_hydraulic_conductance
   entity_type: population
   value_type: maximum

--- a/data/Wright_2009/metadata.yml
+++ b/data/Wright_2009/metadata.yml
@@ -348,7 +348,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: carots_mass(umol/m2)
-  unit_in: mmol/kg
+  unit_in: mmol{carotenoid}/kg
   trait_name: leaf_carotenoid_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -372,7 +372,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: carots_area
-  unit_in: umol/m2
+  unit_in: umol{carotenoid}/m2
   trait_name: leaf_carotenoid_per_area
   entity_type: individual
   value_type: raw

--- a/data/Wright_2009/metadata.yml
+++ b/data/Wright_2009/metadata.yml
@@ -180,7 +180,7 @@ locations:
 contexts: .na
 traits:
 - var_in: ChlAmass(mmol/kg)
-  unit_in: mmol/kg
+  unit_in: mmol{chlorophyllA}/kg
   trait_name: leaf_chlorophyll_A_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -204,7 +204,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: ChlBmass
-  unit_in: mmol/kg
+  unit_in: mmol{chlorophyllB}/kg
   trait_name: leaf_chlorophyll_B_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -228,7 +228,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: Chl(tot)mass
-  unit_in: mmol/kg
+  unit_in: mmol{chlorophyll}/kg
   trait_name: leaf_chlorophyll_per_dry_mass
   entity_type: individual
   value_type: raw
@@ -252,7 +252,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: Chl(tot)area
-  unit_in: umol/m2
+  unit_in: umol{chlorophyll}/m2
   trait_name: leaf_chlorophyll_per_area
   entity_type: individual
   value_type: raw
@@ -276,7 +276,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: ChlAarea(umol m-2)
-  unit_in: umol/m2
+  unit_in: umol{chlorophyllA}/m2
   trait_name: leaf_chlorophyll_A_per_area
   entity_type: individual
   value_type: raw
@@ -300,7 +300,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: ChlBarea
-  unit_in: umol/m2
+  unit_in: umol{chlorophyllB}/m2
   trait_name: leaf_chlorophyll_B_per_area
   entity_type: individual
   value_type: raw
@@ -324,7 +324,7 @@ traits:
     at 4 wavelengths (470, 646.5, 663.6 and 750 nm), enabling estimation of Chlorophyll
     A and B, and total carotenoids (see spreadsheet).'
 - var_in: Chla/b
-  unit_in: umol/umol
+  unit_in: umol{chlorophyllA}/umol{chlorophyllB}
   trait_name: leaf_chlorophyll_A_B_ratio
   entity_type: individual
   value_type: raw


### PR DESCRIPTION
There were a few traits where units were in moles, but didn't specify "moles of what" - which isn't sufficiently explicit and also causes problems once there is a study where you have to convert grams to moles - since the conversion is of course different for each compound/element.

All unit in moles, except "moles of photons" have now been made explicit.