### PR TITLE
Pin APD 2.1.2, and read the trait hierarchy from the release too

### DIFF
--- a/scripts/build_traits_yml_from_APD.R
+++ b/scripts/build_traits_yml_from_APD.R
@@ -13,7 +13,7 @@ library(traits.build)
 # The APD release this build is pinned to. APD is a versioned, citable vocabulary
 # (Wenk et al. 2024, doi:10.1038/s41597-024-03368-z), so a build should record
 # which release it used. Bump this deliberately, and re-run, when APD releases.
-apd_version <- "2.1.1"
+apd_version <- "2.1.2"
 
 # Read the *published* copies, not the APD repo's working tree.
 # raw.githubusercontent.com/.../master/ was doing two things badly at once: it

--- a/scripts/build_traits_yml_from_APD.R
+++ b/scripts/build_traits_yml_from_APD.R
@@ -13,7 +13,7 @@ library(traits.build)
 # The APD release this build is pinned to. APD is a versioned, citable vocabulary
 # (Wenk et al. 2024, doi:10.1038/s41597-024-03368-z), so a build should record
 # which release it used. Bump this deliberately, and re-run, when APD releases.
-apd_version <- "2.1.0"
+apd_version <- "2.1.1"
 
 # Read the *published* copies, not the APD repo's working tree.
 # raw.githubusercontent.com/.../master/ was doing two things badly at once: it
@@ -23,9 +23,13 @@ apd_version <- "2.1.0"
 # move; the versioned path also means this build is reproducible.
 path_APD <- sprintf("https://traitecoevo.github.io/APD/release/%s", apd_version)
 
-# The trait hierarchy is an APD *input* table rather than a build product, so it is
-# not in the release snapshot. data/ is a stable location in that repo.
-path_APD_data <- "https://raw.githubusercontent.com/traitecoevo/APD/master/data"
+# The trait hierarchy used to be the one table read from APD's repo rather than
+# its release: it is an *input* table, not a build product, so no snapshot carried
+# it. APD's `make release` snapshots it from 2.1.1 onwards, so it comes from the
+# same pinned release as everything else now and this build has no dependency on
+# any branch of that repo. (2.1.0 and earlier have no copy -- pinning back that
+# far means restoring the raw.githubusercontent.com path.)
+path_APD_data <- path_APD
 
 trait_groups <- readr::read_csv(file.path(path_APD_data, "APD_trait_hierarchy.csv"), show_col_types = FALSE) %>%
   dplyr::select(trait_groupings = label, hierarchy) %>%


### PR DESCRIPTION
Closes the last loose ends from APD's move to published, version-pinned URLs (#850), and resolves #853.

> Branch is still named `chore/pin-apd-2.1.1` — APD 2.1.2 shipped while this was open, so the pin moved.

## `config/traits.yml` is unchanged, and that is the point

Regenerating against APD 2.1.2 produces a **byte-identical** `config/traits.yml`. **Zero changed lines.**

That resolves #853 without touching anything here. The committed file has always said `plant_height_reproductive: allowed_values_min: 0.001` while APD said `0.1` — a drift that predated #850. @ehwenk confirmed the **vocabulary** was wrong rather than the mapping: these are geophytes and similar, where the reproductive height *is* the length of an inflorescence stalk arising at ground level, so millimetre values are correct. APD 2.1.2 corrects the floor (traitecoevo/APD#65), so the generator and the generated file now agree.

**No database rebuild is implied.** No diff means no trait definition, allowed value or range this build validates against has moved, and none of the 31 `SPRAT_2025_2` records that surfaced the discrepancy is affected.

## 1. `apd_version` 2.1.0 → 2.1.2

Verified all three files the script reads resolve at the pinned release *before* running it — `APD_traits.csv`, `APD_categorical_values.csv` and `APD_trait_hierarchy.csv` all return 200 under `release/2.1.2/`. Worth doing in that order: the script reads over HTTP, so pinning a release that has not deployed yet fails at the fetch.

## 2. The trait hierarchy now comes from the release

```diff
-path_APD_data <- "https://raw.githubusercontent.com/traitecoevo/APD/master/data"
+path_APD_data <- path_APD
```

This was the one table read from a *branch* rather than a release, because as an APD **input** table no snapshot carried it. APD's `make release` snapshots it from 2.1.1 onwards, so it can now come from the same pinned release as everything else — removing the last dependency this build has on any branch of the APD repo (APD's `COMMITMENTS.md` C13).

Verified the published copy is byte-identical to the one on `master` and carries the `label` and `hierarchy` columns this script reads.

(2.1.0 and earlier have no copy — `release/2.1.0/APD_trait_hierarchy.csv` is a 404. Pinning back that far means restoring the old path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)