### PR TITLE
Point book links at the new content/ path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AusTraits is continually evolving, as new datasets are contributed. As such, the
 
 Those interested in simply using data from AusTraits, should visit download the compiled resource from the versioned releases archived on Zenodo at DOI: [10.5281/zenodo.3568417](https://doi.org/10.5281/zenodo.3568417).
 
-Users will want to read up on the [database structure, described in the `traits.build` manual](https://traitecoevo.github.io/traits.build-book/database_structure.html).
+Users will want to read up on the [database structure, described in the `traits.build` manual](https://traitecoevo.github.io/traits.build-book/content/database_structure.html).
 
 Definitions for the traits are described the AusTraits Plant Dictionary (APD), at
 


### PR DESCRIPTION
Chapters in `traits.build-book` move into a `content/` subdirectory ([traits.build-book#43](https://github.com/traitecoevo/traits.build-book/pull/43)), and that PR carries **no redirect aliases** — so these links break the moment it merges.

Draft on purpose: **must not merge before** traits.build-book#43. Merge it straight after.