### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# austraits.build — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add austraits.build-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`austraits.build` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
+  rules, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: austraits.build-specific architecture, key entry points, build & test, known gotchas._

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# austraits.build — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add austraits.build-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`austraits.build` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
-  rules, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: austraits.build-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# austraits.build — agent & contributor guide
+
+`austraits.build` is the **data compendium that compiles the AusTraits database** — an open-source
+compilation of traits for Australian plant species (Falster et al. 2021,
+doi:10.1038/s41597-021-01006-6). It holds the raw source datasets and the configuration that the
+`traits.build` engine harmonises into the released AusTraits resource. Type is `Compendium`, not a
+package; it `Depends` on `traits.build (>= 2.1.0)`.
+
+## Repo-local guidance
+
+- **Source data:** `data/` — one subdirectory per contributed source (300+), each typically a
+  `data.csv` + `metadata.yml` pair. This is the bulk of the repo and the thing most PRs touch.
+- **Config (build inputs):** `config/` —
+  - `traits.yml` — trait definitions. **Generated** from the AusTraits Plant Dictionary (APD); see
+    below — don't hand-edit it as the source of truth.
+  - `metadata.yml` — resource-level metadata, `unit_conversions.csv`, `taxon_list.csv`.
+- **Build script:** `build.R` — the top-level pipeline. It loads the schema/config, then for each
+  source runs `dataset_configure()` → `dataset_process()` → `dataset_update_taxonomy()`, and
+  assembles the combined `austraits` object. **`build.R` is auto-generated** (see header) from
+  `remake.yml.whisker` — regenerate it with
+  `traits.build::build_setup_pipeline(method = "furrr", database_name = "austraits", workers = 1)`
+  rather than editing by hand.
+- **Custom build helpers:** `R/` — `build_align_taxon_names.R`, `build_update_taxon_list.R` (taxonomy
+  alignment via **APCalign**), and `custom_R_code.R`.
+- **Maintenance scripts:** `scripts/` — notably `build_traits_yml_from_APD.R` (regenerates
+  `config/traits.yml` from the APD repo), plus `release.Rmd`, `news.Rmd`, `dictionary.Rmd`,
+  reporting scripts.
+- **Output:** `export/` — the compiled `austraits` object is written under `export/data` after a
+  build.
+
+**Build/run:** the README's recipe is install `traits.build`, clone this repo, then `source("build.R")`
+(it can use multiple CPUs — raise `workers`). After running you get an `austraits` object in the
+workspace and a saved copy in `export/data`. Tests live in `tests/` (testthat). Default branch is
+`develop`.
+
+> Gotcha 1: `config/traits.yml` is **generated from APD** via `scripts/build_traits_yml_from_APD.R`
+> (which pulls from `traitecoevo/APD`). To change trait definitions, fix APD upstream and regenerate,
+> don't patch the YAML in place.
+>
+> Gotcha 2: `build.R` is machine-generated — edit `remake.yml.whisker` / rerun `build_setup_pipeline()`
+> instead of editing `build.R` directly, or your changes get clobbered on the next regeneration.
+
+---
+
+## AusTraits family — cross-package context
+
+`austraits.build` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the actual AusTraits dataset
+compilation: it wires together APD (vocabulary) + APCalign (taxonomy) + the traits.build engine over
+raw source datasets, and produces the released `austraits-X.Y.Z.rds`. Family-wide concerns are
+documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, source-of-truth rules, cross-boundary
+  artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ We'd love for you to contribute to the projects. Below are some ways you can con
 For details on on how to contribute, please see the file [CONTRIBUTING.md](https://github.com/traitecoevo/austraits.build/blob/develop/.github/CONTRIBUTING.md)
 
 The AusTraits project is released with a [Contributor Code of Conduct](https://github.com/traitecoevo/austraits.build/blob/develop/.github/CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.
+
+## AusTraits family
+
+`austraits.build` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.
+
 ## Acknowledgements
 
 **Funding**: This work was supported via the following investments:


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- README — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)