### PR TITLE
Read APD from its published, version-pinned URLs

### DIFF
--- a/scripts/build_traits_yml_from_APD.R
+++ b/scripts/build_traits_yml_from_APD.R
@@ -10,10 +10,24 @@ library(stringr)
 library(traits.build)
 
 
-path_APD <- "https://raw.githubusercontent.com/traitecoevo/APD/master"
-path_APD2 <- "https://raw.githubusercontent.com/traitecoevo/APD/master/data"
+# The APD release this build is pinned to. APD is a versioned, citable vocabulary
+# (Wenk et al. 2024, doi:10.1038/s41597-024-03368-z), so a build should record
+# which release it used. Bump this deliberately, and re-run, when APD releases.
+apd_version <- "2.1.0"
 
-trait_groups <- readr::read_csv(file.path(path_APD2, "APD_trait_hierarchy.csv"), show_col_types = FALSE) %>%
+# Read the *published* copies, not the APD repo's working tree.
+# raw.githubusercontent.com/.../master/ was doing two things badly at once: it
+# picked up whatever happened to be on master, which is not necessarily a release,
+# and it hard-coded where APD keeps its files inside its own repo -- so tidying
+# that repo broke this build. These URLs are APD's published interface and do not
+# move; the versioned path also means this build is reproducible.
+path_APD <- sprintf("https://traitecoevo.github.io/APD/release/%s", apd_version)
+
+# The trait hierarchy is an APD *input* table rather than a build product, so it is
+# not in the release snapshot. data/ is a stable location in that repo.
+path_APD_data <- "https://raw.githubusercontent.com/traitecoevo/APD/master/data"
+
+trait_groups <- readr::read_csv(file.path(path_APD_data, "APD_trait_hierarchy.csv"), show_col_types = FALSE) %>%
   dplyr::select(trait_groupings = label, hierarchy) %>%
   dplyr::filter(!is.na(hierarchy)) %>%
   dplyr::mutate(trait_group = stringr::str_replace_all(hierarchy, " \\<", ";")) %>%


### PR DESCRIPTION
## What

`scripts/build_traits_yml_from_APD.R` read three files from
`raw.githubusercontent.com/traitecoevo/APD/master/`. Two of them now come from APD's
published, version-pinned URLs instead:

```r
apd_version <- "2.1.0"
path_APD <- sprintf("https://traitecoevo.github.io/APD/release/%s", apd_version)
```

## Why

Reading another repository's working tree was doing two things badly at once.

**It wasn't reproducible.** `master` is APD's GitHub Pages source branch, not a release
tag, so this build's inputs could change without any APD release having happened — and
nothing recorded which version of the vocabulary a given AusTraits build was made
against. The version is now a named constant to bump deliberately.

**It hard-coded APD's internal layout.** `APD_traits.csv` and
`APD_categorical_values.csv` sat at APD's repo root *because these lines required it*.
APD is being tidied ([traitecoevo/APD#47](https://github.com/traitecoevo/APD/issues/47)),
and moving those files would have broken this build silently — a 404 that `read_csv`
surfaces as a parse error. The published URLs are APD's actual interface and don't move.

## Safety

This is a no-op for the build. Both files are byte-identical between
`master` and `release/2.1.0` today, and parse to identical data:

```
APD_traits.csv                 559 x 26   data identical: TRUE
APD_categorical_values.csv     819 x 5    data identical: TRUE
```

The pinned URLs already resolve (`200`), so **this can merge before anything changes in
APD** — and should, so there is never a window where either repo is broken.

`APD_trait_hierarchy.csv` still comes from `master/data/`. It is an APD *input* table
rather than a build product, so it has no published copy yet; APD's `make release` now
snapshots one, and this can switch after APD's next release.