### PR TITLE
docs: AusTraits family cross-linking, acknowledgements & citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,66 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "austraits.build" in publications use:'
+type: software
+license: BSD-2-Clause
+title: 'austraits.build: Repository used to build an AusTraits data resource'
+version: 7.0.0.900
+doi: 10.1038/s41597-021-01006-6
+abstract: This compendium compiles the AusTraits database, an open-source compilation
+  of data on the traits of Australian plant species (see Falster et al 2021, <https://doi.org/10.1038/s41597-021-01006-6>).
+  For more information on AusTraits go to https://austraits.org.
+authors:
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+- family-names: Wenk
+  given-names: Elizabeth
+  orcid: https://orcid.org/0000-0001-5640-5910
+- family-names: Gallagher
+  given-names: Rachael
+  orcid: https://orcid.org/0000-0002-4680-8115
+preferred-citation:
+  type: article
+  title: AusTraits, a curated plant trait database for the Australian flora
+  authors:
+  - family-names: Falster
+    given-names: Daniel
+    email: daniel.falster@unsw.edu.au
+    orcid: https://orcid.org/0000-0002-9814-092X
+  - family-names: Gallagher
+    given-names: Rachael
+    orcid: https://orcid.org/0000-0002-4680-8115
+  - family-names: Wenk
+    given-names: Elizabeth H.
+  - family-names: Wright
+    given-names: Ian J.
+  - family-names: Indiarto
+    given-names: Dony
+  - family-names: Andrew
+    given-names: Samuel C.
+  - name: others
+  journal: Scientific Data
+  year: '2021'
+  volume: '8'
+  issue: '1'
+  doi: 10.1038/s41597-021-01006-6
+  url: https://doi.org/10.1038/s41597-021-01006-6
+  start: '254'
+repository-code: https://github.com/traitecoevo/austraits.build
+url: http://traitecoevo.github.io/austraits.build/
+contact:
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+keywords:
+- australia
+- database
+- ecology
+- plants
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ Definitions for the traits are described the AusTraits Plant Dictionary (APD), a
 
 Users of AusTraits are requested to cite the source publication, which documents the dataset and approach:
 
-> Falster D, Gallagher R, Wenk, E et al. (2021) AusTraits, a curated plant trait database for the Australian flora. Scientific Data 8: 254.  DOI: [10.1038/s41597-021-01006-6](http://doi.org/10.1038/s41597-021-01006-6)
+> Falster D, Gallagher R, Wenk, E et al. (2021) AusTraits, a curated plant trait database for the Australian flora. Scientific Data 8: 254.  DOI: [10.1038/s41597-021-01006-6](https://doi.org/10.1038/s41597-021-01006-6)
+
+AusTraits is built on two companion resources you may also wish to cite — the AusTraits Plant Dictionary (trait definitions) and APCalign (taxonomy alignment):
+
+> Wenk EH, Sauquet H, Gallagher RV, Brownlee R, Boettiger C, Coleman D, *et al.* (2024) The AusTraits Plant Dictionary. *Scientific Data* 11:537. DOI: [10.1038/s41597-024-03368-z](https://doi.org/10.1038/s41597-024-03368-z)
+
+> Wenk EH, Cornwell WK, Fuchs A, Kar F, Monro AM, Sauquet H, Stephens RE, Falster DS (2024) APCalign: An R package workflow and app for aligning and updating flora names to the Australian Plant Census. *Australian Journal of Botany* 72(4):BT24014. DOI: [10.1071/BT24014](https://doi.org/10.1071/BT24014)
+
+**Related work**: the textual-extraction workflow (Coleman D, Gallagher RV, Falster DS, Sauquet H, Wenk E (2023) A workflow to create trait databases from collections of textual taxonomic descriptions. *Ecological Informatics* 78:102312. DOI: [10.1016/j.ecoinf.2023.102312](https://doi.org/10.1016/j.ecoinf.2023.102312)) and the gap-filled growth-form, life-history and woodiness dataset (Wenk EH, Coleman D, Gallagher RV, Falster DS (2024) A near-complete dataset of plant growth form, life history, and woodiness for all Australian plants. *Australian Journal of Botany* 72(4):BT23111. DOI: [10.1071/BT23111](https://doi.org/10.1071/BT23111)).
 
 ## Rebuilding AusTraits from source
 
@@ -49,7 +57,7 @@ To build the database follows these steps
 
 ***Install `traits.build`***
 
-The first step is to install a copy of [traits.build](https://github.com/traitecoevo/austraits.build/): 
+The first step is to install a copy of [traits.build](https://github.com/traitecoevo/traits.build/): 
 
 ```{r, eval=FALSE, echo=TRUE}
 remotes::install_github("traitecoevo/traits.build", quick = TRUE)
@@ -95,12 +103,42 @@ We'd love for you to contribute to the projects. Below are some ways you can con
 For details on on how to contribute, please see the file [CONTRIBUTING.md](https://github.com/traitecoevo/austraits.build/blob/develop/.github/CONTRIBUTING.md)
 
 The AusTraits project is released with a [Contributor Code of Conduct](https://github.com/traitecoevo/austraits.build/blob/develop/.github/CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.
+
+## AusTraits family
+
+`austraits.build` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.
+
 ## Acknowledgements
 
-**Funding**: This work was supported via the following investments:
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
 
-- Investment (https://doi.org/10.47486/TD044, https:// doi.org/10.47486/DP720) from the Australian Research Data Commons (ARDC). The ARDC is funded by the National Collaborative Research Infrastructure Strategy (NCRIS).
-- Fellowship from the Australian Research Council to Falster (FT160100113), Gallagher (DE170100208) and Wright (FT100100910),
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).
+
+This work received investment ([TD044](https://doi.org/10.47486/TD044),
+[DP720](https://doi.org/10.47486/DP720)) from the ARDC.
+
+**Funding**: AusTraits has also been supported by:
+
+- Fellowships from the Australian Research Council to Falster (FT160100113), Gallagher (DE170100208) and Wright (FT100100910),
 - A UNSW Research Infrastructure Grant to Falster, and
 - A grant from Macquarie University to Gallagher.
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,27 @@
+citHeader("To cite the AusTraits database in publications use:")
+
+bibentry(
+  bibtype  = "Article",
+  title    = "AusTraits, a curated plant trait database for the Australian flora",
+  author   = c(
+    person("Daniel", "Falster"),
+    person("Rachael", "Gallagher"),
+    person("Elizabeth H.", "Wenk"),
+    person("Ian J.", "Wright"),
+    person("Dony", "Indiarto"),
+    person("Samuel C.", "Andrew"),
+    person(family = "others")
+  ),
+  journal  = "Scientific Data",
+  year     = "2021",
+  volume   = "8",
+  number   = "1",
+  pages    = "254",
+  doi      = "10.1038/s41597-021-01006-6",
+  url      = "https://doi.org/10.1038/s41597-021-01006-6",
+  textVersion = paste(
+    "Falster, D., Gallagher, R., Wenk, E.H. et al. (2021)",
+    "AusTraits, a curated plant trait database for the Australian flora.",
+    "Scientific Data 8, 254. https://doi.org/10.1038/s41597-021-01006-6"
+  )
+)


### PR DESCRIPTION
Part of the family-wide README usability pass (see the plan in `traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

Standardises across the AusTraits family:
- the **AusTraits family** cross-link block (→ austraits.org, board #9, `austraits-meta`)
- the canonical **partner + ARDC/NCRIS co-investment acknowledgement** (NCRIS "enabled by")
- a **How to cite** section drawn from the family citation set

...plus repo-specific README fixes. Citation and acknowledgement wording come from the canonical sources in `austraits-meta` (`references/`, `acknowledgements.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)